### PR TITLE
try to give the user better failure messages

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.4.0"
 features = [ "serde" ]
 
 [dependencies.dropshot_endpoint]
-version = "0.2.0"
+version = "0.3.0"
 path = "../dropshot_endpoint"
 
 [dependencies.serde]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -59,6 +59,7 @@ lazy_static = "1.4.0"
 libc = "0.2.71"
 serde_with = "1.4.0"
 subprocess = "0.2.4"
+trybuild = "1.0.31"
 
 [dev-dependencies.schemars]
 version = "0.7.0"

--- a/dropshot/tests/fail.rs
+++ b/dropshot/tests/fail.rs
@@ -1,0 +1,7 @@
+// Copyright 2020 Oxide Computer Company
+
+#[test]
+fn fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/fail/*.rs");
+}

--- a/dropshot/tests/fail/bad_endpoint1.rs
+++ b/dropshot/tests/fail/bad_endpoint1.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint1.stderr
+++ b/dropshot/tests/fail/bad_endpoint1.stderr
@@ -1,3 +1,9 @@
+error: incompatible function signature; expected async fn (Arc<RequestContext>(, Extractor)*) -> Result<HttpResponse, HttpError>
+  --> $DIR/bad_endpoint1.rs:11:1
+   |
+11 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: the trait bound `fn() -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
   --> $DIR/bad_endpoint1.rs:11:10
    |

--- a/dropshot/tests/fail/bad_endpoint1.stderr
+++ b/dropshot/tests/fail/bad_endpoint1.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `fn() -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
+  --> $DIR/bad_endpoint1.rs:11:10
+   |
+11 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
+   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _>` is not implemented for `fn() -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}`
+   |
+  ::: $WORKSPACE/dropshot/src/api_description.rs
+   |
+   |         HandlerType: HttpHandlerFunc<FuncParams, ResponseType>,
+   |                      ----------------------------------------- required by this bound in `dropshot::api_description::ApiEndpoint::new`

--- a/dropshot/tests/fail/bad_endpoint2.rs
+++ b/dropshot/tests/fail/bad_endpoint2.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint2.stderr
+++ b/dropshot/tests/fail/bad_endpoint2.stderr
@@ -1,0 +1,19 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/bad_endpoint2.rs:11:23
+   |
+11 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+   |                       ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/bad_endpoint2.rs:11:23
+   |
+7  | #[endpoint {
+   | ---------- `Self` type implicitly declared here, by this `impl`
+...
+11 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+   |                       ^^^^
+   |                       |
+   |                       use of generic parameter from outer function
+   |                       use a type here instead

--- a/dropshot/tests/fail/bad_endpoint3.rs
+++ b/dropshot/tests/fail/bad_endpoint3.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(
+    _rqctx: Arc<RequestContext>,
+    param: String,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>, std::string::String) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
+  --> $DIR/bad_endpoint3.rs:13:10
+   |
+13 | async fn bad_endpoint(
+   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _>` is not implemented for `fn(std::sync::Arc<dropshot::handler::RequestContext>, std::string::String) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}`
+   |
+  ::: $WORKSPACE/dropshot/src/api_description.rs
+   |
+   |         HandlerType: HttpHandlerFunc<FuncParams, ResponseType>,
+   |                      ----------------------------------------- required by this bound in `dropshot::api_description::ApiEndpoint::new`

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -1,3 +1,18 @@
+error[E0277]: the trait bound `std::string::String: dropshot::handler::Extractor` is not satisfied
+  --> $DIR/bad_endpoint3.rs:15:12
+   |
+9  | / #[endpoint {
+10 | |     method = GET,
+11 | |     path = "/test",
+12 | | }]
+   | |__- required by this bound in `_::{{closure}}#0::need_extractor`
+...
+15 |       param: String,
+   |              ^^^^^^
+   |              |
+   |              the trait `dropshot::handler::Extractor` is not implemented for `std::string::String`
+   |              required by a bound in this
+
 error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>, std::string::String) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
   --> $DIR/bad_endpoint3.rs:13:10
    |

--- a/dropshot/tests/fail/bad_endpoint4.rs
+++ b/dropshot/tests/fail/bad_endpoint4.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[allow(dead_code)]
+struct QueryParams {
+    x: String,
+    y: u32,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(
+    _rqctx: Arc<RequestContext>,
+    _params: Query<QueryParams>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
+   --> $DIR/bad_endpoint4.rs:22:14
+    |
+22  |     _params: Query<QueryParams>,
+    |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                                                ---------- required by this bound in `dropshot::handler::Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+   --> $DIR/bad_endpoint4.rs:22:14
+    |
+22  |     _params: Query<QueryParams>,
+    |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                             ---------------- required by this bound in `dropshot::handler::Query`
+    |
+    = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint5.rs
+++ b/dropshot/tests/fail/bad_endpoint5.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use std::sync::Arc;
+
+#[derive(JsonSchema)]
+#[allow(dead_code)]
+struct QueryParams {
+    x: String,
+    y: u32,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(
+    _rqctx: Arc<RequestContext>,
+    _params: Query<QueryParams>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+   --> $DIR/bad_endpoint5.rs:24:14
+    |
+24  |     _params: Query<QueryParams>,
+    |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                             ---------------- required by this bound in `dropshot::handler::Query`
+    |
+    = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint6.rs
+++ b/dropshot/tests/fail/bad_endpoint6.rs
@@ -1,0 +1,25 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use std::sync::Arc;
+
+#[derive(JsonSchema)]
+#[allow(dead_code)]
+struct Ret {
+    x: String,
+    y: u32,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(_rqctx: Arc<RequestContext>) -> Result<HttpResponseOk<Ret>, HttpError> {
+    Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -15,24 +15,54 @@ error: expected identifier, found `0x1de`
    |                       while parsing this struct
 
 error[E0063]: missing fields `x`, `y` in initializer of `Ret`
-  --> $DIR/bad_endpoint6.rs:17:1
+  --> $DIR/bad_endpoint6.rs:22:23
    |
-17 | / #[endpoint {
-18 | |     method = GET,
-19 | |     path = "/test",
-20 | | }]
-   | |__^ missing `x`, `y`
+22 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ^^^ missing `x`, `y`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-  --> $DIR/bad_endpoint6.rs:17:1
+  --> $DIR/bad_endpoint6.rs:22:23
    |
-17 | / #[endpoint {
-18 | |     method = GET,
-19 | |     path = "/test",
-20 | | }]
-   | |__^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+22 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
    |
    = note: required by `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint6.rs:22:8
+    |
+22  |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint6.rs:22:5
+    |
+22  |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint6.rs:21:94
+    |
+21  |   async fn bad_endpoint(_rqctx: Arc<RequestContext>) -> Result<HttpResponseOk<Ret>, HttpError> {
+    |  ______________________________________________________________________________________________^
+22  | |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+23  | | }
+    | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
   --> $DIR/bad_endpoint6.rs:17:1

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -1,0 +1,49 @@
+error: expected identifier, found `"Oxide"`
+  --> $DIR/bad_endpoint6.rs:22:29
+   |
+22 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ---   ^^^^^^^ expected identifier
+   |                       |
+   |                       while parsing this struct
+
+error: expected identifier, found `0x1de`
+  --> $DIR/bad_endpoint6.rs:22:50
+   |
+22 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ---                        ^^^^^ expected identifier
+   |                       |
+   |                       while parsing this struct
+
+error[E0063]: missing fields `x`, `y` in initializer of `Ret`
+  --> $DIR/bad_endpoint6.rs:17:1
+   |
+17 | / #[endpoint {
+18 | |     method = GET,
+19 | |     path = "/test",
+20 | | }]
+   | |__^ missing `x`, `y`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+  --> $DIR/bad_endpoint6.rs:17:1
+   |
+17 | / #[endpoint {
+18 | |     method = GET,
+19 | |     path = "/test",
+20 | | }]
+   | |__^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+   |
+   = note: required by `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
+  --> $DIR/bad_endpoint6.rs:17:1
+   |
+17 | / #[endpoint {
+18 | |     method = GET,
+19 | |     path = "/test",
+20 | | }]
+   | |__^ the trait `dropshot::handler::HttpHandlerFunc<_, _>` is not implemented for `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}`
+   |
+  ::: $WORKSPACE/dropshot/src/api_description.rs
+   |
+   |           HandlerType: HttpHandlerFunc<FuncParams, ResponseType>,
+   |                        ----------------------------------------- required by this bound in `dropshot::api_description::ApiEndpoint::new`

--- a/dropshot/tests/fail/bad_endpoint7.rs
+++ b/dropshot/tests/fail/bad_endpoint7.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use std::sync::Arc;
+
+#[derive(JsonSchema)]
+#[allow(dead_code)]
+struct Ret {
+    x: String,
+    y: u32,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_endpoint(
+    _rqctx: Arc<RequestContext>,
+) -> Result<HttpResponseOk<Ret>, HttpError> {
+    Ok(HttpResponseOk(Ret {
+        x: "Oxide".to_string(),
+        y: 0x1de,
+    }))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -1,0 +1,68 @@
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+  --> $DIR/bad_endpoint7.rs:24:23
+   |
+24 |       Ok(HttpResponseOk(Ret {
+   |  _______________________^
+25 | |         x: "Oxide".to_string(),
+26 | |         y: 0x1de,
+27 | |     }))
+   | |_____^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+   |
+   = note: required by `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint7.rs:24:8
+    |
+24  |       Ok(HttpResponseOk(Ret {
+    |  ________^
+25  | |         x: "Oxide".to_string(),
+26  | |         y: 0x1de,
+27  | |     }))
+    | |______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint7.rs:24:5
+    |
+24  | /     Ok(HttpResponseOk(Ret {
+25  | |         x: "Oxide".to_string(),
+26  | |         y: 0x1de,
+27  | |     }))
+    | |_______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+   --> $DIR/bad_endpoint7.rs:23:45
+    |
+23  |   ) -> Result<HttpResponseOk<Ret>, HttpError> {
+    |  _____________________________________________^
+24  | |     Ok(HttpResponseOk(Ret {
+25  | |         x: "Oxide".to_string(),
+26  | |         y: 0x1de,
+27  | |     }))
+28  | | }
+    | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+    |
+   ::: $WORKSPACE/dropshot/src/handler.rs
+    |
+    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+
+error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
+  --> $DIR/bad_endpoint7.rs:21:10
+   |
+21 | async fn bad_endpoint(
+   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _>` is not implemented for `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}`
+   |
+  ::: $WORKSPACE/dropshot/src/api_description.rs
+   |
+   |         HandlerType: HttpHandlerFunc<FuncParams, ResponseType>,
+   |                      ----------------------------------------- required by this bound in `dropshot::api_description::ApiEndpoint::new`

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -15,6 +15,7 @@
  * JSON body length)
  */
 
