### PR TITLE
type references aren't generated for query parameters

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -178,7 +178,7 @@ pub enum ApiSchemaGenerator {
             fn(&mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema,
     },
     Static {
-        schema: schemars::schema::Schema,
+        schema: Box<schemars::schema::Schema>,
         dependencies: indexmap::IndexMap<String, schemars::schema::Schema>,
     },
 }
@@ -484,7 +484,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
                             dependencies,
                         } => {
                             definitions.extend(dependencies.clone());
-                            (None, schema.clone())
+                            (None, schema.as_ref().clone())
                         }
                     };
                     let schema = j2oas_schema(name.as_ref(), &js);
@@ -519,7 +519,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         dependencies,
                     } => {
                         definitions.extend(dependencies.clone());
-                        (None, schema.clone())
+                        (None, schema.as_ref().clone())
                     }
                 };
                 let mut content = indexmap::IndexMap::new();

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -177,7 +177,10 @@ pub enum ApiSchemaGenerator {
         schema:
             fn(&mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema,
     },
-    Static(schemars::schema::Schema),
+    Static {
+        schema: schemars::schema::Schema,
+        dependencies: indexmap::IndexMap<String, schemars::schema::Schema>,
+    },
 }
 
 impl std::fmt::Debug for ApiSchemaGenerator {
@@ -186,9 +189,9 @@ impl std::fmt::Debug for ApiSchemaGenerator {
             ApiSchemaGenerator::Gen {
                 ..
             } => f.write_str("[schema generator]"),
-            ApiSchemaGenerator::Static(schema) => {
-                f.write_str(format!("{:?}", schema).as_str())
-            }
+            ApiSchemaGenerator::Static {
+                schema, ..
+            } => f.write_str(format!("{:?}", schema).as_str()),
         }
     }
 }
