### PR TITLE
fill in OpenAPI responses description

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -145,6 +145,7 @@ pub enum ApiEndpointParameterName {
 pub struct ApiEndpointResponse {
     pub schema: Option<ApiSchemaGenerator>,
     pub success: Option<StatusCode>,
+    pub description: Option<String>,
 }
 
 /**
@@ -421,7 +422,16 @@ impl ApiDescription {
                 }
 
                 let response = openapiv3::Response {
-                    description: "TODO: placeholder".to_string(), // TODO
+                    description: if let Some(description) =
+                        &endpoint.response.description
+                    {
+                        description.clone()
+                    } else {
+                        // TODO: perhaps we should require even free-form
+                        // responses to have a description since it's required
+                        // by OpenAPI.
+                        "".to_string()
+                    },
                     headers: indexmap::IndexMap::new(),
                     content: content,
                     links: indexmap::IndexMap::new(),

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -925,6 +925,7 @@ impl HttpResponse for Response<Body> {
         ApiEndpointResponse {
             schema: None,
             success: None,
+            description: None,
         }
     }
 }
@@ -947,6 +948,7 @@ pub trait HttpTypedResponse:
 {
     type Body: JsonSchema + Serialize;
     const STATUS_CODE: StatusCode;
+    const DESCRIPTION: &'static str;
 
     /**
      * Convenience method to produce a response based on the input
@@ -978,6 +980,7 @@ where
         ApiEndpointResponse {
             schema: Some(ApiSchemaGenerator::Gen(T::Body::json_schema)),
             success: Some(T::STATUS_CODE),
+            description: Some(T::DESCRIPTION.to_string()),
         }
     }
 }
@@ -999,6 +1002,7 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> HttpTypedResponse
 {
     type Body = T;
     const STATUS_CODE: StatusCode = StatusCode::CREATED;
+    const DESCRIPTION: &'static str = "successful creation";
 }
 impl<T: JsonSchema + Serialize + Send + Sync + 'static>
     From<HttpResponseCreated<T>> for HttpHandlerResult
@@ -1022,6 +1026,7 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> HttpTypedResponse
 {
     type Body = T;
     const STATUS_CODE: StatusCode = StatusCode::ACCEPTED;
+    const DESCRIPTION: &'static str = "successful operation";
 }
 impl<T: JsonSchema + Serialize + Send + Sync + 'static>
     From<HttpResponseAccepted<T>> for HttpHandlerResult
@@ -1044,6 +1049,7 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> HttpTypedResponse
 {
     type Body = T;
     const STATUS_CODE: StatusCode = StatusCode::OK;
+    const DESCRIPTION: &'static str = "successful operation";
 }
 impl<T: JsonSchema + Serialize + Send + Sync + 'static> From<HttpResponseOk<T>>
     for HttpHandlerResult
@@ -1062,6 +1068,7 @@ pub struct HttpResponseDeleted();
 impl HttpTypedResponse for HttpResponseDeleted {
     type Body = ();
     const STATUS_CODE: StatusCode = StatusCode::NO_CONTENT;
+    const DESCRIPTION: &'static str = "successful deletion";
 }
 impl From<HttpResponseDeleted> for HttpHandlerResult {
     fn from(_: HttpResponseDeleted) -> HttpHandlerResult {
@@ -1080,6 +1087,7 @@ pub struct HttpResponseUpdatedNoContent();
 impl HttpTypedResponse for HttpResponseUpdatedNoContent {
     type Body = ();
     const STATUS_CODE: StatusCode = StatusCode::NO_CONTENT;
+    const DESCRIPTION: &'static str = "successful operation";
 }
 impl From<HttpResponseUpdatedNoContent> for HttpHandlerResult {
     fn from(_: HttpResponseUpdatedNoContent) -> HttpHandlerResult {

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -1026,7 +1026,7 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> HttpTypedResponse
 {
     type Body = T;
     const STATUS_CODE: StatusCode = StatusCode::ACCEPTED;
-    const DESCRIPTION: &'static str = "successful operation";
+    const DESCRIPTION: &'static str = "successfully enqueued operation";
 }
 impl<T: JsonSchema + Serialize + Send + Sync + 'static>
     From<HttpResponseAccepted<T>> for HttpHandlerResult
@@ -1087,7 +1087,7 @@ pub struct HttpResponseUpdatedNoContent();
 impl HttpTypedResponse for HttpResponseUpdatedNoContent {
     type Body = ();
     const STATUS_CODE: StatusCode = StatusCode::NO_CONTENT;
-    const DESCRIPTION: &'static str = "successful operation";
+    const DESCRIPTION: &'static str = "resource updated";
 }
 impl From<HttpResponseUpdatedNoContent> for HttpHandlerResult {
     fn from(_: HttpResponseUpdatedNoContent) -> HttpHandlerResult {

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -541,6 +541,7 @@ mod test {
             response: ApiEndpointResponse {
                 schema: None,
                 success: None,
+                description: None,
             },
             description: None,
             tags: vec![],

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -45,7 +45,7 @@
         ],
         "responses": {
           "200": {
-            "description": "TODO: placeholder",
+            "description": "successful operation",
             "content": {
               "application/json": {
                 "schema": {
@@ -97,7 +97,7 @@
         },
         "responses": {
           "201": {
-            "description": "TODO: placeholder",
+            "description": "successful creation",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,7 +125,7 @@
         ],
         "responses": {
           "204": {
-            "description": "TODO: placeholder"
+            "description": "successful deletion"
           }
         }
       }
@@ -135,7 +135,7 @@
         "operationId": "handler1",
         "responses": {
           "200": {
-            "description": "TODO: placeholder"
+            "description": "successful operation"
           }
         }
       }
@@ -215,7 +215,7 @@
         },
         "responses": {
           "200": {
-            "description": "TODO: placeholder"
+            "description": "successful operation"
           }
         }
       }
@@ -261,7 +261,7 @@
         ],
         "responses": {
           "200": {
-            "description": "TODO: placeholder"
+            "description": "successful operation"
           }
         }
       }

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -214,14 +214,14 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "202": {
+            "description": "successfully enqueued operation"
           }
         }
       }
     },
     "/test/woman": {
-      "get": {
+      "put": {
         "operationId": "handler2",
         "parameters": [
           {
@@ -260,8 +260,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -1,8 +1,9 @@
 // Copyright 2020 Oxide Computer Company
 
 use dropshot::{
-    endpoint, ApiDescription, HttpError, HttpResponseCreated,
-    HttpResponseDeleted, HttpResponseOk, PaginationParams, Path, Query,
+    endpoint, ApiDescription, HttpError, HttpResponseAccepted,
+    HttpResponseCreated, HttpResponseDeleted, HttpResponseOk,
+    HttpResponseUpdatedNoContent, PaginationParams, Path, Query,
     RequestContext, ResultsPage, TypedBody,
 };
 use schemars::JsonSchema;
@@ -28,14 +29,14 @@ struct QueryArgs {
 }
 
 #[endpoint {
-    method = GET,
+    method = PUT,
     path = "/test/woman",
 }]
 async fn handler2(
     _rqctx: Arc<RequestContext>,
     _query: Query<QueryArgs>,
-) -> Result<HttpResponseOk<()>, HttpError> {
-    Ok(HttpResponseOk(()))
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    Ok(HttpResponseUpdatedNoContent())
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -84,8 +85,8 @@ async fn handler5(
     _path: Path<PathArgs>,
     _query: Query<QueryArgs>,
     _body: TypedBody<BodyParam>,
-) -> Result<HttpResponseOk<()>, HttpError> {
-    Ok(HttpResponseOk(()))
+) -> Result<HttpResponseAccepted<()>, HttpError> {
+    Ok(HttpResponseAccepted(()))
 }
 
 #[derive(JsonSchema, Serialize)]

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 Oxide Computer Company
-//! This macro defines attributes associated with HTTP handlers. These
+
+//! This package defines macro attributes associated with HTTP handlers. These
 //! attributes are used both to define an HTTP API and to generate an OpenAPI
 //! Spec (OAS) v3 document that describes the API.
 
@@ -104,7 +105,7 @@ fn do_endpoint(
     let dropshot = get_crate(metadata._dropshot_crate);
 
     // When the user attaches this proc macro to a function with the wrong type
-    // signature, the resulting errors are deeply inscrutable. To attempt to
+    // signature, the resulting errors can be deeply inscrutable. To attempt to
     // make failures easier to understand, we inject code that asserts the types
     // of the various parameters. For the first parameter of type
     // Arc<RequestContext>, we turn that type into a trait and then construct


### PR DESCRIPTION
fixes #11 as described in that discussion.

This leaves as a TODO the case of the freeform `Response<Body>` as OpenAPI still, technically, requires a description.

We also may want to consider in the future letting consumers specify a custom description field. After further consideration, perhaps specifying the description for the success case in the `#[endpoint ... ]` macro isn't that bad if developers want to specify it for freeform return types or customize it for typed responses.