### PR TITLE
implement graceful shutdown on Drop

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of commits]
 
+* https://github.com/oxidecomputer/dropshot/pull/103[#103] When the Dropshot server is dropped before having been shut down, Dropshot now attempts to gracefully shut down rather than panic.
+
 === Breaking Changes
 
 * https://github.com/oxidecomputer/dropshot/pull/100[#100] The type used for the "limit" argument for paginated resources has changed.  This limit refers to the number of items that an HTTP client can ask for in a single request to a paginated endpoint.  The limit is now 4294967295, where it may have previously been larger.  This is not expected to affect consumers because this limit is far larger than practical.  For details, see #100.

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -1282,7 +1282,7 @@ mod test {
     #[test]
     fn test_two_bodies() {
         #[derive(Deserialize, JsonSchema)]
-        struct AStruct {};
+        struct AStruct {}
 
         #[endpoint {
             method = PUT,

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -563,8 +563,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "dropped HttpServer without calling close")]
-    async fn test_drop_server_without_close_panics() {
+    async fn test_drop_server_without_close_okay() {
         let (server, _) = create_test_server();
         std::mem::drop(server);
     }

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -204,14 +204,16 @@ impl<C: ServerContext> HttpServer<C> {
     }
 }
 
-/**
- * Verifies that the server has stopped execution when it is dropped.
- * For graceful termination, use the `close` function.
+/*
+ * For graceful termination, the `close()` function is preferred, as it can
+ * report errors and wait for termination to complete.  However, we impl
+ * `Drop` to attempt to shut down the server to handle less clean shutdowns
+ * (e.g., from failing tests).
  */
 impl<C: ServerContext> Drop for HttpServer<C> {
     fn drop(&mut self) {
-        if self.close_channel.is_some() {
-            panic!("dropped HttpServer without calling close");
+        if let Some(c) = self.close_channel.take() {
+            c.send(()).expect("failed to send close signal")
         }
     }
 }

--- a/dropshot/tests/fail/bad_endpoint6.rs
+++ b/dropshot/tests/fail/bad_endpoint6.rs
@@ -21,7 +21,7 @@ struct Ret {
     path = "/test",
 }]
 async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
-    Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+    Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
 }
 
 fn main() {}

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -1,51 +1,54 @@
-error: expected identifier, found `"Oxide"`
-  --> $DIR/bad_endpoint6.rs:24:29
-   |
-24 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-   |                       ---   ^^^^^^^ expected identifier
-   |                       |
-   |                       while parsing this struct
-
-error: expected identifier, found `0x1de`
-  --> $DIR/bad_endpoint6.rs:24:50
-   |
-24 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-   |                       ---                        ^^^^^ expected identifier
-   |                       |
-   |                       while parsing this struct
-
-error[E0063]: missing fields `x`, `y` in initializer of `Ret`
-  --> $DIR/bad_endpoint6.rs:19:2
-   |
-19 |   #[endpoint {
-   |  __^
-20 | |     method = GET,
-21 | |     path = "/test",
-22 | | }]
-   | |__^ missing `x`, `y`
-
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-  --> $DIR/bad_endpoint6.rs:19:2
+  --> $DIR/bad_endpoint6.rs:24:23
    |
-19 |   #[endpoint {
-   |  __^
-20 | |     method = GET,
-21 | |     path = "/test",
-22 | | }]
-   | |__^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+24 |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
    |
    = note: required by `HttpResponseOk`
 
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+    --> $DIR/bad_endpoint6.rs:24:8
+     |
+24   |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
+     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           --------- required by this bound in `HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+    --> $DIR/bad_endpoint6.rs:24:5
+     |
+24   |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           --------- required by this bound in `HttpResponseOk`
+
+error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
+    --> $DIR/bad_endpoint6.rs:23:98
+     |
+23   |   async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
+     |  __________________________________________________________________________________________________^
+24   | |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
+25   | | }
+     | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+     |
+    ::: $WORKSPACE/dropshot/src/handler.rs
+     |
+     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                             --------- required by this bound in `HttpResponseOk`
+
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint6.rs:19:1
+  --> $DIR/bad_endpoint6.rs:23:10
    |
-19 | / #[endpoint {
-20 | |     method = GET,
-21 | |     path = "/test",
-22 | | }]
-   | |__^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
+23 | async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
+   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
    |
   ::: $WORKSPACE/dropshot/src/api_description.rs
    |
-   |           FuncParams: Extractor + 'static,
-   |                                   ------- required by this bound in `ApiEndpoint::<Context>::new`
+   |         FuncParams: Extractor + 'static,
+   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -227,7 +227,7 @@ async fn test_paginate_errors() {
     struct ErrorTestCase {
         path: String,
         message: &'static str,
-    };
+    }
     let test_cases = vec![
         ErrorTestCase {
             path: "/intapi?limit=0".to_string(),


### PR DESCRIPTION
Previously if the Dropshot server was dropped prior to closing it, it would panic.  This was intended to guide people to using `close()` for graceful shutdown.  I've now run into this a lot more in failing test suites, where it's way more disruptive than it is helpful because the program panics while panicking, and you're left with very little debug information.  So I'm proposing that we do attempt a graceful shutdown in `Drop`.  I don't consider this a breaking change because previously, a program that ran into this behavior would panic anyway.