+use dropshot::endpoint;
 use dropshot::test_util::read_json;
 use dropshot::test_util::read_string;
 use dropshot::ApiDescription;
@@ -24,7 +25,6 @@ use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
 use dropshot::CONTENT_TYPE_JSON;
-use dropshot_endpoint::endpoint;
 use http::StatusCode;
 use hyper::Body;
 use hyper::Method;

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -20,6 +20,7 @@ async fn handler1(
 }
 
 #[derive(Deserialize, JsonSchema)]
+#[allow(dead_code)]
 struct QueryArgs {
     _tomax: String,
     _xamot: Option<String>,

--- a/dropshot_endpoint/Cargo.toml
+++ b/dropshot_endpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dropshot_endpoint"
 description = "macro used by dropshot consumers for registering handlers"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adam H. Leventhal <ahl@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -144,7 +144,7 @@ fn do_endpoint(
                                 }
                                 fn need_arc_requestcontext<T>()
                                 where
-                                    T: ?Sized + TypeEq<This = #req>
+                                    T: ?Sized + TypeEq<This = #req>,
                                 {
                                 }
                                 need_arc_requestcontext::<#ty>();
@@ -155,7 +155,7 @@ fn do_endpoint(
                             const _: fn() = ||{
                                 fn need_extractor<T>()
                                 where
-                                    T: ?Sized + #req
+                                    T: ?Sized + #req,
                                 {
                                 }
                                 need_extractor::<#ty>();
@@ -264,8 +264,9 @@ fn extract_doc_from_attrs(attrs: &Vec<syn::Attribute>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
-    fn test_endpoint() {
+    fn test_endpoint1() {
         let ret = do_endpoint(
             quote! {
                 method = GET,
@@ -277,16 +278,110 @@ mod tests {
             }
             .into(),
         );
+        let full = quote! {
+            std::sync::Arc< dropshot::RequestContext>
+        };
+        let short = quote! {
+            Arc<RequestContext>
+        };
         let expected = quote! {
+            const _: fn() = || {
+                trait TypeEq {
+                    type This: ?Sized;
+                }
+                impl<T: ?Sized> TypeEq for T {
+                    type This = Self;
+                }
+                fn need_arc_requestcontext<T>()
+                where
+                    T: ?Sized + TypeEq<This = #full>,
+                {
+                }
+                need_arc_requestcontext::<#short>();
+            };
+
             #[allow(non_camel_case_types, missing_docs)]
             #[doc = "API Endpoint: handler_xyz"]
             pub struct handler_xyz {}
+
             #[allow(non_upper_case_globals, missing_docs)]
             #[doc = "API Endpoint: handler_xyz"]
             const handler_xyz: handler_xyz = handler_xyz {};
+
             impl From<handler_xyz> for dropshot::ApiEndpoint {
                 fn from(_: handler_xyz) -> Self {
                     fn handler_xyz(_rqctx: Arc<RequestContext>) {}
+                    dropshot::ApiEndpoint::new(
+                        "handler_xyz".to_string(),
+                        handler_xyz,
+                        dropshot::Method::GET,
+                        "/a/b/c",
+                    )
+                }
+            }
+        };
+
+        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+    }
+
+    #[test]
+    fn test_endpoint2() {
+        let ret = do_endpoint(
+            quote! {
+                method = GET,
+                path = "/a/b/c"
+            }
+            .into(),
+            quote! {
+                fn handler_xyz(_rqctx: Arc<RequestContext>, q: Query<Q>) {}
+            }
+            .into(),
+        );
+        let full = quote! {
+            std::sync::Arc< dropshot::RequestContext>
+        };
+        let short = quote! {
+            Arc<RequestContext>
+        };
+        let query = quote! {
+            Query<Q>
+        };
+        let expected = quote! {
+            const _: fn() = || {
+                trait TypeEq {
+                    type This: ?Sized;
+                }
+                impl<T: ?Sized> TypeEq for T {
+                    type This = Self;
+                }
+                fn need_arc_requestcontext<T>()
+                where
+                    T: ?Sized + TypeEq<This = #full>,
+                {
+                }
+                need_arc_requestcontext::<#short>();
+            };
+
+            const _: fn() = || {
+                fn need_extractor<T>()
+                where
+                    T: ?Sized + dropshot::Extractor,
+                {
+                }
+                need_extractor::<#query>();
+            };
+
+            #[allow(non_camel_case_types, missing_docs)]
+            #[doc = "API Endpoint: handler_xyz"]
+            pub struct handler_xyz {}
+
+            #[allow(non_upper_case_globals, missing_docs)]
+            #[doc = "API Endpoint: handler_xyz"]
+            const handler_xyz: handler_xyz = handler_xyz {};
+
+            impl From<handler_xyz> for dropshot::ApiEndpoint {
+                fn from(_: handler_xyz) -> Self {
+                    fn handler_xyz(_rqctx: Arc<RequestContext>, q: Query<Q>) {}
                     dropshot::ApiEndpoint::new(
                         "handler_xyz".to_string(),
                         handler_xyz,
@@ -314,7 +409,28 @@ mod tests {
             }
             .into(),
         );
+        let full = quote! {
+            std::sync::Arc< dropshot::RequestContext>
+        };
+        let short = quote! {
+            Arc<RequestContext>
+        };
         let expected = quote! {
+            const _: fn() = || {
+                trait TypeEq {
+                    type This: ?Sized;
+                }
+                impl<T: ?Sized> TypeEq for T {
+                    type This = Self;
+                }
+                fn need_arc_requestcontext<T>()
+                where
+                    T: ?Sized + TypeEq<This = #full>,
+                {
+                }
+                need_arc_requestcontext::<#short>();
+            };
+
             #[allow(non_camel_case_types, missing_docs)]
             #[doc = "API Endpoint: handler_xyz"]
             pub struct handler_xyz {}
@@ -353,7 +469,28 @@ mod tests {
             }
             .into(),
         );
+        let full = quote! {
+            std::sync::Arc< dropshot::RequestContext>
+        };
+        let short = quote! {
+            Arc<RequestContext>
+        };
         let expected = quote! {
+            const _: fn() = || {
+                trait TypeEq {
+                    type This: ?Sized;
+                }
+                impl<T: ?Sized> TypeEq for T {
+                    type This = Self;
+                }
+                fn need_arc_requestcontext<T>()
+                where
+                    T: ?Sized + TypeEq<This = #full>,
+                {
+                }
+                need_arc_requestcontext::<#short>();
+            };
+
             #[allow(non_camel_case_types, missing_docs)]
             #[doc = "API Endpoint: handle \"xyz\" requests"]
             pub struct handler_xyz {}

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -8,7 +8,7 @@ extern crate proc_macro;
 use proc_macro2::TokenStream;
 use quote::format_ident;
 use quote::quote;
-use quote::ToTokens;
+use quote::{quote_spanned, ToTokens};
 use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
 use serde_tokenstream::Error;
@@ -68,7 +68,7 @@ fn do_endpoint(
     let method = metadata.method.as_str();
     let path = metadata.path;
 
-    let ast: ItemFn = syn::parse2(item)?;
+    let ast: ItemFn = syn::parse2(item.clone())?;
 
     let name = &ast.sig.ident;
     let name_str = name.to_string();
@@ -103,9 +103,88 @@ fn do_endpoint(
 
     let dropshot = get_crate(metadata._dropshot_crate);
 
+    // When the user attaches this proc macro to a function with the wrong type
+    // signature, the resulting errors are deeply inscrutable. To attempt to
+    // make failures easier to understand, we inject code that asserts the types
+    // of the various parameters. For the first parameter of type
+    // Arc<RequestContext>, we turn that type into a trait and then construct
+    // a dummy function that requires a type match. It will fail for anything
+    // of the wrong type. Subsequent parameters are simpler: we simply need to
+    // call a dummy function that requires a type that satisfies the trait
+    // Extractor.
+    let mut checks = ast
+        .sig
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, arg)| {
+            let req = if i == 0 {
+                quote! { std::sync::Arc<#dropshot::RequestContext> }
+            } else {
+                quote! { #dropshot::Extractor }
+            };
+
+            match arg {
+                syn::FnArg::Receiver(_) => {
+                    // The compiler failure here is already comprehensible.
+                    quote! {}
+                }
+                syn::FnArg::Typed(pat) => {
+                    let span = Error::new_spanned(pat.ty.as_ref(), "").span();
+                    let ty = pat.ty.as_ref().into_token_stream();
+
+                    if i == 0 {
+                        quote_spanned! { span=>
+                            const _: fn() = ||{
+                                trait TypeEq {
+                                    type This: ?Sized;
+                                }
+                                impl<T: ?Sized> TypeEq for T {
+                                    type This = Self;
+                                }
+                                fn need_arc_requestcontext<T>()
+                                where
+                                    T: ?Sized + TypeEq<This = #req>
+                                {
+                                }
+                                need_arc_requestcontext::<#ty>();
+                            };
+                        }
+                    } else {
+                        quote_spanned! { span=>
+                            const _: fn() = ||{
+                                fn need_extractor<T>()
+                                where
+                                    T: ?Sized + #req
+                                {
+                                }
+                                need_extractor::<#ty>();
+                            };
+                        }
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Help the user if they don't give any parameters.
+    if ast.sig.inputs.len() == 0 {
+        checks.push(
+            Error::new_spanned(
+                (&ast.sig).into_token_stream(),
+                "incompatible function signature; expected async fn \
+                 (Arc<RequestContext>(, Extractor)*) -> Result<HttpResponse, \
+                 HttpError>",
+            )
+            .to_compile_error(),
+        );
+    }
+
     // The final TokenStream returned will have a few components that reference
     // `#name`, the name of the method to which this macro was applied...
     let stream = quote! {
+        #(#checks)*
+
         // ... a struct type called `#name` that has no members
         #[allow(non_camel_case_types, missing_docs)]
         #description_doc_comment
@@ -119,7 +198,7 @@ fn do_endpoint(
         // `#name` to be passed into `ApiDescription::register()`
         impl From<#name> for #dropshot::ApiEndpoint {
             fn from(_: #name) -> Self {
-                #ast
+                #item
 
                 #dropshot::ApiEndpoint::new(
                     #name_str.to_string(),
@@ -194,7 +273,7 @@ mod tests {
             }
             .into(),
             quote! {
-                fn handler_xyz() {}
+                fn handler_xyz(_rqctx: Arc<RequestContext>) {}
             }
             .into(),
         );
@@ -207,7 +286,7 @@ mod tests {
             const handler_xyz: handler_xyz = handler_xyz {};
             impl From<handler_xyz> for dropshot::ApiEndpoint {
                 fn from(_: handler_xyz) -> Self {
-                    fn handler_xyz() {}
+                    fn handler_xyz(_rqctx: Arc<RequestContext>) {}
                     dropshot::ApiEndpoint::new(
                         "handler_xyz".to_string(),
                         handler_xyz,
@@ -231,7 +310,7 @@ mod tests {
             }
             .into(),
             quote! {
-                fn handler_xyz() {}
+                fn handler_xyz(_rqctx: Arc<RequestContext>) {}
             }
             .into(),
         );
@@ -244,7 +323,7 @@ mod tests {
             const handler_xyz: handler_xyz = handler_xyz {};
             impl From<handler_xyz> for dropshot::ApiEndpoint {
                 fn from(_: handler_xyz) -> Self {
-                    fn handler_xyz() {}
+                    fn handler_xyz(_rqctx: Arc<RequestContext>) {}
                     dropshot::ApiEndpoint::new(
                         "handler_xyz".to_string(),
                         handler_xyz,
@@ -270,7 +349,7 @@ mod tests {
             .into(),
             quote! {
                 /** handle "xyz" requests */
-                fn handler_xyz() {}
+                fn handler_xyz(_rqctx: Arc<RequestContext>) {}
             }
             .into(),
         );
@@ -284,7 +363,7 @@ mod tests {
             impl From<handler_xyz> for dropshot::ApiEndpoint {
                 fn from(_: handler_xyz) -> Self {
                     #[doc = r#" handle "xyz" requests "#]
-                    fn handler_xyz() {}
+                    fn handler_xyz(_rqctx: Arc<RequestContext>) {}
                     dropshot::ApiEndpoint::new(
                         "handler_xyz".to_string(),
                         handler_xyz,


### PR DESCRIPTION
I took a crack at producing less inscrutable error messages when people don't specify the right types for endpoints. I could use some input as to whether this is beneficial or just different.

Thanks.