### PR TITLE
formatting with rustfmt-2.0.0-rc.2

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -345,7 +345,7 @@ impl ApiDescription {
                 .iter()
                 .filter_map(|param| {
                     match &param.name {
-                        ApiEndpointParameterName::Body => (),
+                        ApiEndpointParameterName::Body => {}
                         _ => return None,
                     }
 

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -570,7 +570,7 @@ where
  */
 trait GetMetadata {
     fn metadata(loc: ApiEndpointParameterLocation)
-        -> Vec<ApiEndpointParameter>;
+    -> Vec<ApiEndpointParameter>;
 }
 
 impl<ParamType> GetMetadata for ParamType

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -570,7 +570,7 @@ where
  */
 trait GetMetadata {
     fn metadata(loc: ApiEndpointParameterLocation)
-    -> Vec<ApiEndpointParameter>;
+        -> Vec<ApiEndpointParameter>;
 }
 
 impl<ParamType> GetMetadata for ParamType

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -842,9 +842,11 @@ mod test {
             "project_id"
         ]);
         assert_eq!(result.variables.get("project_id").unwrap(), "p12345");
-        assert!(router
-            .lookup_route(&Method::GET, "/projects/p12345/child")
-            .is_err());
+        assert!(
+            router
+                .lookup_route(&Method::GET, "/projects/p12345/child")
+                .is_err()
+        );
         let result =
             router.lookup_route(&Method::GET, "/projects/p12345/").unwrap();
         assert_eq!(result.handler.label(), "h5");
@@ -902,15 +904,15 @@ mod test {
             Method::GET,
             "/projects/{project_id}/instances",
         ));
-        assert!(router
-            .lookup_route(&Method::GET, "/projects/instances")
-            .is_err());
-        assert!(router
-            .lookup_route(&Method::GET, "/projects//instances")
-            .is_err());
-        assert!(router
-            .lookup_route(&Method::GET, "/projects///instances")
-            .is_err());
+        assert!(
+            router.lookup_route(&Method::GET, "/projects/instances").is_err()
+        );
+        assert!(
+            router.lookup_route(&Method::GET, "/projects//instances").is_err()
+        );
+        assert!(
+            router.lookup_route(&Method::GET, "/projects///instances").is_err()
+        );
         let result = router
             .lookup_route(&Method::GET, "/projects/foo/instances")
             .unwrap();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,7 @@
 # Stable features that we customize locally
 # ---------------------------------------------------------------------------
 max_width = 80
-use_small_heuristics = "max"
+width_heuristics = "max"
 unstable_features = true
 
 #
@@ -66,7 +66,7 @@ struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true
 force_multiline_blocks = false
-fn_args_layout = "Tall"
+fn_params_layout = "Tall"
 brace_style = "SameLineWhere"
 control_brace_style = "AlwaysSameLine"
 trailing_semicolon = true
@@ -75,22 +75,14 @@ match_block_trailing_comma = false
 blank_lines_upper_bound = 1
 blank_lines_lower_bound = 0
 edition = "2018"
-version = "One"
 inline_attribute_width = 0
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
-color = "Auto"
-required_version = "1.4.15"
-disable_all_formatting = false
-skip_children = false
+required_version = "2.0.0-rc.2"
 hide_parse_errors = false
 error_on_line_overflow = false
 error_on_unformatted = false
-report_todo = "Never"
-report_fixme = "Never"
 ignore = []
-emit_mode = "Files"
-make_backup = false


### PR DESCRIPTION
Not sure why I got this itch, but wanted to see what rustfmt 2 was looking like. I think it's basically sensible, but I'm not a fan of the change in `handler.rs`. @davepacheco let me know what you think and I can file a bug against rustfmt

To be clear: I don't intend to merge this PR.