### PR TITLE
prepare for releases via cargo release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,29 @@
+:showtitle:
+:toc: left
+:icons: font
+
+= Dropshot Changelog
+
+// cargo-release: next header goes here (do not change this line)
+
+== Unreleased changes (release date TBD)
+
+https://github.com/oxidecomputer/dropshot/compare/v0.3.0\...HEAD[Full list of commits]
+
+=== Breaking changes
+
+* Dropshot now uses tokio 1.0 and hyper 0.14.  tokio 1.0 is incompatible at runtime with previous versions (0.2 and earlier).  Consumers must update to tokio 1.0 when updating to Dropshot {{version}}.  tokio does not expect to introduce new breaking changes in the foreseeable future.
+
+=== Deprecated
+
+* `ApiDescription::print_openapi()`, replaced with `ApiDescription::openapi()`.  See #68 below.
+
+=== Other notable changes
+
+* #68 Improve ergonomics of OpenAPI definition generation.  This change deprecates `ApiDescription::print_openapi()`, replacing it with the easier-to-use `ApiDescription::openapi()`, which provides a builder interface.
+* #64 The maximum request size is now configurable.  It defaults to the previously hardcoded value of 1024 bytes.  (The default is aggressive just to ensure test coverage.)
+* #61 The schemars dependency is updated to 0.8
+
+== Prior to 0.3.0
+
+Changes not documented.

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,10 +1,15 @@
 :showtitle:
 :toc: left
 :icons: font
+:toclevels: 1
 
 = Dropshot Changelog
 
 // cargo-release: next header goes here (do not change this line)
+
+// WARNING: This file is modified programmatically by `cargo release` as
+// configured in release.toml.  DO NOT change the format of the headers or the
+// list of raw commits.
 
 == Unreleased changes (release date TBD)
 
@@ -12,17 +17,17 @@ https://github.com/oxidecomputer/dropshot/compare/v0.3.0\...HEAD[Full list of co
 
 === Breaking changes
 
-* Dropshot now uses tokio 1.0 and hyper 0.14.  tokio 1.0 is incompatible at runtime with previous versions (0.2 and earlier).  Consumers must update to tokio 1.0 when updating to Dropshot {{version}}.  tokio does not expect to introduce new breaking changes in the foreseeable future.
+* Dropshot now uses tokio 1.0 and hyper 0.14.  tokio 1.0 is incompatible at runtime with previous versions (0.2 and earlier).  Consumers must update to tokio 1.0 when updating to Dropshot {{version}}.  tokio does not expect to introduce new breaking changes in the foreseeable future, so we do not expect to have to do this again.
 
 === Deprecated
 
-* `ApiDescription::print_openapi()`, replaced with `ApiDescription::openapi()`.  See #68 below.
+* `ApiDescription::print_openapi()` is now deprecated.  It's been replaced with `ApiDescription::openapi()`.  See #68 below.
 
 === Other notable changes
 
-* #68 Improve ergonomics of OpenAPI definition generation.  This change deprecates `ApiDescription::print_openapi()`, replacing it with the easier-to-use `ApiDescription::openapi()`, which provides a builder interface.
-* #64 The maximum request size is now configurable.  It defaults to the previously hardcoded value of 1024 bytes.  (The default is aggressive just to ensure test coverage.)
-* #61 The schemars dependency is updated to 0.8
+* https://github.com/oxidecomputer/dropshot/issues/68[#68] Improve ergonomics of OpenAPI definition generation.  This change deprecates `ApiDescription::print_openapi()`, replacing it with the easier-to-use `ApiDescription::openapi()`, which provides a builder interface.
+* https://github.com/oxidecomputer/dropshot/issues/64[#64] The maximum request size is now configurable.  It defaults to the previously hardcoded value of 1024 bytes.  (The default is aggressive just to ensure test coverage.)
+* https://github.com/oxidecomputer/dropshot/issues/61[#61] The schemars dependency is updated to 0.8.  Consumers must be using the same version of schemars.  (See https://github.com/oxidecomputer/dropshot/issues/67[#67].)
 
 == Prior to 0.3.0
 

