### PR TITLE
Upgrade to tokio 1.0 and hyper 0.14

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/dropshot/"
 [dependencies]
 async-trait = "0.1.24"
 base64 = "0.12.3"
-bytes = "0.5.4"
+bytes = "1"
 futures = "0.3.1"
 hostname = "0.3.0"
 http = "0.2.0"

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -14,7 +14,6 @@ bytes = "0.5.4"
 futures = "0.3.1"
 hostname = "0.3.0"
 http = "0.2.0"
-hyper = "0.13.0"
 indexmap = "1.0.0"
 openapiv3 = "0.3.0"
 paste = "1.0.0"
@@ -34,6 +33,10 @@ features = [ "serde" ]
 version = "0.3.0"
 path = "../dropshot_endpoint"
 
+[dependencies.hyper]
+version = "0.14"
+features = [ "full" ]
+
 [dependencies.serde]
 version = "1.0.0"
 features = [ "derive" ]
@@ -43,7 +46,7 @@ version = "2.5.0"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.tokio]
-version = "0.2.0"
+version = "1.0"
 features = [ "full" ]
 
 [dependencies.uuid]

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -44,7 +44,7 @@
  * errors into HttpErrors.
  */
 
-use hyper::error::Error as HyperError;
+use hyper::Error as HyperError;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/dropshot/src/http_util.rs
+++ b/dropshot/src/http_util.rs
@@ -29,7 +29,7 @@ pub async fn http_read_body<T>(
     cap: usize,
 ) -> Result<Bytes, HttpError>
 where
-    T: HttpBody<Data = Bytes, Error = hyper::error::Error> + std::marker::Unpin,
+    T: HttpBody<Data = Bytes, Error = hyper::Error> + std::marker::Unpin,
 {
     /*
      * This looks a lot like the implementation of hyper::body::to_bytes(), but

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -94,9 +94,7 @@ impl HttpServer {
      * TODO-cleanup is it more accurate to call this start() and say it returns
      * a Future that resolves when the server is finished?
      */
-    pub fn run(
-        &mut self,
-    ) -> tokio::task::JoinHandle<Result<(), hyper::Error>> {
+    pub fn run(&mut self) -> tokio::task::JoinHandle<Result<(), hyper::Error>> {
         let future =
             self.server_future.take().expect("cannot run() more than once");
         tokio::spawn(async { future.await })

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -68,7 +68,7 @@ pub struct ServerConfig {
  */
 pub struct HttpServer {
     app_state: Arc<DropshotState>,
-    server_future: Option<BoxFuture<'static, Result<(), hyper::error::Error>>>,
+    server_future: Option<BoxFuture<'static, Result<(), hyper::Error>>>,
     local_addr: SocketAddr,
     close_channel: Option<tokio::sync::oneshot::Sender<()>>,
 }
@@ -96,7 +96,7 @@ impl HttpServer {
      */
     pub fn run(
         &mut self,
-    ) -> tokio::task::JoinHandle<Result<(), hyper::error::Error>> {
+    ) -> tokio::task::JoinHandle<Result<(), hyper::Error>> {
         let future =
             self.server_future.take().expect("cannot run() more than once");
         tokio::spawn(async { future.await })
@@ -104,7 +104,7 @@ impl HttpServer {
 
     pub async fn wait_for_shutdown(
         &mut self,
-        join_handle: tokio::task::JoinHandle<Result<(), hyper::error::Error>>,
+        join_handle: tokio::task::JoinHandle<Result<(), hyper::Error>>,
     ) -> Result<(), String> {
         let join_result = join_handle
             .await
@@ -126,7 +126,7 @@ impl HttpServer {
         api: ApiDescription,
         private: Arc<dyn Any + Send + Sync + 'static>,
         log: &Logger,
-    ) -> Result<HttpServer, hyper::error::Error> {
+    ) -> Result<HttpServer, hyper::Error> {
         /* TODO-cleanup too many Arcs? */
         let log_close = log.new(o!());
         let app_state = Arc::new(DropshotState {

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -411,7 +411,7 @@ pub struct TestContext {
     pub client_testctx: ClientTestContext,
     pub server: HttpServer,
     pub log: Logger,
-    server_task: JoinHandle<Result<(), hyper::error::Error>>,
+    server_task: JoinHandle<Result<(), hyper::Error>>,
     log_context: Option<LogContext>,
 }
 

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -942,7 +942,7 @@ async fn start_example(path: &str, port: u16) -> ExampleContext {
             return rv;
         }
 
-        tokio::time::delay_for(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
     panic!(


### PR DESCRIPTION
There are some minor code changes needed to complete the upgrade to tokio 1.0 and hyper 0.14 which I've made here.
Additionally hyper upgrades to bytes 1 and that change seems to be needed here as well.

I fell down this rabbit whole as I was planning to start writing my own service based on dropshot, but haven't written it yet so I don't have any downstream codebases to test against. I got no test failures on my machine, but some were skipped so I figured I'd see what your CI does with this.

Let me know how to rewrite the summary, if you want a squashed branch, etc. or, since I've checked the "Allow edits by maintainers" box, feel free to do with this PR as you wish! 

Fixes #60 
Duplicate of #66 