### PR TITLE
fix #19 openapi spec incomplete for pagination querystring parameters

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.8.0"
 features = [ "serde", "v4" ]
 
 [dependencies.schemars]
-version = "0.7.0"
+version = "0.7.6"
 features = [ "uuid" ]
 
 [dev-dependencies]
@@ -62,5 +62,5 @@ subprocess = "0.2.4"
 trybuild = "1.0.31"
 
 [dev-dependencies.schemars]
-version = "0.7.0"
+version = "0.7.6"
 features = [ "chrono", "uuid" ]

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -84,6 +84,47 @@ pub struct ApiEndpointParameter {
     pub examples: Vec<String>,
 }
 
+impl ApiEndpointParameter {
+    pub fn new_named(
+        loc: &ApiEndpointParameterLocation,
+        name: String,
+        description: Option<String>,
+        required: bool,
+        schema: ApiSchemaGenerator,
+        examples: Vec<String>,
+    ) -> Self {
+        Self {
+            name: match loc {
+                ApiEndpointParameterLocation::Path => {
+                    ApiEndpointParameterName::Path(name)
+                }
+                ApiEndpointParameterLocation::Query => {
+                    ApiEndpointParameterName::Query(name)
+                }
+            },
+            description,
+            required,
+            schema,
+            examples,
+        }
+    }
+
+    pub fn new_body(
+        description: Option<String>,
+        required: bool,
+        schema: ApiSchemaGenerator,
+        examples: Vec<String>,
+    ) -> Self {
+        Self {
+            name: ApiEndpointParameterName::Body,
+            description,
+            required,
+            schema,
+            examples,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ApiEndpointParameterLocation {
     Path,
@@ -95,19 +136,6 @@ pub enum ApiEndpointParameterName {
     Path(String),
     Query(String),
     Body,
-}
-
-impl From<(ApiEndpointParameterLocation, String)> for ApiEndpointParameterName {
-    fn from((location, name): (ApiEndpointParameterLocation, String)) -> Self {
-        match location {
-            ApiEndpointParameterLocation::Path => {
-                ApiEndpointParameterName::Path(name)
-            }
-            ApiEndpointParameterLocation::Query => {
-                ApiEndpointParameterName::Query(name)
-            }
-        }
-    }
 }
 
 /**

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -664,7 +664,7 @@ where
  * in an error.
  *
  * - `loc` is the input to GetMetadata::metadata, query or path parameters.
- * - `schema`, is what we're processing.
+ * - `schema` is what we're processing.
  * - `definitions` is the map of referenced schemas created in the generation
  * step (as noted above, we would ideally just have these all inline).
  * - `required` defines whether parameters are required. In the case of an
@@ -747,7 +747,6 @@ fn schema2parameters(
             if let Some(subschemas) = subschemas {
                 match subschemas.as_ref() {
                     // We expect any_of in the case of an enum.
-                    // TODO make them optional
                     schemars::schema::SubschemaValidation {
                         all_of: None,
                         any_of: Some(schemas),

--- a/dropshot/src/pagination.rs
+++ b/dropshot/src/pagination.rs
@@ -186,7 +186,7 @@ impl<ItemType> ResultsPage<ItemType> {
  * careful when designing these structures to consider what you might want to
  * support in the future.
  */
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize)]
 #[serde(bound(deserialize = "PageSelector: DeserializeOwned, ScanParams: \
                              DeserializeOwned"))]
 /*
@@ -217,6 +217,25 @@ pub struct PaginationParams<ScanParams, PageSelector> {
     pub(crate) limit: Option<NonZeroU64>,
 }
 
+/*
+ * We use the JsonSchema from `RawPaginationParams` which obscures the contents
+ * of `PageSelector` (vid `RawWhichPage`).
+ */
+impl<ScanParams, PageSelector> JsonSchema
+    for PaginationParams<ScanParams, PageSelector>
+where
+    ScanParams: JsonSchema,
+{
+    fn schema_name() -> String {
+        unimplemented!();
+    }
+    fn json_schema(
+        gen: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        RawPaginationParams::<ScanParams>::json_schema(gen)
+    }
+}
+
 /**
  * Describes whether the client is beginning a new scan or resuming an existing
  * one
@@ -225,7 +244,7 @@ pub struct PaginationParams<ScanParams, PageSelector> {
  * the particular type of request.  See [`PaginationParams`] for more
  * information.
  */
-#[derive(Debug, JsonSchema)]
+#[derive(Debug)]
 pub enum WhichPage<ScanParams, PageSelector> {
     /**
      * Indicates that the client is beginning a new scan

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -29,40 +29,40 @@ error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
    = note: required by `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint6.rs:22:8
-    |
-22  |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint6.rs:22:8
+     |
+22   |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint6.rs:22:5
-    |
-22  |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint6.rs:22:5
+     |
+22   |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint6.rs:21:94
-    |
-21  |   async fn bad_endpoint(_rqctx: Arc<RequestContext>) -> Result<HttpResponseOk<Ret>, HttpError> {
-    |  ______________________________________________________________________________________________^
-22  | |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-23  | | }
-    | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint6.rs:21:94
+     |
+21   |   async fn bad_endpoint(_rqctx: Arc<RequestContext>) -> Result<HttpResponseOk<Ret>, HttpError> {
+     |  ______________________________________________________________________________________________^
+22   | |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+23   | | }
+     | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
   --> $DIR/bad_endpoint6.rs:17:1

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -11,50 +11,50 @@ error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
    = note: required by `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint7.rs:24:8
-    |
-24  |       Ok(HttpResponseOk(Ret {
-    |  ________^
-25  | |         x: "Oxide".to_string(),
-26  | |         y: 0x1de,
-27  | |     }))
-    | |______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint7.rs:24:8
+     |
+24   |       Ok(HttpResponseOk(Ret {
+     |  ________^
+25   | |         x: "Oxide".to_string(),
+26   | |         y: 0x1de,
+27   | |     }))
+     | |______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint7.rs:24:5
-    |
-24  | /     Ok(HttpResponseOk(Ret {
-25  | |         x: "Oxide".to_string(),
-26  | |         y: 0x1de,
-27  | |     }))
-    | |_______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint7.rs:24:5
+     |
+24   | /     Ok(HttpResponseOk(Ret {
+25   | |         x: "Oxide".to_string(),
+26   | |         y: 0x1de,
+27   | |     }))
+     | |_______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-   --> $DIR/bad_endpoint7.rs:23:45
-    |
-23  |   ) -> Result<HttpResponseOk<Ret>, HttpError> {
-    |  _____________________________________________^
-24  | |     Ok(HttpResponseOk(Ret {
-25  | |         x: "Oxide".to_string(),
-26  | |         y: 0x1de,
-27  | |     }))
-28  | | }
-    | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-    |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-    |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
+    --> $DIR/bad_endpoint7.rs:23:45
+     |
+23   |   ) -> Result<HttpResponseOk<Ret>, HttpError> {
+     |  _____________________________________________^
+24   | |     Ok(HttpResponseOk(Ret {
+25   | |         x: "Oxide".to_string(),
+26   | |         y: 0x1de,
+27   | |     }))
+28   | | }
+     | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                             --------- required by this bound in `dropshot::handler::HttpResponseOk`
 
 error[E0277]: the trait bound `fn(std::sync::Arc<dropshot::handler::RequestContext>) -> impl std::future::Future {<impl std::convert::From<bad_endpoint> for dropshot::api_description::ApiEndpoint>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _>` is not satisfied
   --> $DIR/bad_endpoint7.rs:21:10

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -14,10 +14,29 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "description": "Client-requested limit on page size (optional)\n\nConsumers should use [`dropshot::RequestContext::page_limit()`] to access this value.",
               "type": "integer",
               "format": "uint64",
               "minimum": 1
+            },
+            "allowReserved": true,
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "type": "string"
+            },
+            "allowReserved": true,
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "a_number",
+            "schema": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0
             },
             "allowReserved": true,
             "style": "form"


### PR DESCRIPTION
fixes #19 

Our processing of schemas was incomplete, in particular for flattened enums as in the case of `PaginationParams`.

I'll give this a little while; post-merge comments welcome.