### PR TITLE
use 32-bit types for pagination limits

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of commits]
 
+=== Breaking Changes
+
+* https://github.com/oxidecomputer/dropshot/pull/100[#100] The type used for the "limit" argument for paginated resources has changed.  This limit refers to the number of items that an HTTP client can ask for in a single request to a paginated endpoint.  The limit is now 4294967295, where it may have previously been larger.  This is not expected to affect consumers because this limit is far larger than practical.  For details, see #100.
+
 == 0.5.1 (released 2021-03-18)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.5.0\...v0.5.1[Full list of commits]

--- a/dropshot/examples/pagination-basic.rs
+++ b/dropshot/examples/pagination-basic.rs
@@ -81,7 +81,7 @@ async fn example_list_projects(
     query: Query<PaginationParams<EmptyScanParams, ProjectPage>>,
 ) -> Result<HttpResponseOk<ResultsPage<Project>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let tree = rqctx.context();
     let projects = match &pag_params.page {
         WhichPage::First(..) => {

--- a/dropshot/examples/pagination-multiple-resources.rs
+++ b/dropshot/examples/pagination-multiple-resources.rs
@@ -174,7 +174,7 @@ async fn example_list_projects(
     query: Query<PaginationParams<ExScanParams, ExPageSelector>>,
 ) -> Result<HttpResponseOk<ResultsPage<Project>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let data = rqctx.context();
     let scan_params = scan_params(&pag_params.page);
 
@@ -200,7 +200,7 @@ async fn example_list_disks(
     query: Query<PaginationParams<ExScanParams, ExPageSelector>>,
 ) -> Result<HttpResponseOk<ResultsPage<Disk>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let data = rqctx.context();
     let scan_params = scan_params(&pag_params.page);
 
@@ -226,7 +226,7 @@ async fn example_list_instances(
     query: Query<PaginationParams<ExScanParams, ExPageSelector>>,
 ) -> Result<HttpResponseOk<ResultsPage<Instance>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let data = rqctx.context();
     let scan_params = scan_params(&pag_params.page);
 

--- a/dropshot/examples/pagination-multiple-sorts.rs
+++ b/dropshot/examples/pagination-multiple-sorts.rs
@@ -237,7 +237,7 @@ async fn example_list_projects(
     query: Query<PaginationParams<ProjectScanParams, ProjectScanPageSelector>>,
 ) -> Result<HttpResponseOk<ResultsPage<Project>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let data = rqctx.context();
     let scan_params = ProjectScanParams {
         sort: match &pag_params.page {

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -132,7 +132,7 @@ impl<Context: ServerContext> RequestContext<Context> {
              * Compare the client-provided limit to the configured max for the
              * server and take the smaller one.
              */
-            .map(|limit_nzu32| min(limit_nzu32, server_config.page_max_nitems))
+            .map(|limit| min(limit, server_config.page_max_nitems))
             /*
              * If no limit was provided by the client, use the configured
              * default.

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -62,13 +62,12 @@ use serde::Serialize;
 use slog::Logger;
 use std::cmp::min;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::future::Future;
 use std::marker::PhantomData;
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 /**
@@ -120,7 +119,7 @@ impl<Context: ServerContext> RequestContext<Context> {
     pub fn page_limit<ScanParams, PageSelector>(
         &self,
         pag_params: &PaginationParams<ScanParams, PageSelector>,
-    ) -> Result<NonZeroUsize, HttpError>
+    ) -> Result<NonZeroU32, HttpError>
     where
         ScanParams: DeserializeOwned,
         PageSelector: DeserializeOwned + Serialize,
@@ -130,31 +129,10 @@ impl<Context: ServerContext> RequestContext<Context> {
         Ok(pag_params
             .limit
             /*
-             * Convert the client-provided limit from a NonZeroU64 to a
-             * usize.  That's because internally, we want the limit to be a
-             * "usize" so we can use functions like `iter.take()` with it (as an
-             * example).  We could put "usize" in the public interface, but that
-             * would cause the server's exported interface to change when it was
-             * built differently, although that's arguably correct.  Instead, we
-             * essentially validate here that the client gave us a value that we
-             * can support.
-             */
-            .map(|limit_nzu64| usize::try_from(limit_nzu64.get()))
-            .transpose()
-            .map_err(|_| {
-                HttpError::for_bad_request(
-                    None,
-                    String::from("unsupported pagination limit: too large"),
-                )
-            })?
-            /*
              * Compare the client-provided limit to the configured max for the
              * server and take the smaller one.
              */
-            .map(|limit_usize| {
-                let limit_nzusize = NonZeroUsize::new(limit_usize).unwrap();
-                min(limit_nzusize, server_config.page_max_nitems)
-            })
+            .map(|limit_nzu32| min(limit_nzu32, server_config.page_max_nitems))
             /*
              * If no limit was provided by the client, use the configured
              * default.

--- a/dropshot/src/pagination.rs
+++ b/dropshot/src/pagination.rs
@@ -109,7 +109,7 @@ use serde::Serialize;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::num::NonZeroU64;
+use std::num::NonZeroU32;
 
 /**
  * A page of results from a paginated API
@@ -239,7 +239,7 @@ where
      * [`RequestContext`][crate::handler::RequestContext::page_limit()]
      * to access this value.
      */
-    pub(crate) limit: Option<NonZeroU64>,
+    pub(crate) limit: Option<NonZeroU32>,
 }
 
 pub(crate) const PAGINATION_PARAM_SENTINEL: &str =
@@ -287,7 +287,7 @@ struct SchemaPaginationParams<ScanParams> {
     #[schemars(flatten)]
     params: Option<ScanParams>,
     /** Maximum number of items returned by a single call */
-    limit: Option<NonZeroU64>,
+    limit: Option<NonZeroU32>,
     /** Token returned by previous call to retreive the subsequent page */
     page_token: Option<String>,
 }
@@ -526,7 +526,7 @@ mod test {
     use serde::Deserialize;
     use serde::Serialize;
     use serde_json::json;
-    use std::{fmt::Debug, num::NonZeroU64};
+    use std::{fmt::Debug, num::NonZeroU32};
 
     #[test]
     fn test_page_token_serialization() {
@@ -662,7 +662,7 @@ mod test {
 
         fn parse_as_first_page<T: DeserializeOwned + Debug>(
             querystring: &str,
-        ) -> (T, Option<NonZeroU64>) {
+        ) -> (T, Option<NonZeroU32>) {
             let pagparams: PaginationParams<T, MyPageSelector> =
                 serde_urlencoded::from_str(querystring).unwrap();
             let limit = pagparams.limit;
@@ -751,7 +751,7 @@ mod test {
 
         fn parse_as_next_page(
             querystring: &str,
-        ) -> (MyPageSelector, Option<NonZeroU64>) {
+        ) -> (MyPageSelector, Option<NonZeroU32>) {
             let pagparams: PaginationParams<MyScanParams, MyPageSelector> =
                 serde_urlencoded::from_str(querystring).unwrap();
             let limit = pagparams.limit;

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -24,7 +24,7 @@ use hyper::Request;
 use hyper::Response;
 use std::future::Future;
 use std::net::SocketAddr;
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -66,9 +66,9 @@ pub struct ServerConfig {
     /** maximum allowed size of a request body */
     pub request_body_max_bytes: usize,
     /** maximum size of any page of results */
-    pub page_max_nitems: NonZeroUsize,
+    pub page_max_nitems: NonZeroU32,
     /** default size for a page of results */
-    pub page_default_nitems: NonZeroUsize,
+    pub page_default_nitems: NonZeroU32,
 }
 
 /**
@@ -129,8 +129,8 @@ impl<C: ServerContext> HttpServerStarter<C> {
             config: ServerConfig {
                 /* We start aggressively to ensure test coverage. */
                 request_body_max_bytes: config.request_body_max_bytes,
-                page_max_nitems: NonZeroUsize::new(10000).unwrap(),
-                page_default_nitems: NonZeroUsize::new(100).unwrap(),
+                page_max_nitems: NonZeroU32::new(10000).unwrap(),
+                page_default_nitems: NonZeroU32::new(100).unwrap(),
             },
             router: api.into_router(),
             log: log.new(o!()),

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -46,7 +46,7 @@
             "schema": {
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
-              "format": "uint64",
+              "format": "uint32",
               "minimum": 1
             },
             "style": "form"

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -54,7 +54,7 @@
             "schema": {
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
-              "format": "uint64",
+              "format": "uint32",
               "minimum": 1
             },
             "style": "form"

--- a/dropshot/tests/test_openapi_old.json
+++ b/dropshot/tests/test_openapi_old.json
@@ -46,7 +46,7 @@
             "schema": {
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
-              "format": "uint64",
+              "format": "uint32",
               "minimum": 1
             },
             "style": "form"

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -680,7 +680,7 @@ async fn api_dictionary(
     >,
 ) -> Result<HttpResponseOk<ResultsPage<DictionaryWord>>, HttpError> {
     let pag_params = query.into_inner();
-    let limit = rqctx.page_limit(&pag_params)?.get();
+    let limit = rqctx.page_limit(&pag_params)?.get() as usize;
     let dictionary: &BTreeSet<String> = &*WORD_LIST;
 
     let (bound, scan_params) = match &pag_params.page {

--- a/dropshot/tests/test_pagination_schema.json
+++ b/dropshot/tests/test_pagination_schema.json
@@ -31,7 +31,7 @@
             "schema": {
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
-              "format": "uint64",
+              "format": "uint32",
               "minimum": 1
             },
             "style": "form"


### PR DESCRIPTION
This change modifies the numeric type that's used for the "limit" in paginated endpoints.

Previously, this was a `NonZeroU64` in the externally-facing data structures, but only exposed internally as a `usize` (via `RequestContext::page_limit`).  If the conversion from `NonZeroU64` to `usize` failed, a 400 response was sent back to the client.

Why did it work this way?  I wanted `usize` internally because all of the internal consumers were backed by Rust collection iterators, which use `usize` to describe a number of elements (e.g., [take](https://doc.rust-lang.org/core/iter/trait.Iterator.html#method.take)).  But I figured that using `usize` externally would cause the OpenAPI spec to change depending on the bitness of the server, which didn't seem right.  Still, this solution has a few issues:

* On any server where `usize::MAX` is smaller than `u64::MAX`, the OpenAPI spec could advertise a value larger than was supported.  On these servers, the error that a client would get for the range `usize::MAX` to `u64::MAX` is likely different than they would get for values above `u64::MAX`.
* When I went to add a consumer backed by a PostgreSQL-compatible database (CockroachDB, actually) I discovered that even [`u64` doesn't have a direct translation to PostgreSQL](https://docs.rs/tokio-postgres/0.7.0/tokio_postgres/types/trait.ToSql.html#types).  Indeed, [the largest native numeric type in PostgreSQL appears to be a signed 64-bit integer](https://www.postgresql.org/docs/current/datatype-numeric.html).

Neither of these is a big deal, but they're worth addressing.

This change modifies both the externally-facing and internally-facing types to `NonZeroU32`.  I chose this because it's large enough to be sufficient for all foreseeable practical purposes, but small enough to be satisfy the PostgreSQL consumer without additional validation.  This is still arbitrary, obviousy, but _any_ choice here, once it's big enough for practical purposes, is just a matter of making things most convenient for consumers.