### PR TITLE
fix handling of additional_properties field for enums

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -973,10 +973,15 @@ fn j2oas_object(
                     .collect::<_>(),
                 required: obj.required.iter().cloned().collect::<_>(),
                 additional_properties: obj.additional_properties.as_ref().map(
-                    |schema| {
-                        openapiv3::AdditionalProperties::Schema(Box::new(
-                            j2oas_schema(None, schema),
-                        ))
+                    |schema| match schema.as_ref() {
+                        schemars::schema::Schema::Bool(b) => {
+                            openapiv3::AdditionalProperties::Any(*b)
+                        }
+                        schemars::schema::Schema::Object(obj) => {
+                            openapiv3::AdditionalProperties::Schema(Box::new(
+                                j2oas_schema_object(None, obj),
+                            ))
+                        }
                     },
                 ),
                 min_properties: obj.min_properties.map(|n| n as usize),

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -639,7 +639,7 @@ fn j2oas_schema(
     schema: &schemars::schema::Schema,
 ) -> openapiv3::ReferenceOr<openapiv3::Schema> {
     match schema {
-        schemars::schema::Schema::Bool(_) => todo!(),
+        schemars::schema::Schema::Bool(_) => unreachable!(),
         schemars::schema::Schema::Object(obj) => j2oas_schema_object(name, obj),
     }
 }
@@ -1298,5 +1298,21 @@ mod test {
             "only one body extractor can be used in a handler (this function \
              has 2)"
         );
+    }
+
+    #[test]
+    fn test_additional_properties() {
+        #[allow(dead_code)]
+        #[derive(JsonSchema)]
+        enum Union {
+            A { a: u32 },
+        }
+        let settings = schemars::gen::SchemaSettings::openapi3();
+        let mut generator = schemars::gen::SchemaGenerator::new(settings);
+        let schema = Union::json_schema(&mut generator);
+        let _ = j2oas_schema(None, &schema);
+        for (key, schema) in generator.definitions().iter() {
+            let _ = j2oas_schema(Some(key), schema);
+        }
     }
 }


### PR DESCRIPTION
schemars 0.8.1 exposed this by correcting their handling of enums with regard to the additional_properties field.

Previously this field was always `None`. By the json spec this is incorrect:

>    Omitting this keyword has the same assertion behavior as an empty schema.

And:

> true:  Always passes validation, as if the empty schema {}

i.e. an empty schema accepts all fields. So omitting the field was equivalent to allowing any additional property. The fix explicitly prohibits additional properties

fixes #101 