--- a/dropshot_endpoint/release.toml
+++ b/dropshot_endpoint/release.toml
@@ -1,0 +1,2 @@
+# Overrides the cargo-release config file from the root of this repo.
+pre-release-replacements = []

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,19 @@
+# This file is used by cargo-release.
+
+# Update the change log to reflect the new release and set us up for the next release.
+pre-release-replacements = [
+  # First, replace the current "Unreleased changes" header with one reflecting the new release version and date.
+  {file="../CHANGELOG.adoc", search="Unreleased changes \\(release date TBD\\)", replace="{{version}} (released {{date}})", exactly=1},
+  # Update the link to the list of raw commits in the formerly "Unreleased changes" section.  It should end at the tag for the newly-released version.
+  {file="../CHANGELOG.adoc", search="\\\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
+  # Next, append a new "Unreleased changes" header beneath the sentinel line.
+  {file="../CHANGELOG.adoc", search="// cargo-release: next header goes here \\(do not change this line\\)", replace="// cargo-release: next header goes here (do not change this line)\n\n== Unreleased changes (release date TBD)\n\nhttps://github.com/oxidecomputer/dropshot/compare/{{tag_name}}\\...HEAD[Full list of commits]", exactly=1},
+]
+
+disable-push = true
+consolidate-commits = true
+pre-release-commit-message = "release {{version}}"
+post-release-commit-message = "starting {{next_version}} after releasing {{version}}"
+tag-message = "release {{version}}"
+tag-prefix=""
+dev-version-ext = "dev"


### PR DESCRIPTION
Status of this: I think this is ready to test in earnest, but I'm not ready to do that on Friday evening.  Here's the dry run:

```
$ cargo release --prev-tag-name=v0.3.0 --dry-run -vv minor
[2021-01-30T01:21:12Z DEBUG] Files changed in dropshot_endpoint since v0.3.0: [
        "/Users/dap/oxide/dropshot/dropshot_endpoint/dropshot_endpoint/Cargo.toml",
        "/Users/dap/oxide/dropshot/dropshot_endpoint/dropshot_endpoint/release.toml",
        "/Users/dap/oxide/dropshot/dropshot_endpoint/dropshot_endpoint/src/lib.rs",
    ]
[2021-01-30T01:21:12Z DEBUG] Files changed in dropshot since v0.3.0: [
        "/Users/dap/oxide/dropshot/dropshot/dropshot/Cargo.toml",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/basic.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/module-basic.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/pagination-basic.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/pagination-multiple-resources.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/pagination-multiple-sorts.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/examples/petstore.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/api_description.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/config.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/error.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/handler.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/http_util.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/lib.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/router.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/server.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/src/test_util.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/common/mod.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint1.stderr",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint3.stderr",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint6.stderr",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint7.stderr",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint8.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/fail/bad_endpoint8.stderr",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/test_config.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/test_openapi.json",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/test_openapi.rs",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/test_openapi_fuller.json",
        "/Users/dap/oxide/dropshot/dropshot/dropshot/tests/test_pagination.rs",
    ]
[2021-01-30T01:21:12Z INFO ] Update dropshot_endpoint to version 0.4.0
[2021-01-30T01:21:12Z INFO ] Fixing dropshot's dependency on dropshot_endpoint to `^0.4.0` (from `^0.3.0`)
[2021-01-30T01:21:12Z DEBUG] Updating lock file
[2021-01-30T01:21:12Z INFO ] Update dropshot to version 0.4.0
[2021-01-30T01:21:12Z DEBUG] Updating lock file
[2021-01-30T01:21:12Z DEBUG] Substituting values for /Users/dap/oxide/dropshot/dropshot/../CHANGELOG.adoc
[2021-01-30T01:21:12Z TRACE] Change:
    --- ../CHANGELOG.adoc	original
    +++ ../CHANGELOG.adoc	replaced
    @@ -11 +11,5 @@
    -https://github.com/oxidecomputer/dropshot/compare/v0.3.0\...HEAD[Full list of commits]
    +https://github.com/oxidecomputer/dropshot/compare/v0.4.0\...HEAD[Full list of commits]
    +
    +== 0.4.0 (released 2021-01-29)
    +
    +https://github.com/oxidecomputer/dropshot/compare/v0.3.0...v0.4.0[Full list of commits]
    
[2021-01-30T01:21:12Z TRACE] cd /Users/dap/oxide/dropshot
[2021-01-30T01:21:12Z TRACE] git commit  -am release {{version}}
[2021-01-30T01:21:12Z INFO ] Running cargo publish on dropshot_endpoint
[2021-01-30T01:21:12Z TRACE] /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo publish --manifest-path /Users/dap/oxide/dropshot/dropshot_endpoint/Cargo.toml
[2021-01-30T01:21:12Z INFO ] Running cargo publish on dropshot
[2021-01-30T01:21:12Z TRACE] /Users/dap/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo publish --manifest-path /Users/dap/oxide/dropshot/dropshot/Cargo.toml
[2021-01-30T01:21:12Z DEBUG] Creating git tag v0.4.0
[2021-01-30T01:21:12Z TRACE] cd /Users/dap/oxide/dropshot/dropshot_endpoint
[2021-01-30T01:21:12Z TRACE] git tag -a v0.4.0 -m release 0.4.0 
[2021-01-30T01:21:12Z DEBUG] Creating git tag v0.4.0
[2021-01-30T01:21:12Z TRACE] cd /Users/dap/oxide/dropshot/dropshot
[2021-01-30T01:21:12Z TRACE] git tag -a v0.4.0 -m release 0.4.0 
[2021-01-30T01:21:12Z INFO ] Starting dropshot_endpoint's next development iteration 0.4.1-dev
[2021-01-30T01:21:12Z INFO ] Fixing dropshot's dependency on dropshot_endpoint to `^0.4.1-dev` (from `^0.3.0`)
[2021-01-30T01:21:12Z INFO ] Starting dropshot's next development iteration 0.4.1-dev
[2021-01-30T01:21:12Z TRACE] cd /Users/dap/oxide/dropshot
[2021-01-30T01:21:12Z TRACE] git commit  -am starting {{next_version}} after releasing {{version}}
```

Next steps would be to:

- make sure this PR passes all tests
- land the PR
- run the above in non-dry-run mode to cut release 0.4.0