@@ -370,6 +373,8 @@ impl<Context: ServerContext> ApiDescription<Context> {
 
         let settings = schemars::gen::SchemaSettings::openapi3();
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
+        let mut definitions =
+            indexmap::IndexMap::<String, schemars::schema::Schema>::new();
 
         for (path, method, endpoint) in &self.router {
             let path = openapi.paths.entry(path).or_insert(
@@ -412,7 +417,11 @@ impl<Context: ServerContext> ApiDescription<Context> {
                     };
 
                     let schema = match &param.schema {
-                        ApiSchemaGenerator::Static(schema) => {
+                        ApiSchemaGenerator::Static {
+                            schema,
+                            dependencies,
+                        } => {
+                            definitions.extend(dependencies.clone());
                             j2oas_schema(None, schema)
                         }
                         _ => {
@@ -470,7 +479,11 @@ impl<Context: ServerContext> ApiDescription<Context> {
                             name,
                             schema,
                         } => (Some(name()), schema(&mut generator)),
-                        ApiSchemaGenerator::Static(schema) => {
+                        ApiSchemaGenerator::Static {
+                            schema,
+                            dependencies,
+                        } => {
+                            definitions.extend(dependencies.clone());
                             (None, schema.clone())
                         }
                     };
@@ -501,7 +514,11 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         name,
                         schema,
                     } => (Some(name()), schema(&mut generator)),
-                    ApiSchemaGenerator::Static(schema) => {
+                    ApiSchemaGenerator::Static {
+                        schema,
+                        dependencies,
+                    } => {
+                        definitions.extend(dependencies.clone());
                         (None, schema.clone())
                     }
                 };
@@ -559,6 +576,11 @@ impl<Context: ServerContext> ApiDescription<Context> {
             .schemas;
         generator.definitions().iter().for_each(|(key, schema)| {
             schemas.insert(key.clone(), j2oas_schema(None, schema));
+        });
+        definitions.into_iter().for_each(|(key, schema)| {
+            if !schemas.contains_key(&key) {
+                schemas.insert(key, j2oas_schema(None, &schema));
+            }
         });
 
         openapi

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -821,7 +821,7 @@ fn schema2parameters(
                             None,
                             required && object.required.contains(name),
                             ApiSchemaGenerator::Static {
-                                schema: s,
+                                schema: Box::new(s),
                                 dependencies: visitor.dependencies(),
                             },
                             vec![],
@@ -1033,12 +1033,14 @@ impl Extractor for UntypedBody {
             None,
             true,
             ApiSchemaGenerator::Static {
-                schema: SchemaObject {
-                    instance_type: Some(InstanceType::String.into()),
-                    format: Some(String::from("binary")),
-                    ..Default::default()
-                }
-                .into(),
+                schema: Box::new(
+                    SchemaObject {
+                        instance_type: Some(InstanceType::String.into()),
+                        format: Some(String::from("binary")),
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
                 dependencies: indexmap::IndexMap::default(),
             },
             vec![],

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -3,7 +3,7 @@
  * Interface for implementing HTTP endpoint handler functions.
  *
  * For information about supported endpoint function signatures, argument types,
- * extractors, and return types, see the top-level documentation for this crate.
+ * extractors, and return types, see the top-level documentation dependencies: () for this crate.
  * As documented there, we support several different sets of function arguments
  * and return types.
  *
@@ -682,21 +682,62 @@ where
          * the structure to encode as an individual parameter.
          */
         let mut generator = schemars::gen::SchemaGenerator::new(
-            schemars::gen::SchemaSettings::openapi3().with(|settings| {
-                /*
-                 * Strip off any definitions prefix so that we can lookup
-                 * references simply. Ideally we would force no references to
-                 * be generated, but that doesn't seem to be an option.
-                 */
-                settings.definitions_path = String::new();
-            }),
+            schemars::gen::SchemaSettings::openapi3()
+                .with(|settings| settings.inline_subschemas = false),
         );
         let schema = ParamType::json_schema(&mut generator);
-        schema2parameters(loc, &schema, generator.definitions(), true)
+        schema2parameters(loc, &schema, &generator, true)
     }
 }
 
-/**
+/// Used to visit all schemas and collect all dependencies.
+struct ReferenceVisitor<'a> {
+    generator: &'a schemars::gen::SchemaGenerator,
+    dependencies: indexmap::IndexMap<String, schemars::schema::Schema>,
+}
+
+impl<'a> ReferenceVisitor<'a> {
+    fn new(generator: &'a schemars::gen::SchemaGenerator) -> Self {
+        Self {
+            generator,
+            dependencies: indexmap::IndexMap::new(),
+        }
+    }
+
+    fn dependencies(
+        self,
+    ) -> indexmap::IndexMap<String, schemars::schema::Schema> {
+        self.dependencies
+    }
+}
+
+impl<'a> schemars::visit::Visitor for ReferenceVisitor<'a> {
+    fn visit_schema_object(&mut self, schema: &mut SchemaObject) {
+        if let Some(refstr) = &schema.reference {
+            let definitions_path = &self.generator.settings().definitions_path;
+            let name = &refstr[definitions_path.len()..];
+
+            if !self.dependencies.contains_key(name) {
+                let mut refschema = self
+                    .generator
+                    .definitions()
+                    .get(name)
+                    .expect("invalid reference")
+                    .clone();
+                self.dependencies.insert(
+                    name.to_string(),
+                    schemars::schema::Schema::Bool(false),
+                );
+                schemars::visit::visit_schema(self, &mut refschema);
+                self.dependencies.insert(name.to_string(), refschema);
+            }
+        }
+
+        schemars::visit::visit_schema_object(self, schema);
+    }
+}
+
+/*
  * This helper function produces a list of parameters. It is invoked
  * recursively with subschemas, which we will encounter in the case of enums
  * and structs that have been flattened into the containing structure. The
@@ -715,7 +756,7 @@ where
 fn schema2parameters(
     loc: &ApiEndpointParameterLocation,
     schema: &schemars::schema::Schema,
-    definitions: &schemars::Map<String, schemars::schema::Schema>,
+    generator: &schemars::gen::SchemaGenerator,
     required: bool,
 ) -> Vec<ApiEndpointParameter> {
     /*
@@ -736,22 +777,18 @@ fn schema2parameters(
             string: None,
             array: None,
             object: None,
-            reference: Some(refstr),
+            reference: Some(_),
             extensions: _,
-        }) => match definitions.get(refstr) {
-            // Recur on the referenced type.
-            Some(refschema) => {
-                schema2parameters(loc, refschema, definitions, required)
-            }
-            // This should not be possible.
-            None => panic!("invalid reference {}", refstr),
-        },
-
+        }) => schema2parameters(
+            loc,
+            generator.dereference(schema).expect("invalid reference"),
+            generator,
+            required,
+        ),
         // Match objects and subschemas.
         schemars::schema::Schema::Object(schemars::schema::SchemaObject {
             metadata: _,
-            // TODO: should be Some(schemars::schema::SingleOrVec::Single(_))
-            instance_type: _,
+            instance_type: Some(schemars::schema::SingleOrVec::Single(_)),
             format: None,
             enum_values: None,
             const_value: None,
@@ -770,12 +807,23 @@ fn schema2parameters(
             if let Some(object) = object {
                 parameters.extend(object.properties.iter().map(
                     |(name, schema)| {
+                        // We won't often see referenced schemas here, but we may
+                        // in the case of enumerated strings. To handle this, we
+                        // package up the dependencies to include in the top-
+                        // level definitions section.
+                        let mut s = schema.clone();
+                        let mut visitor = ReferenceVisitor::new(generator);
+                        schemars::visit::visit_schema(&mut visitor, &mut s);
+
                         ApiEndpointParameter::new_named(
                             loc,
                             name.clone(),
                             None,
                             required && object.required.contains(name),
-                            ApiSchemaGenerator::Static(schema.clone()),
+                            ApiSchemaGenerator::Static {
+                                schema: s,
+                                dependencies: visitor.dependencies(),
+                            },
                             vec![],
                         )
                     },
@@ -798,12 +846,7 @@ fn schema2parameters(
                     } => parameters.extend(schemas.iter().flat_map(
                         |subschema| {
                             // Note that all these parameters will be optional.
-                            schema2parameters(
-                                loc,
-                                subschema,
-                                definitions,
-                                false,
-                            )
+                            schema2parameters(loc, subschema, generator, false)
                         },
                     )),
 
@@ -822,10 +865,7 @@ fn schema2parameters(
                     } if schemas.len() == 1 => parameters.extend(
                         schemas.iter().flat_map(|subschema| {
                             schema2parameters(
-                                loc,
-                                subschema,
-                                definitions,
-                                required,
+                                loc, subschema, generator, required,
                             )
                         }),
                     ),
@@ -988,18 +1028,19 @@ impl Extractor for UntypedBody {
     }
 
     fn metadata() -> Vec<ApiEndpointParameter> {
-        let schema = SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            format: Some(String::from("binary")),
-            ..Default::default()
-        }
-        .into();
-
         vec![ApiEndpointParameter::new_body(
             ApiEndpointBodyContentType::Bytes,
             None,
             true,
-            ApiSchemaGenerator::Static(schema),
+            ApiSchemaGenerator::Static {
+                schema: SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    format: Some(String::from("binary")),
+                    ..Default::default()
+                }
+                .into(),
+                dependencies: indexmap::IndexMap::default(),
+            },
             vec![],
         )]
     }

--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -33,8 +33,8 @@ pub enum ConfigLogging {
 /**
  * Log messages have a level that's used for filtering in the usual way.
  */
-#[serde(rename_all = "lowercase")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ConfigLoggingLevel {
     Trace,
     Debug,
@@ -60,8 +60,8 @@ impl From<&ConfigLoggingLevel> for Level {
 /**
  * Specifies the behavior when logging to a file that already exists.
  */
-#[serde(rename_all = "lowercase")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ConfigLoggingIfExists {
     /** Fail to create the log */
     Fail,

--- a/dropshot/tests/test_pagination_schema.json
+++ b/dropshot/tests/test_pagination_schema.json
@@ -1,0 +1,102 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "test",
+    "description": "gusty winds may exist",
+    "termsOfService": "no hat, no cane? no service!",
+    "contact": {
+      "name": "old mate"
+    },
+    "license": {
+      "name": "CDDL"
+    },
+    "version": "1985.7"
+  },
+  "paths": {
+    "/super_pages": {
+      "get": {
+        "operationId": "handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "garbage_goes_in",
+            "schema": {
+              "$ref": "#/components/schemas/GarbageGoesIn"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "ResultsPage_for_ResponseItem",
+                  "description": "A single page of results",
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "description": "list of items on this page of results",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ResponseItem"
+                      }
+                    },
+                    "next_page": {
+                      "description": "token used to fetch the next page of results (if any)",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ResponseItem": {
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "word"
+        ]
+      },
+      "GarbageGoesIn": {
+        "type": "string",
+        "enum": [
+          "garbage-can"
+        ]
+      }
+    }
+  }
+}

--- a/dropshot/tests/test_pagination_schema.rs
+++ b/dropshot/tests/test_pagination_schema.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::{
+    endpoint, ApiDescription, HttpError, HttpResponseOk, PaginationParams,
+    Query, RequestContext, ResultsPage,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{io::Cursor, str::from_utf8, sync::Arc};
+
+#[derive(JsonSchema, Serialize)]
+struct ResponseItem {
+    word: String,
+}
+
+#[derive(Deserialize, JsonSchema, Serialize)]
+struct ScanParams {
+    garbage_goes_in: GarbageGoesIn,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GarbageGoesIn {
+    GarbageCan,
+}
+
+#[derive(Deserialize, JsonSchema, Serialize)]
+struct PageSelector {
+    scan: ScanParams,
+    last_seen: String,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/super_pages",
+}]
+async fn handler(
+    _rqctx: Arc<RequestContext<()>>,
+    _query: Query<PaginationParams<ScanParams, PageSelector>>,
+) -> Result<HttpResponseOk<ResultsPage<ResponseItem>>, HttpError> {
+    unimplemented!();
+}
+
+#[test]
+fn test_pagination_schema() -> Result<(), String> {
+    let mut api = ApiDescription::new();
+    api.register(handler)?;
+    let mut output = Cursor::new(Vec::new());
+
+    let _ = api
+        .openapi("test", "1985.7")
+        .description("gusty winds may exist")
+        .contact_name("old mate")
+        .license_name("CDDL")
+        .terms_of_service("no hat, no cane? no service!")
+        .write(&mut output);
+    let actual = from_utf8(&output.get_ref()).unwrap();
+
+    expectorate::assert_contents("tests/test_pagination_schema.json", actual);
+    Ok(())
+}


### PR DESCRIPTION
Closes #88 

I thought this was specific to pagination schemas, but the actual problem effects any query (or path) parameter that has a type definition. This is most typically seen with enumerated string i.e. where a string value can only have one of a few specific values.

Without this fix, the new test don't have the type `GarbageGoesIn` in components/schemas

I will merge this tomorrow unless someone weighs in, but I'll be happy to address post-merge comments as always.