### PR TITLE
Implement std::error::Error for HttpError

### DIFF
--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -47,6 +47,8 @@
 use hyper::Error as HyperError;
 use serde::Deserialize;
 use serde::Serialize;
+use std::error::Error;
+use std::fmt;
 
 /**
  * `HttpError` represents an error generated as part of handling an API
@@ -282,5 +284,17 @@ impl HttpError {
                 .into(),
             )
             .unwrap()
+    }
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HttpError({}): {}", self.status_code, self.external_message)
+    }
+}
+
+impl Error for HttpError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
     }
 }


### PR DESCRIPTION
This implementation allows `HttpError` to be composed within a [thiserror](https://docs.rs/thiserror/1.0.24/thiserror/) error type.