### PR TITLE
Allow for serde_json::Value in body/return types

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -640,7 +640,21 @@ fn j2oas_schema(
     schema: &schemars::schema::Schema,
 ) -> openapiv3::ReferenceOr<openapiv3::Schema> {
     match schema {
-        schemars::schema::Schema::Bool(_) => unreachable!(),
+        /*
+         * The permissive, "match anything" schema. We'll typically see this
+         * when consumers use a type such as serde_json::Value.
+         */
+        schemars::schema::Schema::Bool(true) => {
+            openapiv3::ReferenceOr::Item(openapiv3::Schema {
+                schema_data: openapiv3::SchemaData::default(),
+                schema_kind: openapiv3::SchemaKind::Any(
+                    openapiv3::AnySchema::default(),
+                ),
+            })
+        }
+        schemars::schema::Schema::Bool(false) => {
+            panic!("We don't expect to see a schema that matches the null set")
+        }
         schemars::schema::Schema::Object(obj) => j2oas_schema_object(name, obj),
     }
 }

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -407,11 +407,13 @@
       "BodyParam": {
         "type": "object",
         "properties": {
+          "_any": {},
           "_x": {
             "type": "string"
           }
         },
         "required": [
+          "_any",
           "_x"
         ]
       },

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -67,6 +67,7 @@ async fn handler3(
 #[derive(JsonSchema, Deserialize)]
 struct BodyParam {
     _x: String,
+    _any: serde_json::Value,
 }
 
 #[derive(Serialize, JsonSchema)]

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -415,11 +415,13 @@
       "BodyParam": {
         "type": "object",
         "properties": {
+          "_any": {},
           "_x": {
             "type": "string"
           }
         },
         "required": [
+          "_any",
           "_x"
         ]
       },

--- a/dropshot/tests/test_openapi_old.json
+++ b/dropshot/tests/test_openapi_old.json
@@ -407,11 +407,13 @@
       "BodyParam": {
         "type": "object",
         "properties": {
+          "_any": {},
           "_x": {
             "type": "string"
           }
         },
         "required": [
+          "_any",
           "_x"
         ]
       },


### PR DESCRIPTION
Currently we fail on an `unreachable!()`: not quite true--obviously--since I forgot about permissive types such as `serde_json::Value`. This fix adds handling for that type. It also improves the panic message for the empty set type.

Note that I ran the resulting schema through openapi-generator and the model looks exactly as we would hope:

```rust
pub struct BodyParam {
    #[serde(rename = "_any")]
    pub _any: Option<serde_json::Value>,
    #[serde(rename = "_x")]
    pub _x: String,
}
```

(albeit with some extraneous renames... generated code, what can you do)