### PR TITLE
would like support for freeform request bodies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@ https://github.com/oxidecomputer/dropshot/compare/v0.4.0\...HEAD[Full list of co
 // configured in release.toml.  DO NOT change the format of the headers or the
 // list of raw commits.
 
+=== Notable changes
+
+* https://github.com/oxidecomputer/dropshot/issues/44[#44] The new extractor `UntypedBody` allows API endpoints to accept either raw bytes or a UTF-8 string.
+
 == 0.4.0 (released 2021-02-01)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.3.0\...v0.4.0[Full list of commits]

--- a/dropshot/src/http_util.rs
+++ b/dropshot/src/http_util.rs
@@ -14,6 +14,8 @@ use crate::from_map::from_map;
 
 /** header name for conveying request ids ("x-request-id") */
 pub const HEADER_REQUEST_ID: &str = "x-request-id";
+/** MIME type for raw bytes */
+pub const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
 /** MIME type for plain JSON data */
 pub const CONTENT_TYPE_JSON: &str = "application/json";
 /** MIME type for newline-delimited JSON data */
@@ -41,6 +43,7 @@ where
      * std::marker::Unpin, &mut T)
      * TODO Error type shouldn't have to be hyper Error -- Into<ApiError> should
      * work too?
+     * TODO do we need to use saturating_add() here?
      */
     let mut parts = std::vec::Vec::new();
     let mut nbytesread: usize = 0;
@@ -90,6 +93,7 @@ where
      * read?  What if the underlying implementation chooses to wait for a much
      * larger number of bytes?
      * TODO better understand pin_mut!()
