### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+#
+# Dependabot configuration file
+#
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "dropshot"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "dropshot_endpoint"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I want to experiment with using dependabot to keep dependencies up to date.  I'm starting with Dropshot since it's already public and has no private dependencies.