### PR TITLE
WIP: update to tokio 0.3

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -43,7 +43,7 @@ version = "2.5.0"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.tokio]
-version = "0.2.0"
+version = "0.3.0"
 features = [ "full" ]
 
 [dependencies.uuid]

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -942,7 +942,7 @@ async fn start_example(path: &str, port: u16) -> ExampleContext {
             return rv;
         }
 
-        tokio::time::delay_for(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
     panic!(


### PR DESCRIPTION
See #60.

The only breaking build-time change I've found is that `tokio::time::delay_for` has been renamed to `tokio::time::sleep` (with no alias or anything).  At runtime, things still fail like this:

```
$ RUST_BACKTRACE=full cargo test 
    Finished test [unoptimized + debuginfo] target(s) in 0.09s
     Running target/debug/deps/dropshot-a4cd805ac67f9af3

running 55 tests
test from_map::test::test_lone_literal ... ok
test api_description::test::test_empty_struct ... ok
test from_map::test::test_deep ... ok
test from_map::test::test_missing_data1 ... ok
test from_map::test::test_missing_data2 ... ok
test from_map::test::test_types ... ok
test handler::test::test_metadata_flattened ... ok
test api_description::test::test_badpath1 ... ok
test api_description::test::test_badpath3 ... ok
test api_description::test::test_badpath2 ... ok
test handler::test::test_metadata_flattened_enum ... ok
test handler::test::test_metadata_pagination ... ok
test handler::test::test_metadata_simple ... ok
test api_description::test::test_garbage_barge_structure_conversion ... ok
test logging::test::test_config_bad_file_no_level ... ok
test logging::test::test_config_bad_file_no_file ... ok
test logging::test::test_config_bad_terminal_bad_level ... ok
test logging::test::test_config_bad_log_mode ... ok
test logging::test::test_config_bad_terminal_no_level ... ok
test pagination::test::test_results_page ... ok
test logging::test::test_config_bad_file_bad_path_type ... ok
test logging::test::test_config_bad_file_path_exists_fail ... ok
test pagination::test::test_page_token_serialization ... ok
test pagination::test::test_pagparams_parsing ... ok
test router::test::test_embedded_non_variable ... ok
test router::test::test_empty_variable ... ok
test router::test::test_error_cases ... ok
test router::test::test_iter ... ok
test router::test::test_iter2 ... ok
test router::test::test_iter_null ... ok
test logging::test::test_config_stderr_terminal ... ok
test router::test::test_router_basic ... ok
test logging::test::test_config_file ... ok
test router::test::test_duplicate_route1 ... ok
test router::test::test_duplicate_route2 ... ok
test router::test::test_variable_name_bad_start ... ok
test router::test::test_duplicate_varname ... ok
test router::test::test_variables_basic ... ok
test router::test::test_inconsistent_varname ... ok
test router::test::test_variables_multi ... ok
test router::test::test_literal_after_variable ... ok
test router::test::test_variable_after_literal ... ok
test test_util::test::test_bunyan_easy_cases ... ok
test router::test::test_variable_name_bad_end ... ok
test router::test::test_duplicate_route3 ... ok
test test_util::test::test_bunyan_seq_easy_cases ... ok
test router::test::test_variable_name_empty ... ok
test test_util::test::test_bunyan_bad_hostname ... ok
test test_util::test::test_bunyan_bad_name ... ok
test test_util::test::test_bunyan_bad_pid ... ok
test test_util::test::test_bunyan_bad_v ... ok
test test_util::test::test_bunyan_seq_bad_order ... ok
test test_util::test::test_bunyan_seq_bounds_bad ... ok
test test_util::test::test_bunyan_seq_lower_violated ... ok
test test_util::test::test_bunyan_seq_upper_violated ... ok

test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/fail-4a8aa0e291e93d2d

running 1 test
    Checking dropshot-tests v0.0.0 (/Users/dap/oxide/dropshot/target/tests/dropshot)
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s


test tests/fail/bad_endpoint1.rs ... ok
test tests/fail/bad_endpoint2.rs ... ok
test tests/fail/bad_endpoint3.rs ... ok
test tests/fail/bad_endpoint4.rs ... ok
test tests/fail/bad_endpoint5.rs ... ok
test tests/fail/bad_endpoint6.rs ... ok
test tests/fail/bad_endpoint7.rs ... ok


test fail ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/test_config-8c4031850df77277

running 4 tests
test test_config_bad_bind_address_port_too_small ... ok
test test_config_bad_bind_address_port_too_large ... ok
test test_config_bad_bind_address_garbage ... ok
test test_config_bind_address ... FAILED

failures:

---- test_config_bind_address stdout ----
log file: /var/folders/x3/6tbrhnss6zz677z4zjsyvkqc0000gn/T/test_config-8c4031850df77277-config_bind_address.20243.0.log
note: configured to log to "/var/folders/x3/6tbrhnss6zz677z4zjsyvkqc0000gn/T/test_config-8c4031850df77277-config_bind_address.20243.0.log"
thread 'test_config_bind_address' panicked at 'there is no reactor running, must be called from the context of Tokio runtime', /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/io/driver/mod.rs:202:14
stack backtrace:
   0:        0x101d04634 - std::backtrace_rs::backtrace::libunwind::trace::h6df1416181381e81
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/../../backtrace/src/backtrace/libunwind.rs:96
   1:        0x101d04634 - std::backtrace_rs::backtrace::trace_unsynchronized::h792524067a83cded
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/../../backtrace/src/backtrace/mod.rs:66
   2:        0x101d04634 - std::sys_common::backtrace::_print_fmt::he614892186429f3f
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:79
   3:        0x101d04634 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hcfc48256a5ab8835
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:58
   4:        0x101d27380 - core::fmt::write::haf3903118f694c48
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/fmt/mod.rs:1080
   5:        0x10171bfda - std::io::Write::write_fmt::h15aa2f50e681f5ef
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/io/mod.rs:1516
   6:        0x101cfa1a8 - std::io::impls::<impl std::io::Write for alloc::boxed::Box<W>>::write_fmt::h60f8c617b1dd6b36
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/io/impls.rs:179
   7:        0x101d063ff - std::sys_common::backtrace::_print::ha64a9740ea6183e6
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:61
   8:        0x101d063ff - std::sys_common::backtrace::print::h1fad353b070e1eef
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:48
   9:        0x101d063ff - std::panicking::default_hook::{{closure}}::h91bd4c58cf71392b
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:208
  10:        0x101d0607e - std::panicking::default_hook::h7bd29c87df967048
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:224
  11:        0x101d069cb - std::panicking::rust_panic_with_hook::hae2b05f08a320721
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:577
  12:        0x101d0654b - std::panicking::begin_panic_handler::{{closure}}::h72d68d3a77e0b718
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:484
  13:        0x101d04aa8 - std::sys_common::backtrace::__rust_end_short_backtrace::h7c5e286792f94edb
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:153
  14:        0x101d0650a - rust_begin_unwind
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:483
  15:        0x101d3597f - core::panicking::panic_fmt::h1b194bb80d76fb10
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/panicking.rs:85
  16:        0x101d3580a - core::option::expect_failed::hc2674535f85de2cd
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/option.rs:1226
  17:        0x101c5d9d9 - core::option::Option<T>::expect::h59058eaa2f77b36a
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:346
  18:        0x101c4c480 - tokio::io::driver::Handle::current::he37bf2a1995fd3fc
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/io/driver/mod.rs:201
  19:        0x101c4ceab - tokio::io::registration::Registration::new_with_ready::h906cd5dc156c0cf3
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/io/registration.rs:106
  20:        0x101c682b2 - tokio::io::poll_evented::PollEvented<E>::new_with_ready::h192ad6cc804e2f85
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/io/poll_evented.rs:206
  21:        0x101c6819a - tokio::io::poll_evented::PollEvented<E>::new::h5f54245bbdf05d55
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/io/poll_evented.rs:178
  22:        0x101647a96 - tokio::net::tcp::stream::TcpStream::connect_std::{{closure}}::h5e573c31aefdf9ad
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.22/src/net/tcp/stream.rs:204
  23:        0x10162c55c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h6a249f03781862af
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  24:        0x1015d0c1e - hyper::client::connect::http::connect::{{closure}}::h8e18b515d5554e32
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:589
  25:        0x10162c7ec - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hae6e58e2be06a4ce
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  26:        0x1015cade7 - hyper::client::connect::http::ConnectingTcpRemote::connect::{{closure}}::hd0c08a2273e7474a
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:532
  27:        0x10162bbfc - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h045f3a9a17e89f00
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  28:        0x1015c9085 - hyper::client::connect::http::ConnectingTcp::connect::{{closure}}::h5b1861cea5bec5ad
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:602
  29:        0x10162c04c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h36550560fb452369
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  30:        0x1015cefe2 - hyper::client::connect::http::HttpConnector<R>::call_async::{{closure}}::hcf9422e7e743ceb2
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:321
  31:        0x10162c18c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h3bc87ea375eae8c7
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  32:        0x1015c8852 - <hyper::client::connect::http::HttpConnector<R> as tower_service::Service<http::uri::Uri>>::call::{{closure}}::hc38b2a47a446363f
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:247
  33:        0x10162bd3c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h046126083c959bed
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  34:        0x10166c81d - <core::pin::Pin<P> as core::future::future::Future>::poll::he2b0ad8e96c3280f
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:119
  35:        0x1015c83ac - <hyper::client::connect::http::HttpConnecting<R> as core::future::future::Future>::poll::hd4e116c62f0dc53f
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/connect/http.rs:387
  36:        0x10170e136 - <hyper::service::oneshot::Oneshot<S,Req> as core::future::future::Future>::poll::hecf9cc7a17c8fc6e
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/service/oneshot.rs:50
  37:        0x10170d70c - <F as futures_core::future::TryFuture>::try_poll::hdf5b64cea0723859
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.5/src/future.rs:83
  38:        0x1016b558c - <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll::h789b9b20502e9b34
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/try_future/into_future.rs:31
  39:        0x10160bc0c - <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll::hf4e7e9c1eafb4739
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/map.rs:67
  40:        0x1016e580c - <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll::hc77fe9ce67e9b989
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  41:        0x10171034c - <futures_util::future::try_future::MapErr<Fut,F> as core::future::future::Future>::poll::hd8288961121c2c8c
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  42:        0x10171238c - <F as futures_core::future::TryFuture>::try_poll::h9e3e23f79aaf4639
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.5/src/future.rs:83
  43:        0x1016b54ac - <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll::h5a9fb13ec33047f0
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/try_future/into_future.rs:31
  44:        0x10160b7e4 - <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll::he7c6f1ee510910c8
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/map.rs:67
  45:        0x1016e549c - <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll::h75028e60bbc77bc5
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  46:        0x10170ffac - <futures_util::future::try_future::MapOk<Fut,F> as core::future::future::Future>::poll::h14a4724bc64bf407
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  47:        0x1017123ec - <F as futures_core::future::TryFuture>::try_poll::hbb0524d11a8f9776
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.5/src/future.rs:83
  48:        0x101690403 - <futures_util::future::try_future::try_flatten::TryFlatten<Fut,<Fut as futures_core::future::TryFuture>::Ok> as core::future::future::Future>::poll::hc35f9ce829c0d984
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/try_future/try_flatten.rs:47
  49:        0x1017103dc - <futures_util::future::try_future::TryFlatten<Fut1,Fut2> as core::future::future::Future>::poll::h81c8e4d52e97fd4d
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  50:        0x10171051c - <futures_util::future::try_future::AndThen<Fut1,Fut2,F> as core::future::future::Future>::poll::h98c9b0e3e596c35b
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  51:        0x101654a5e - <futures_util::future::either::Either<A,B> as core::future::future::Future>::poll::h483136b77e0ea487
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/either.rs:65
  52:        0x1016f7048 - <hyper::common::lazy::Lazy<F,R> as core::future::future::Future>::poll::hc6596ddb978b43f6
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/common/lazy.rs:59
  53:        0x1016f6d34 - futures_util::future::future::FutureExt::poll_unpin::h2c824648ae6928b8
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/mod.rs:554
  54:        0x10164ebee - <futures_util::future::select::Select<A,B> as core::future::future::Future>::poll::h5c58ab5f9dee98e0
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/select.rs:64
  55:        0x101607d71 - <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll::h160aac0f11a3620e
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/map.rs:67
  56:        0x1016e533c - <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll::h2f2f6293b70a1169
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  57:        0x1016b1ce0 - <futures_util::future::future::flatten::Flatten<Fut,<Fut as core::future::future::Future>::Output> as core::future::future::Future>::poll::h31af139dd230cf2d
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/flatten.rs:47
  58:        0x1016e394c - <futures_util::future::future::Then<Fut1,Fut2,F> as core::future::future::Future>::poll::h0de1575a86a20323
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  59:        0x1016e514c - <F as futures_core::future::TryFuture>::try_poll::h1951c3f570d70210
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.5/src/future.rs:83
  60:        0x1016b562c - <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll::hd6f80d299a9124b7
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/try_future/into_future.rs:31
  61:        0x1016098a4 - <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll::h9660bec95b345852
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/future/map.rs:67
  62:        0x1016e56ac - <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll::ha72bd81339405510
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  63:        0x10170fffc - <futures_util::future::try_future::MapOk<Fut,F> as core::future::future::Future>::poll::h24ef8cb69706d8db
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  64:        0x1017122fc - <F as futures_core::future::TryFuture>::try_poll::h5ae6689f02696ca2
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.5/src/future.rs:83
  65:        0x10168fc99 - <futures_util::future::try_future::try_flatten::TryFlatten<Fut,<Fut as futures_core::future::TryFuture>::Ok> as core::future::future::Future>::poll::h89208dfc5530bf93
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/try_future/try_flatten.rs:47
  66:        0x10171042c - <futures_util::future::try_future::TryFlatten<Fut1,Fut2> as core::future::future::Future>::poll::ha4bc75e5556613e9
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  67:        0x10171056c - <futures_util::future::try_future::AndThen<Fut1,Fut2,F> as core::future::future::Future>::poll::heca74e14b150b57a
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/lib.rs:107
  68:        0x1015f522e - hyper::client::Client<C,B>::retryably_send_request::{{closure}}::h5f904bbabfbb4b5a
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/mod.rs:255
  69:        0x10162d29b - <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::he1a68728fe1ad8a5
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.5/src/future/poll_fn.rs:54
  70:        0x101b0b65d - <core::pin::Pin<P> as core::future::future::Future>::poll::hf4c42ee2f92eb2f5
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:119
  71:        0x101b40c48 - <hyper::client::ResponseFuture as core::future::future::Future>::poll::h330197b058f66a0f
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.7/src/client/mod.rs:627
  72:        0x1016f9a1e - test_config::test_config_bind_address::{{closure}}::h133bd59d0aaad609
                               at /Users/dap/oxide/dropshot/dropshot/tests/test_config.rs:105
  73:        0x10162be40 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h0c367344e297ccf8
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
  74:        0x10166c729 - <core::pin::Pin<P> as core::future::future::Future>::poll::h78aa1f47a7f46bc1
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:119
  75:        0x10161485d - tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}::{{closure}}::h7acf274f808b1964
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:184
  76:        0x10164f3a6 - tokio::coop::with_budget::{{closure}}::h277eb5a15bde52df
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/coop.rs:121
  77:        0x1016a2574 - std::thread::local::LocalKey<T>::try_with::hef33dc6f4cfca5aa
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:272
  78:        0x1016a1f9c - std::thread::local::LocalKey<T>::with::haa86ff3b580c6df7
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:248
  79:        0x1016142a9 - tokio::coop::with_budget::hb995aabe97a8c2c0
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/coop.rs:114
  80:        0x1016142a9 - tokio::coop::budget::h8a462c3a9616792c
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/coop.rs:98
  81:        0x1016142a9 - tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}::h5692d6d87958f38e
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:184
  82:        0x1016153c4 - tokio::runtime::basic_scheduler::enter::{{closure}}::h9484118978ade228
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:266
  83:        0x10166c90a - tokio::macros::scoped_tls::ScopedKey<T>::set::h43ab09ece01c0594
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/macros/scoped_tls.rs:61
  84:        0x10161531b - tokio::runtime::basic_scheduler::enter::h4aeb130a34f7608f
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:266
  85:        0x1016140cd - tokio::runtime::basic_scheduler::Inner<P>::block_on::h982d502c6df2c72c
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:176
  86:        0x1016149a9 - tokio::runtime::basic_scheduler::InnerGuard<P>::block_on::h4277d0da584214ba
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:405
  87:        0x101614cf8 - tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on::hf03497ea9d20694c
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/basic_scheduler.rs:136
  88:        0x1015ec7aa - tokio::runtime::Runtime::block_on::h130461194224f54d
                               at /Users/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.6/src/runtime/mod.rs:450
  89:        0x1015c7092 - test_config::test_config_bind_address::h7e9476fa3ae8b711
                               at /Users/dap/oxide/dropshot/dropshot/tests/test_config.rs:61
  90:        0x1016f91a1 - test_config::test_config_bind_address::{{closure}}::h8c2c862e4195c9dc
                               at /Users/dap/oxide/dropshot/dropshot/tests/test_config.rs:61
  91:        0x1016fd301 - core::ops::function::FnOnce::call_once::h1b1bc4c64f184f46
                               at /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227
  92:        0x1017418ba - core::ops::function::FnOnce::call_once::h8a5d8c592178429e
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ops/function.rs:227
  93:        0x1017418ba - test::__rust_begin_short_backtrace::h8c20647892dadc50
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:516
  94:        0x101740061 - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h8df67f0990a35131
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042
  95:        0x101740061 - <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hf09671a739eb25fc
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:308
  96:        0x101740061 - std::panicking::try::do_call::hf1dc9cac489107de
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:381
  97:        0x101740061 - std::panicking::try::h9599bce4aaa8bbbf
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:345
  98:        0x101740061 - std::panic::catch_unwind::h203582ef7b5c1ee7
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:382
  99:        0x101740061 - test::run_test_in_process::h8ad05dbe22ef66ba
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:543
 100:        0x101740061 - test::run_test::run_test_inner::{{closure}}::hadc7a51fce6724fe
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:449
 101:        0x10171b41b - std::sys_common::backtrace::__rust_begin_short_backtrace::h6e10ee62b301fe5a
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:137
 102:        0x101720645 - std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}::hada0c711499bf9bc
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/thread/mod.rs:464
 103:        0x101720645 - <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h6e54792f2e5b9eeb
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:308
 104:        0x101720645 - std::panicking::try::do_call::h78edcf08bb257583
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:381
 105:        0x101720645 - std::panicking::try::h76bc625add9266eb
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:345
 106:        0x101720645 - std::panic::catch_unwind::h0b51b751ac0aff59
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:382
 107:        0x101720645 - std::thread::Builder::spawn_unchecked::{{closure}}::h9f08b0d941a32467
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/thread/mod.rs:463
 108:        0x101720645 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h48bb72bd4d1e4e41
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ops/function.rs:227
 109:        0x101d0d9ad - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h761c0c24cc66dea8
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042
 110:        0x101d0d9ad - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h15cdc23ec4ed7bf4
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042
 111:        0x101d0d9ad - std::sys::unix::thread::Thread::new::thread_start::he3e6719579180a65
                               at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys/unix/thread.rs:87
 112:     0x7fff6a844109 - __pthread_start


failures:
    test_config_bind_address

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '-p dropshot --test test_config'
```

That's a call through hyper, for which we're on v0.13, which is still on tokio 0.2.  See #60 for details.