### PR TITLE
feat: mark endpoint const as pub

### DIFF
--- a/dropshot/examples/module-basic.rs
+++ b/dropshot/examples/module-basic.rs
@@ -1,0 +1,167 @@
+// Copyright 2020 Oxide Computer Company
+/*!
+ * Example use of Dropshot.
+ */
+
+use dropshot::ApiDescription;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpServer;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::any::Any;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    /*
+     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
+     * since it's available and won't expose this server outside the host.  We
+     * request port 0, which allows the operating system to pick any available
+     * port.
+     */
+    let config_dropshot = Default::default();
+
+    /*
+     * For simplicity, we'll configure an "info"-level logger that writes to
+     * stderr assuming that it's a terminal.
+     */
+    let config_logging = ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Info,
+    };
+    let log = config_logging
+        .to_logger("example-basic")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    /*
+     * Build a description of the API.
+     */
+    let mut api = ApiDescription::new();
+    api.register(routes::example_api_get_counter).unwrap();
+    api.register(routes::example_api_put_counter).unwrap();
+
+    /*
+     * The functions that implement our API endpoints will share this context.
+     */
+    let api_context = ExampleContext::new();
+
+    /*
+     * Set up the server.
+     */
+    let mut server = HttpServer::new(&config_dropshot, api, api_context, &log)
+        .map_err(|error| format!("failed to create server: {}", error))?;
+    let server_task = server.run();
+
+    /*
+     * Wait for the server to stop.  Note that there's not any code to shut down
+     * this server, so we should never get past this point.
+     */
+    server.wait_for_shutdown(server_task).await
+}
+
+/**
+ * Application-specific example context (state shared by handler functions)
+ */
+pub struct ExampleContext {
+    /** counter that can be manipulated by requests to the HTTP API */
+    pub counter: AtomicU64,
+}
+
+impl ExampleContext {
+    /**
+     * Return a new ExampleContext.
+     */
+    pub fn new() -> Arc<ExampleContext> {
+        Arc::new(ExampleContext {
+            counter: AtomicU64::new(0),
+        })
+    }
+
+    /**
+     * Given `rqctx` (which is provided by Dropshot to all HTTP handler
+     * functions), return our application-specific context.
+     */
+    pub fn from_rqctx(rqctx: &Arc<RequestContext>) -> Arc<ExampleContext> {
+        let ctx: Arc<dyn Any + Send + Sync + 'static> =
+            Arc::clone(&rqctx.server.private);
+        ctx.downcast::<ExampleContext>().expect("wrong type for private data")
+    }
+}
+
+/*
+ * HTTP API interface
+ */
+
+/**
+ * `CounterValue` represents the value of the API's counter, either as the
+ * response to a GET request to fetch the counter or as the body of a PUT
+ * request to update the counter.
+ */
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct CounterValue {
+    counter: u64,
+}
+
+/**
+ * The routes module might be imported from another crate that publishes
+ * mountable routes
+ */
+pub mod routes {
+    use crate::{CounterValue, ExampleContext};
+    use dropshot::endpoint;
+    use dropshot::HttpError;
+    use dropshot::HttpResponseOk;
+    use dropshot::HttpResponseUpdatedNoContent;
+    use dropshot::RequestContext;
+    use dropshot::TypedBody;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    /**
+     * Fetch the current value of the counter.
+     * NOTE: The endpoint macro inherits its module visibility from
+     * the endpoint async function definition
+     */
+    #[endpoint {
+          method = GET,
+          path = "/counter",
+      }]
+    pub async fn example_api_get_counter(
+        rqctx: Arc<RequestContext>,
+    ) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+        let api_context = ExampleContext::from_rqctx(&rqctx);
+
+        Ok(HttpResponseOk(CounterValue {
+            counter: api_context.counter.load(Ordering::SeqCst),
+        }))
+    }
+
+    /**
+     * Update the current value of the counter.  Note that the special value of 10
+     * is not allowed (just to demonstrate how to generate an error).
+     */
+    #[endpoint {
+          method = PUT,
+          path = "/counter",
+      }]
+    pub async fn example_api_put_counter(
+        rqctx: Arc<RequestContext>,
+        update: TypedBody<CounterValue>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let api_context = ExampleContext::from_rqctx(&rqctx);
+        let updated_value = update.into_inner();
+
+        if updated_value.counter == 10 {
+            Err(HttpError::for_bad_request(
+                Some(String::from("BadInput")),
+                format!("do not like the number {}", updated_value.counter),
+            ))
+        } else {
+            api_context.counter.store(updated_value.counter, Ordering::SeqCst);
+            Ok(HttpResponseUpdatedNoContent())
+        }
+    }
+}


### PR DESCRIPTION
The endpoint macro did not create a pub const and thus could
not be used in modules outside of main. I updated the macro
but feel that the visibility of the entities that it creates
should be pulled from the visibility of the handler function
that it wraps.

I also updated the basic example to show the module namespacing
that can now be achieved.