### PR TITLE
enforce non-style clippy checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,14 @@ jobs:
     - name: Check style
       run: cargo +nightly-2020-07-26 fmt -- --check
 
+  clippy-lint:
+    runs-on: ubuntu-18.04
+    steps:
+    # actions/checkout@v2
+    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+    - name: Run Clippy Lints
+      run: cargo clippy -- -D warnings
+
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ $ cargo +nightly doc
 You can **build and run the whole test suite** with `cargo test`.  The test
 suite runs cleanly and should remain clean.
 
-=== Code formatting
+=== Code formatting and lint
 
 Dropshot works with stable Rust versions, but for consistency the code is
 _formatted_ with a specific version of `rustfmt`.  To contribute to Dropshot,
@@ -38,6 +38,8 @@ You can then **format the code** using `cargo +nightly-2020-07-26 fmt` or
 `rustfmt +nightly-2020-07-26`.  Make sure to run this before pushing changes.
 The CI uses this version of `rustfmt` to check that the code is correctly
 formatted.
+
+https://github.com/rust-lang/rust-clippy[Clippy] is used to check for common code issues.  (We disable the style checks.)  You can run it with `cargo clippy`.  CI will run clippy as well.
 
 
 == Configuration reference

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -275,6 +275,7 @@ impl ApiDescription {
      * This routine is deprecated in favour of the new openapi() builder
      * routine.
      */
+    #[allow(clippy::too_many_arguments)]
     #[deprecated(note = "switch to openapi()")]
     pub fn print_openapi(
         &self,

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -189,7 +189,7 @@ macro_rules! impl_extractor_for_tuple {
         async fn from_request(_rqctx: Arc<RequestContext>)
             -> Result<( $($T,)* ), HttpError>
         {
-            Ok( ($($T::from_request(Arc::clone(&_rqctx)).await?,)* ) )
+            futures::try_join!($($T::from_request(Arc::clone(&_rqctx)),)*)
         }
 
         fn metadata() -> Vec<ApiEndpointParameter> {

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -489,6 +489,12 @@
  * which is really serde#1183.
  */
 
+/*
+ * Clippy's style advice is definitely valuable, but not worth the trouble for
+ * automated enforcement.
+ */
+#![allow(clippy::style)]
+
 mod api_description;
 mod config;
 mod error;

--- a/dropshot/src/pagination.rs
+++ b/dropshot/src/pagination.rs
@@ -383,7 +383,7 @@ fn serialize_page_token<PageSelector: Serialize>(
     let token_bytes = {
         let serialized_token = SerializedToken {
             v: PaginationVersion::V1,
-            page_start: page_start,
+            page_start,
         };
 
         let json_bytes =
@@ -445,7 +445,7 @@ fn deserialize_page_token<PageSelector: DeserializeOwned>(
      */
     let deserialized: SerializedToken<PageSelector> =
         serde_json::from_slice(&json_bytes).map_err(|_| {
-            format!("failed to parse pagination token: corrupted token")
+            String::from("failed to parse pagination token: corrupted token")
         })?;
 
     if deserialized.v != PaginationVersion::V1 {

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -146,7 +146,7 @@ impl PathSegment {
  */
 #[derive(Debug)]
 pub struct RouterLookupResult<'a> {
-    pub handler: &'a Box<dyn RouteHandler>,
+    pub handler: &'a dyn RouteHandler,
     pub variables: BTreeMap<String, String>,
 }
 
@@ -298,7 +298,7 @@ impl HttpRouter {
         path: &'b str,
     ) -> Result<RouterLookupResult<'a>, HttpError> {
         let all_segments = path_to_segments(path);
-        let mut node: &Box<HttpRouterNode> = &self.root;
+        let mut node = &self.root;
         let mut variables: BTreeMap<String, String> = BTreeMap::new();
 
         for segment in all_segments {
@@ -337,7 +337,7 @@ impl HttpRouter {
         node.methods
             .get(&methodname)
             .map(|handler| RouterLookupResult {
-                handler: &handler.handler,
+                handler: &*handler.handler,
                 variables,
             })
             .ok_or_else(|| {

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -4,6 +4,12 @@
 //! attributes are used both to define an HTTP API and to generate an OpenAPI
 //! Spec (OAS) v3 document that describes the API.
 
+/*
+ * Clippy's style advice is definitely valuable, but not worth the trouble for
+ * automated enforcement.
+ */
+#![allow(clippy::style)]
+
 extern crate proc_macro;
 
 use proc_macro2::TokenStream;
@@ -196,7 +202,7 @@ fn do_endpoint(
         .collect::<Vec<_>>();
 
     // Help the user if they don't give any parameters.
-    if ast.sig.inputs.len() == 0 {
+    if ast.sig.inputs.is_empty() {
         checks.push(
             Error::new_spanned(
                 (&ast.sig).into_token_stream(),
@@ -258,7 +264,7 @@ fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
     quote!(#(#compile_errors)*)
 }
 
-fn extract_doc_from_attrs(attrs: &Vec<syn::Attribute>) -> Option<String> {
+fn extract_doc_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
     let doc = syn::Ident::new("doc", proc_macro2::Span::call_site());
 
     attrs
@@ -290,7 +296,7 @@ fn normalize_comment_string(s: String) -> String {
         .replace("\n * ", " ")
         .trim_end_matches(&[' ', '\n'] as &[char])
         .to_string();
-    if ret.starts_with(" ") && !ret.starts_with("  ") {
+    if ret.starts_with(' ') && !ret.starts_with("  ") {
         // Trim off the first character if the comment
         // begins with a single space.
         ret.as_str()[1..].to_string()


### PR DESCRIPTION
This is an update of #4 (and I used some of @steveklabnik's fixes -- thanks for that!).  I've elected to avoid all of the style checks.  While I find these worthwhile for myself to learn better ways to write code, I find them subjective enough that I wouldn't want to enforce them, even with overrides.