+     * TODO do we need to use saturating_add() here?
      */
     let mut nbytesread: usize = 0;
     while let Some(maybebuf) = body.data().await {

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -213,13 +213,14 @@
  *      [query_params: Query<Q>,]
  *      [path_params: Path<P>,]
  *      [body_param: TypedBody<J>,]
+ *      [body_param: UntypedBody<J>,]
  * ) -> Result<HttpResponse*, HttpError>
  * ```
  *
  * Other than the RequestContext, parameters may appear in any order.  The types
- * `Query`, `Path`, and `TypedBody` are called **Extractors** because they cause
- * information to be pulled out of the request and made available to the handler
- * function.
+ * `Query`, `Path`, `TypedBody`, and `UntypedBody` are called **Extractors**
+ * because they cause information to be pulled out of the request and made
+ * available to the handler function.
  *
  * * [`Query`]`<Q>` extracts parameters from a query string, deserializing them
  *   into an instance of type `Q`. `Q` must implement `serde::Deserialize` and
@@ -230,10 +231,12 @@
  * * [`TypedBody`]`<J>` extracts content from the request body by parsing the
  *   body as JSON and deserializing it into an instance of type `J`. `J` must
  *   implement `serde::Deserialize` and `schemars::JsonSchema`.
+ * * [`UntypedBody`] extracts the raw bytes of the request body.
  *
- * If the handler takes a `Query<Q>`, `Path<P>`, or a `TypedBody<J>` and the
- * corresponding extraction cannot be completed, the request fails with status
- * code 400 and an error message reflecting a validation error.
+ * If the handler takes a `Query<Q>`, `Path<P>`, `TypedBody<J>`, or
+ * `UntypedBody`, and the corresponding extraction cannot be completed, the
+ * request fails with status code 400 and an error message reflecting a
+ * validation error.
  *
  * As with any serde-deserializable type, you can make fields optional by having
  * the corresponding property of the type be an `Option`.  Here's an example of
@@ -531,8 +534,10 @@ pub use handler::Path;
 pub use handler::Query;
 pub use handler::RequestContext;
 pub use handler::TypedBody;
+pub use handler::UntypedBody;
 pub use http_util::CONTENT_TYPE_JSON;
 pub use http_util::CONTENT_TYPE_NDJSON;
+pub use http_util::CONTENT_TYPE_OCTET_STREAM;
 pub use http_util::HEADER_REQUEST_ID;
 pub use logging::ConfigLogging;
 pub use logging::ConfigLoggingIfExists;

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -20,10 +20,12 @@ use dropshot::test_util::read_json;
 use dropshot::test_util::read_string;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
+use dropshot::HttpResponseOk;
 use dropshot::Path;
 use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
+use dropshot::UntypedBody;
 use dropshot::CONTENT_TYPE_JSON;
 use http::StatusCode;
 use hyper::Body;
@@ -49,6 +51,7 @@ fn demo_api() -> ApiDescription {
     api.register(demo_handler_path_param_string).unwrap();
     api.register(demo_handler_path_param_uuid).unwrap();
     api.register(demo_handler_path_param_u32).unwrap();
+    api.register(demo_handler_untyped_body).unwrap();
 
     /*
      * We don't need to exhaustively test these cases, as they're tested by unit
@@ -515,6 +518,94 @@ async fn test_demo_path_param_u32() {
 }
 
 /*
+ * Test `UntypedBody`.
+ */
+#[tokio::test]
+async fn test_untyped_body() {
+    let api = demo_api();
+    let testctx = common::test_setup("test_untyped_body", api);
+    let client = &testctx.client_testctx;
+
+    /* Error case: body too large. */
+    let big_body = vec![0u8; 1025];
+    let error = client
+        .make_request_with_body(
+            Method::PUT,
+            "/testing/untyped_body",
+            big_body.into(),
+            StatusCode::BAD_REQUEST,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.message,
+        "request body exceeded maximum size of 1024 bytes"
+    );
+
+    /* Error case: invalid UTF-8, when parsing as a UTF-8 string. */
+    let bad_body = vec![0x80u8; 1];
+    let error = client
+        .make_request_with_body(
+            Method::PUT,
+            "/testing/untyped_body?parse_str=true",
+            bad_body.clone().into(),
+            StatusCode::BAD_REQUEST,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.message,
+        "failed to parse body as UTF-8 string: invalid utf-8 sequence of 1 \
+         bytes from index 0"
+    );
+
+    /* Success case: invalid UTF-8, when not parsing. */
+    let mut response = client
+        .make_request_with_body(
+            Method::PUT,
+            "/testing/untyped_body",
+            bad_body.into(),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    let json: DemoUntyped = read_json(&mut response).await;
+    assert_eq!(json.nbytes, 1);
+    assert_eq!(json.as_utf8, None);
+
+    /* Success case: empty body */
+    let mut response = client
+        .make_request_with_body(
+            Method::PUT,
+            "/testing/untyped_body?parse_str=true",
+            "".into(),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    let json: DemoUntyped = read_json(&mut response).await;
+    assert_eq!(json.nbytes, 0);
+    assert_eq!(json.as_utf8, Some(String::from("")));
+
+    /* Success case: non-empty content */
+    let body: Vec<u8> = Vec::from(&b"t\xce\xbcv"[..]);
+    let mut response = client
+        .make_request_with_body(
+            Method::PUT,
+            "/testing/untyped_body?parse_str=true",
+            body.into(),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    let json: DemoUntyped = read_json(&mut response).await;
+    assert_eq!(json.nbytes, 4);
+    assert_eq!(json.as_utf8, Some(String::from("tμv")));
+
+    testctx.teardown().await;
+}
+
+/*
  * Demo handler functions
  */
 
@@ -624,6 +715,37 @@ async fn demo_handler_path_param_u32(
     path_params: Path<DemoPathU32>,
 ) -> Result<Response<Body>, HttpError> {
     http_echo(&path_params.into_inner())
+}
+
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct DemoUntyped {
+    pub nbytes: usize,
+    pub as_utf8: Option<String>,
+}
+#[derive(Deserialize, JsonSchema)]
+pub struct DemoUntypedQuery {
+    pub parse_str: Option<bool>,
+}
+#[endpoint {
+    method = PUT,
+    path = "/testing/untyped_body"
+}]
+async fn demo_handler_untyped_body(
+    _rqctx: Arc<RequestContext>,
+    body: UntypedBody,
+    query: Query<DemoUntypedQuery>,
+) -> Result<HttpResponseOk<DemoUntyped>, HttpError> {
+    let nbytes = body.as_bytes().len();
+    let as_utf8 = if query.into_inner().parse_str.unwrap_or(false) {
+        Some(String::from(body.as_str()?))
+    } else {
+        None
+    };
+
+    Ok(HttpResponseOk(DemoUntyped {
+        nbytes,
+        as_utf8,
+    }))
 }
 
 #[derive(Deserialize, Serialize, JsonSchema)]

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -5,6 +5,27 @@
     "version": "threeve"
   },
   "paths": {
+    "/datagoeshere": {
+      "put": {
+        "operationId": "handler7",
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/impairment": {
       "get": {
         "operationId": "handler6",

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -4,7 +4,7 @@ use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseAccepted,
     HttpResponseCreated, HttpResponseDeleted, HttpResponseOk,
     HttpResponseUpdatedNoContent, PaginationParams, Path, Query,
-    RequestContext, ResultsPage, TypedBody,
+    RequestContext, ResultsPage, TypedBody, UntypedBody,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -125,6 +125,17 @@ async fn handler6(
     unimplemented!();
 }
 
+#[endpoint {
+    method = PUT,
+    path = "/datagoeshere",
+}]
+async fn handler7(
+    _rqctx: Arc<RequestContext>,
+    _dump: UntypedBody,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    unimplemented!();
+}
+
 #[test]
 fn test_openapi_old() -> Result<(), String> {
     let mut api = ApiDescription::new();
@@ -134,6 +145,7 @@ fn test_openapi_old() -> Result<(), String> {
     api.register(handler4)?;
     api.register(handler5)?;
     api.register(handler6)?;
+    api.register(handler7)?;
 
     let mut output = Cursor::new(Vec::new());
 

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -136,8 +136,7 @@ async fn handler7(
     unimplemented!();
 }
 
-#[test]
-fn test_openapi_old() -> Result<(), String> {
+fn make_api() -> Result<ApiDescription, String> {
     let mut api = ApiDescription::new();
     api.register(handler1)?;
     api.register(handler2)?;
@@ -146,7 +145,12 @@ fn test_openapi_old() -> Result<(), String> {
     api.register(handler5)?;
     api.register(handler6)?;
     api.register(handler7)?;
+    Ok(api)
+}
 
+#[test]
+fn test_openapi_old() -> Result<(), String> {
+    let api = make_api()?;
     let mut output = Cursor::new(Vec::new());
 
     #[allow(deprecated)]
@@ -164,20 +168,13 @@ fn test_openapi_old() -> Result<(), String> {
     );
     let actual = from_utf8(&output.get_ref()).unwrap();
 
-    expectorate::assert_contents("tests/test_openapi.json", actual);
+    expectorate::assert_contents("tests/test_openapi_old.json", actual);
     Ok(())
 }
 
 #[test]
 fn test_openapi() -> Result<(), String> {
-    let mut api = ApiDescription::new();
-    api.register(handler1)?;
-    api.register(handler2)?;
-    api.register(handler3)?;
-    api.register(handler4)?;
-    api.register(handler5)?;
-    api.register(handler6)?;
-
+    let api = make_api()?;
     let mut output = Cursor::new(Vec::new());
 
     let _ = api.openapi("test", "threeve").write(&mut output);
@@ -189,14 +186,7 @@ fn test_openapi() -> Result<(), String> {
 
 #[test]
 fn test_openapi_fuller() -> Result<(), String> {
-    let mut api = ApiDescription::new();
-    api.register(handler1)?;
-    api.register(handler2)?;
-    api.register(handler3)?;
-    api.register(handler4)?;
-    api.register(handler5)?;
-    api.register(handler6)?;
-
+    let api = make_api()?;
     let mut output = Cursor::new(Vec::new());
 
     let _ = api

--- a/dropshot/tests/test_openapi_old.json
+++ b/dropshot/tests/test_openapi_old.json
@@ -2,15 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "test",
-    "description": "gusty winds may exist",
-    "termsOfService": "no hat, no cane? no service!",
-    "contact": {
-      "name": "old mate"
-    },
-    "license": {
-      "name": "CDDL"
-    },
-    "version": "1985.7"
+    "version": "threeve"
   },
   "paths": {
     "/datagoeshere": {


### PR DESCRIPTION
This fixes #44.

I've added a new extractor called `UntypedBody`, which exposes:

- `as_bytes() -> &[u8]`: returns a byte slice
- `as_str() -> Result<&str, HttpError>`: returns a (UTF-8) `str` from the byte slice.  If the string is not valid UTF-8, then this bails with a 400 response saying that the body should be a UTF-8 string.

This approach is straightforward and seems convenient to me -- what do you think @jclulow and @ahl?  Note that from this, we cannot statically determine if the endpoint is _expecting_ a UTF-8 string or just an octet stream, so the JSON schema for this just says that it's a set of binary bytes.  If we want that, we'd need to separate this into two types, maybe `BodyBytes` and `BodyUtf8`?  I wasn't sure that was worth it here.

In terms of the implementation: I've piggy-backed off the existing `ApiEndpointParameterName::Body` to stash the expected content-type rather than more serious surgery to the api_description.rs.  I could separate this into something that doesn't overload the "name" if that seems better, or maybe just rename this to `ApiEndpointParameterMetadata`?  I defer to @ahl on this.

The OpenAPI schema looks like this:
https://github.com/oxidecomputer/dropshot/blob/95e1bfa92303f127779c4a4c229e9d603d5e3113/dropshot/tests/test_openapi.json#L12-L22

Edit: I forgot to mention that I chose that schema based on the suggestions in the [Considerations for File Uploads](https://swagger.io/specification/#considerations-for-file-uploads) section in the Swagger spec.