### PR TITLE
openapi: optional query parameters

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -16,7 +16,6 @@ http = "0.2.0"
 hyper = "0.13.0"
 indexmap = "1.0.0"
 openapiv3 = "0.3.0"
-schemars = "0.7.0"
 serde_json = "1.0.0"
 serde_urlencoded = "0.6.0"
 slog-async = "2.4.0"
@@ -48,6 +47,10 @@ features = [ "full" ]
 [dependencies.uuid]
 version = "0.8.0"
 features = [ "serde", "v4" ]
+
+[dependencies.schemars]
+version = "0.7.0"
+features = [ "uuid" ]
 
 [dev-dependencies]
 libc = "0.2.71"

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -202,10 +202,10 @@
  *
  * * [`Query`]`<Q>` extracts parameters from a query string, deserializing them
  *   into an instance of type `Q`. `Q` must implement `serde::Deserialize` and
- *   `dropshot::ExtractedParameter`.
+ *   `schemars::JsonSchema`.
  * * [`Path`]`<P>` extracts parameters from HTTP path, deserializing them into
  *    an instance of type `P`. `P` must implement `serde::Deserialize` and
- *    `dropshot::ExtractedParameter`.
+ *    `schemars::JsonSchema`.
  * * [`Json`]`<J>` extracts content from the request body by parsing the body as
  *   JSON and deserializing it into an instance of type `J`. `J` must implement
  *   `serde::Deserialize` and `schemars::JsonSchema`.
@@ -221,16 +221,16 @@
  *
  * ```
  * use http::StatusCode;
- * use dropshot::ExtractedParameter;
  * use dropshot::HttpError;
  * use dropshot::Json;
  * use dropshot::Query;
  * use dropshot::RequestContext;
  * use hyper::Body;
  * use hyper::Response;
+ * use schemars::JsonSchema;
  * use std::sync::Arc;
  *
- * #[derive(serde::Deserialize, ExtractedParameter)]
+ * #[derive(serde::Deserialize, JsonSchema)]
  * struct MyQueryArgs {
  *     limit: u32,
  *     marker: Option<String>
@@ -299,7 +299,6 @@ pub use api_description::ApiEndpointResponse;
 pub use config::ConfigDropshot;
 pub use error::HttpError;
 pub use error::HttpErrorResponseBody;
-pub use handler::ExtractedParameter;
 pub use handler::Extractor;
 pub use handler::HttpResponse;
 pub use handler::HttpResponseAccepted;
@@ -327,4 +326,3 @@ pub use http::Method;
 
 extern crate dropshot_endpoint;
 pub use dropshot_endpoint::endpoint;
-pub use dropshot_endpoint::ExtractedParameter;

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -31,7 +31,6 @@ use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::CONTENT_TYPE_JSON;
 use dropshot_endpoint::endpoint;
-use dropshot_endpoint::ExtractedParameter;
 use http::StatusCode;
 use hyper::Body;
 use hyper::Method;
@@ -507,7 +506,7 @@ async fn demo_handler_args_1(
     http_echo(&"demo_handler_args_1")
 }
 
-#[derive(Serialize, Deserialize, ExtractedParameter)]
+#[derive(Serialize, Deserialize, JsonSchema)]
 pub struct DemoQueryArgs {
     pub test1: String,
     pub test2: Option<u32>,
@@ -539,7 +538,7 @@ async fn demo_handler_args_2json(
     http_echo(&json.into_inner())
 }
 
-#[derive(Deserialize, Serialize, ExtractedParameter)]
+#[derive(Deserialize, Serialize, JsonSchema)]
 pub struct DemoJsonAndQuery {
     pub query: DemoQueryArgs,
     pub json: DemoJsonBody,
@@ -560,7 +559,7 @@ async fn demo_handler_args_3(
     http_echo(&combined)
 }
 
-#[derive(Deserialize, Serialize, ExtractedParameter)]
+#[derive(Deserialize, Serialize, JsonSchema)]
 pub struct DemoPathString {
     pub test1: String,
 }
@@ -575,7 +574,7 @@ async fn demo_handler_path_param_string(
     http_echo(&path_params.into_inner())
 }
 
-#[derive(Deserialize, Serialize, ExtractedParameter)]
+#[derive(Deserialize, Serialize, JsonSchema)]
 pub struct DemoPathUuid {
     pub test1: Uuid,
 }
@@ -590,7 +589,7 @@ async fn demo_handler_path_param_uuid(
     http_echo(&path_params.into_inner())
 }
 
-#[derive(Deserialize, Serialize, ExtractedParameter)]
+#[derive(Deserialize, Serialize, JsonSchema)]
 pub struct DemoPathImpossible {
     pub test1: String,
 }

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -94,6 +94,21 @@
           },
           {
             "in": "query",
+            "name": "_destro",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              }
+            },
+            "allowReserved": true,
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "_tomax",
             "required": true,
             "schema": {
@@ -105,7 +120,6 @@
           {
             "in": "query",
             "name": "_xamot",
-            "required": true,
             "schema": {
               "type": "string"
             },
@@ -144,6 +158,21 @@
         "parameters": [
           {
             "in": "query",
+            "name": "_destro",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              }
+            },
+            "allowReserved": true,
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "_tomax",
             "required": true,
             "schema": {
@@ -155,7 +184,6 @@
           {
             "in": "query",
             "name": "_xamot",
-            "required": true,
             "schema": {
               "type": "string"
             },

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -2,9 +2,9 @@
 
 use difference::assert_diff;
 use dropshot::{
-    endpoint, ApiDescription, ExtractedParameter, HttpError,
-    HttpResponseCreated, HttpResponseDeleted, HttpResponseOkObject, Json, Path,
-    Query, RequestContext,
+    endpoint, ApiDescription, HttpError, HttpResponseCreated,
+    HttpResponseDeleted, HttpResponseOkObject, Json, Path, Query,
+    RequestContext,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -20,10 +20,11 @@ async fn handler1(
     Ok(HttpResponseOkObject(()))
 }
 
-#[derive(Deserialize, ExtractedParameter)]
+#[derive(Deserialize, JsonSchema)]
 struct QueryArgs {
     _tomax: String,
     _xamot: Option<String>,
+    _destro: Vec<u16>,
 }
 
 #[endpoint {
@@ -37,7 +38,7 @@ async fn handler2(
     Ok(HttpResponseOkObject(()))
 }
 
-#[derive(Deserialize, ExtractedParameter)]
+#[derive(Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct PathArgs {
     x: String,
@@ -127,7 +128,7 @@ fn fixture(path: &str, actual: &str) -> Result<(), String> {
         let expected = expected_s.as_str();
 
         println!("set FIXTURE= if these changes are intentional");
-        assert_diff!(actual, expected, "\n", 0);
+        assert_diff!(expected, actual, "\n", 0);
     }
 
     Ok(())

--- a/dropshot_endpoint/Cargo.toml
+++ b/dropshot_endpoint/Cargo.toml
@@ -14,7 +14,6 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 schemars = "0.7"
-serde_derive_internals = "0.25"
 serde_tokenstream = "0.1.0"
 
 [dependencies.serde]


### PR DESCRIPTION
This fixes #6, allowing for optional parameters.

This removes `ExtractedParameter` in favor of `JsonSchema`. I'm still not sure `JsonSchema` is going to be a long-term solution as its use is kind of janky in some ways, but it's a massive step in the right direction and, I think, is helping to inform what an improved picture will look like.

@davepacheco if you're going to take a look, you might want to check out the tests and examples first to see if anything looks obviously worse.

This is a flag day; consumers will need to be updated once this merges.