### PR TITLE
Add support for wildcard routes: `/foo/bar/{rest:.*}`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of co
 
 * https://github.com/oxidecomputer/dropshot/pull/105[#105] When generating an OpenAPI spec, Dropshot now uses references rather than inline schemas to represent request and response bodies.
 * https://github.com/oxidecomputer/dropshot/pull/103[#103] When the Dropshot server is dropped before having been shut down, Dropshot now attempts to gracefully shut down rather than panic.
+* https://github.com/oxidecomputer/dropshot/pull/110[#110] Wildcard paths are now supported. Consumers may take over routing (e.g. for file serving) by annotating a path component: `/static/{path:.*}`. The `path` member should then be of type `Vec<String>` and it will be filled in with all path components following `/static/`.
 
 === Breaking Changes
 

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -27,6 +27,7 @@ slog-async = "2.4.0"
 slog-bunyan = "2.2.0"
 slog-json = "2.3.0"
 slog-term = "2.5.0"
+syn = "1.0.73"
 toml = "0.5.6"
 
 [dependencies.chrono]

--- a/dropshot/examples/index.rs
+++ b/dropshot/examples/index.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), String> {
 
 #[derive(Deserialize, JsonSchema)]
 struct AllPath {
-    path: String,
+    path: Vec<String>,
 }
 
 /**
@@ -89,7 +89,7 @@ async fn index(
         .header(http::header::CONTENT_TYPE, "text/html")
         .body(
             format!(
-                "<HTML><HEAD>nothing at {}</HEAD></HTML>",
+                "<HTML><HEAD>nothing at {:?}</HEAD></HTML>",
                 path.into_inner().path
             )
             .into(),

--- a/dropshot/examples/index.rs
+++ b/dropshot/examples/index.rs
@@ -1,0 +1,97 @@
+// Copyright 2021 Oxide Computer Company
+/*!
+ * Example use of Dropshot for matching wildcard paths to serve static content.
+ */
+
+use dropshot::ApiDescription;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpError;
+use dropshot::HttpServerStarter;
+use dropshot::RequestContext;
+use dropshot::{endpoint, Path};
+use http::{Response, StatusCode};
+use hyper::Body;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    /*
+     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
+     * since it's available and won't expose this server outside the host.  We
+     * request port 0, which allows the operating system to pick any available
+     * port.
+     */
+    let config_dropshot: ConfigDropshot = Default::default();
+
+    /*
+     * For simplicity, we'll configure an "info"-level logger that writes to
+     * stderr assuming that it's a terminal.
+     */
+    let config_logging = ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Info,
+    };
+    let log = config_logging
+        .to_logger("example-basic")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    /*
+     * Build a description of the API.
+     */
+    let mut api = ApiDescription::new();
+    api.register(index).unwrap();
+
+    /*
+     * Set up the server.
+     */
+    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+        .map_err(|error| format!("failed to create server: {}", error))?
+        .start();
+
+    /*
+     * Wait for the server to stop.  Note that there's not any code to shut down
+     * this server, so we should never get past this point.
+     */
+    server.await
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct AllPath {
+    path: String,
+}
+
+/**
+ * Return static content.for all paths.
+ */
+#[endpoint {
+    method = GET,
+
+    /*
+     * Match literally every path including the empty path.
+     */
+    path = "/{path:.*}",
+
+    /*
+     * This isn't an API so we don't want this to appear in the OpenAPI
+     * description if we were to generate it.
+     */
+    unpublished = true,
+}]
+async fn index(
+    _rqctx: Arc<RequestContext<()>>,
+    path: Path<AllPath>,
+) -> Result<Response<Body>, HttpError> {
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "text/html")
+        .body(
+            format!(
+                "<HTML><HEAD>nothing at {}</HEAD></HTML>",
+                path.into_inner().path
+            )
+            .into(),
+        )?)
+}

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -1260,14 +1260,27 @@ mod test {
             method = PUT,
             path = "I don't start with a slash"
         }]
+<<<<<<< HEAD
         async fn test_badpath_handler(
+=======
+        async fn test_twobodies_handler(
+>>>>>>> 2486f79 (fix handling of escape codes in paths)
             _: Arc<RequestContext<()>>,
         ) -> Result<Response<Body>, HttpError> {
             unimplemented!();
         }
 
         let mut api = ApiDescription::new();
+<<<<<<< HEAD
         api.register(test_badpath_handler).unwrap();
+=======
+        let error = api.register(test_twobodies_handler).unwrap_err();
+        assert_eq!(
+            error,
+            "only one body extractor can be used in a handler (this function \
+             has 2)"
+        );
+>>>>>>> 2486f79 (fix handling of escape codes in paths)
     }
 
     #[test]

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -1260,27 +1260,14 @@ mod test {
             method = PUT,
             path = "I don't start with a slash"
         }]
-<<<<<<< HEAD
         async fn test_badpath_handler(
-=======
-        async fn test_twobodies_handler(
->>>>>>> 2486f79 (fix handling of escape codes in paths)
             _: Arc<RequestContext<()>>,
         ) -> Result<Response<Body>, HttpError> {
             unimplemented!();
         }
 
         let mut api = ApiDescription::new();
-<<<<<<< HEAD
         api.register(test_badpath_handler).unwrap();
-=======
-        let error = api.register(test_twobodies_handler).unwrap_err();
-        assert_eq!(
-            error,
-            "only one body extractor can be used in a handler (this function \
-             has 2)"
-        );
->>>>>>> 2486f79 (fix handling of escape codes in paths)
     }
 
     #[test]

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -238,7 +238,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
             .iter()
             .filter_map(|segment| match PathSegment::from(segment) {
                 PathSegment::VarnameSegment(v) => Some(v),
-                PathSegment::VarnameRegEx(v, _) => Some(v),
+                PathSegment::VarnameWildcard(v) => Some(v),
                 PathSegment::Literal(_) => None,
             })
             .collect::<HashSet<_>>();

--- a/dropshot/src/from_map.rs
+++ b/dropshot/src/from_map.rs
@@ -49,16 +49,19 @@ impl MapValue for String {
 }
 
 /**
- * Deserializer for BTreeMap<String, String> that interprets the values. It has
+ * Deserializer for BTreeMap<String, MapValue> that interprets the values. It has
  * two modes: about to iterate over the map or about to process a single value.
  */
 #[derive(Debug)]
-enum MapDeserializer<'de, Z> {
+enum MapDeserializer<'de, Z: MapValue + Debug + Clone + 'static> {
     Map(&'de BTreeMap<String, Z>),
     Value(Z),
 }
 
-impl<'de, Z> MapDeserializer<'de, Z> {
+impl<'de, Z> MapDeserializer<'de, Z>
+where
+    Z: MapValue + Debug + Clone + 'static,
+{
     fn from_map(input: &'de BTreeMap<String, Z>) -> Self {
         MapDeserializer::Map(input)
     }
@@ -325,7 +328,10 @@ where
 /*
  * Deserializer component for processing enum variants.
  */
-impl<'de, 'a, Z> VariantAccess<'de> for &mut MapDeserializer<'de, Z> {
+impl<'de, 'a, Z> VariantAccess<'de> for &mut MapDeserializer<'de, Z>
+where
+    Z: MapValue + Clone + Debug + 'static,
+{
     type Error = MapError;
 
     fn unit_variant(self) -> Result<(), MapError> {
@@ -557,7 +563,7 @@ mod test {
         }
     }
     #[test]
-    fn string_seq() {
+    fn wherefore_art_thou_a_valid_sequence_when_in_fact_you_are_a_lone_value() {
         #[derive(Deserialize, Debug)]
         struct A {
             b: Vec<String>,

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -801,6 +801,8 @@ fn schema2parameters(
             if let Some(object) = object {
                 parameters.extend(object.properties.iter().map(
                     |(name, schema)| {
+                        validate_parameter_schema(loc, name, schema, generator);
+
                         // We won't often see referenced schemas here, but we may
                         // in the case of enumerated strings. To handle this, we
                         // package up the dependencies to include in the top-
@@ -875,6 +877,148 @@ fn schema2parameters(
          * The generated schema should be an object.
          */
         invalid => panic!("invalid type {:#?}", invalid),
+    }
+}
+
+/**
+ * Confirm that the parameter schema type is either an atomic value (i.e.
+ * string, number, boolean) or an array of strings (to accommodate wild card
+ * paths).
+ */
+fn validate_parameter_schema(
+    loc: &ApiEndpointParameterLocation,
+    name: &String,
+    schema: &schemars::schema::Schema,
+    generator: &schemars::gen::SchemaGenerator,
+) {
+    match schema {
+        /*
+         * We expect references to be on their own.
+         */
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            metadata: _,
+            instance_type: None,
+            format: None,
+            enum_values: None,
+            const_value: None,
+            subschemas: None,
+            number: None,
+            string: None,
+            array: None,
+            object: None,
+            reference: Some(_),
+            extensions: _,
+        }) => validate_parameter_schema(
+            loc,
+            name,
+            generator.dereference(schema).expect("invalid reference"),
+            generator,
+        ),
+
+        /*
+         * Match atomic value types.
+         */
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            instance_type:
+                Some(schemars::schema::SingleOrVec::Single(instance_type)),
+            subschemas: None,
+            array: None,
+            object: None,
+            reference: None,
+            ..
+        }) if match instance_type.as_ref() {
+            InstanceType::Boolean
+            | InstanceType::Number
+            | InstanceType::String
+            | InstanceType::Integer => true,
+            _ => false,
+        } =>
+        { /* All good. */ }
+
+        /*
+         * For path parameters only, match array types and validate that their
+         * items are strings.
+         */
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            metadata: _,
+            instance_type:
+                Some(schemars::schema::SingleOrVec::Single(instance_type)),
+            format: None,
+            enum_values: None,
+            const_value: None,
+            subschemas: None,
+            number: None,
+            string: None,
+            array: Some(array_validation),
+            object: None,
+            reference: None,
+            extensions: _,
+        }) if matches!(loc, ApiEndpointParameterLocation::Path)
+            && matches!(instance_type.as_ref(), InstanceType::Array) =>
+        {
+            match array_validation.as_ref() {
+                schemars::schema::ArrayValidation {
+                    items:
+                        Some(schemars::schema::SingleOrVec::Single(item_schema)),
+                    additional_items: None,
+                    ..
+                } => validate_string_schema(name, item_schema, generator),
+                _ => panic!("parameter {} has an invalid array type", name),
+            }
+        }
+
+        _ => panic!("parameter {} has an invalid type", name),
+    }
+}
+
+/**
+ * Validate that the given schema is for a simple string type.
+ */
+fn validate_string_schema(
+    name: &String,
+    schema: &schemars::schema::Schema,
+    generator: &schemars::gen::SchemaGenerator,
+) {
+    match schema {
+        /*
+         * We expect references to be on their own.
+         */
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            metadata: _,
+            instance_type: None,
+            format: None,
+            enum_values: None,
+            const_value: None,
+            subschemas: None,
+            number: None,
+            string: None,
+            array: None,
+            object: None,
+            reference: Some(_),
+            extensions: _,
+        }) => validate_string_schema(
+            name,
+            generator.dereference(schema).expect("invalid reference"),
+            generator,
+        ),
+
+        /*
+         * Match string value types.
+         */
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            instance_type:
+                Some(schemars::schema::SingleOrVec::Single(instance_type)),
+            subschemas: None,
+            array: None,
+            object: None,
+            reference: None,
+            ..
+        }) if matches!(instance_type.as_ref(), InstanceType::String) => { /* All good. */
+        }
+
+        _ => {
+            panic!("parameter {} is an array of a type other than string", name)
+        }
     }
 }
 

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -46,6 +46,7 @@ use crate::api_description::ApiEndpointResponse;
 use crate::api_description::ApiSchemaGenerator;
 use crate::pagination::PaginationParams;
 use crate::pagination::PAGINATION_PARAM_SENTINEL;
+use crate::router::VariableSet;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -61,7 +62,6 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use slog::Logger;
 use std::cmp::min;
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
@@ -93,7 +93,7 @@ pub struct RequestContext<Context: ServerContext> {
     /** HTTP request details */
     pub request: Arc<Mutex<Request<Body>>>,
     /** HTTP request routing variables */
-    pub path_variables: BTreeMap<String, String>,
+    pub path_variables: VariableSet,
     /** unique id assigned to this request */
     pub request_id: String,
     /** logger for this specific request */

--- a/dropshot/src/http_util.rs
+++ b/dropshot/src/http_util.rs
@@ -7,10 +7,10 @@ use bytes::BufMut;
 use bytes::Bytes;
 use hyper::body::HttpBody;
 use serde::de::DeserializeOwned;
-use std::collections::BTreeMap;
 
 use super::error::HttpError;
 use crate::from_map::from_map;
+use crate::router::VariableSet;
 
 /** header name for conveying request ids ("x-request-id") */
 pub const HEADER_REQUEST_ID: &str = "x-request-id";
@@ -136,7 +136,7 @@ where
  * TODO-testing: Add automated tests.
  */
 pub fn http_extract_path_params<T: DeserializeOwned>(
-    path_params: &BTreeMap<String, String>,
+    path_params: &VariableSet,
 ) -> Result<T, HttpError> {
     from_map(path_params).map_err(|message| {
         /*

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -13,6 +13,7 @@ use http::StatusCode;
 use percent_encoding::percent_decode_str;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::str::Utf8Error;
 
 /**
  * `HttpRouter` is a simple data structure for routing incoming HTTP requests to
@@ -752,31 +753,6 @@ pub fn route_path_to_segments(path: &str) -> Vec<&str> {
         ret.pop();
     }
     ret
-}
-
-/**
- * Helper function for splitting a Uri path into the first segment and the
- * remainder of the path.
- */
-pub fn get_path_segment(mut path: &str) -> (&str, &str) {
-    assert!(!path.is_empty());
-
-    /* Skip leading slashes */
-    while path.starts_with('/') {
-        path = &path[1..];
-    }
-
-    match path.find('/') {
-        Some(index) => {
-            let segment = &path[..index];
-            let mut rest = &path[index + 1..];
-            while rest.starts_with('/') {
-                rest = &rest[1..];
-            }
-            (segment, rest)
-        }
-        None => (path, ""),
-    }
 }
 
 #[cfg(test)]

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -1004,6 +1004,21 @@ mod test {
         ));
     }
 
+    /*
+     * TODO: We allow a trailing slash after the wildcard specifier, but we may
+     * reconsider this if we decided to distinguish between the presence or
+     * absence of the trailing slash.
+     */
+    #[test]
+    fn test_slash_after_wildcard_is_fine_dot_dot_dot_for_now() {
+        let mut router = HttpRouter::new();
+        router.insert(new_endpoint(
+            new_handler(),
+            Method::GET,
+            "/some/{more:.*}/",
+        ));
+    }
+
     #[test]
     fn test_error_cases() {
         let mut router = HttpRouter::new();

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -60,51 +60,9 @@
         }
       }
     },
-    "/dup3": {
-      "put": {
-        "operationId": "handler10",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/dup4": {
-      "put": {
-        "operationId": "handler11",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
     "/dup5": {
       "put": {
-        "operationId": "handler12",
+        "operationId": "handler10",
         "requestBody": {
           "content": {
             "application/json": {
@@ -124,7 +82,7 @@
     },
     "/dup6": {
       "put": {
-        "operationId": "handler13",
+        "operationId": "handler11",
         "requestBody": {
           "content": {
             "application/json": {
@@ -144,7 +102,7 @@
     },
     "/dup7": {
       "put": {
-        "operationId": "handler14",
+        "operationId": "handler12",
         "requestBody": {
           "content": {
             "application/json": {
@@ -164,7 +122,7 @@
     },
     "/dup8": {
       "get": {
-        "operationId": "handler15",
+        "operationId": "handler13",
         "responses": {
           "200": {
             "description": "successful operation",
@@ -310,21 +268,7 @@
           },
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -333,7 +277,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -364,21 +308,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -387,7 +317,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -407,25 +337,25 @@
       "BodyParam": {
         "type": "object",
         "properties": {
-          "_any": {},
-          "_x": {
+          "any": {},
+          "x": {
             "type": "string"
           }
         },
         "required": [
-          "_any",
-          "_x"
+          "any",
+          "x"
         ]
       },
       "NeverDuplicatedBodyNextLevel": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedBodyTopLevel": {
@@ -442,12 +372,12 @@
       "NeverDuplicatedNext": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedResponseNextLevel": {
@@ -475,12 +405,12 @@
       "NeverDuplicatedTop": {
         "type": "object",
         "properties": {
-          "_b": {
+          "b": {
             "$ref": "#/components/schemas/NeverDuplicatedNext"
           }
         },
         "required": [
-          "_b"
+          "b"
         ]
       },
       "Response": {
@@ -515,17 +445,6 @@
         },
         "required": [
           "items"
-        ]
-      },
-      "NeverDuplicatedParamNextLevel": {
-        "type": "object",
-        "properties": {
-          "_v": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "_v"
         ]
       }
     }

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -26,9 +26,8 @@ async fn handler1(
 #[derive(Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct QueryArgs {
-    _tomax: String,
-    _xamot: Option<String>,
-    _destro: Vec<u16>,
+    tomax: String,
+    xamot: Option<String>,
 }
 
 #[endpoint {
@@ -65,9 +64,10 @@ async fn handler3(
 }
 
 #[derive(JsonSchema, Deserialize)]
+#[allow(dead_code)]
 struct BodyParam {
-    _x: String,
-    _any: serde_json::Value,
+    x: String,
+    any: serde_json::Value,
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -174,44 +174,6 @@ async fn handler9(
 
 /*
  * Similarly, test that we do not generate duplicate type definitions when the
- * same type is accepted as a query parameter to two different handler
- * functions.
- */
-
-#[derive(Deserialize, JsonSchema)]
-struct NeverDuplicatedParamTopLevel {
-    _b: NeverDuplicatedParamNextLevel,
-}
-
-#[derive(Deserialize, JsonSchema)]
-struct NeverDuplicatedParamNextLevel {
-    _v: bool,
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/dup3",
-}]
-async fn handler10(
-    _rqctx: Arc<RequestContext<()>>,
-    _q: Query<NeverDuplicatedParamTopLevel>,
-) -> Result<HttpResponseOk<()>, HttpError> {
-    unimplemented!();
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/dup4",
-}]
-async fn handler11(
-    _rqctx: Arc<RequestContext<()>>,
-    _q: Query<NeverDuplicatedParamTopLevel>,
-) -> Result<HttpResponseOk<()>, HttpError> {
-    unimplemented!();
-}
-
-/*
- * Similarly, test that we do not generate duplicate type definitions when the
  * same type is accepted as a typed body to two different handler functions.
  */
 
@@ -221,15 +183,16 @@ struct NeverDuplicatedBodyTopLevel {
 }
 
 #[derive(Deserialize, JsonSchema)]
+#[allow(dead_code)]
 struct NeverDuplicatedBodyNextLevel {
-    _v: bool,
+    v: bool,
 }
 
 #[endpoint {
     method = PUT,
     path = "/dup5",
 }]
-async fn handler12(
+async fn handler10(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedBodyTopLevel>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
@@ -240,7 +203,7 @@ async fn handler12(
     method = PUT,
     path = "/dup6",
 }]
-async fn handler13(
+async fn handler11(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedBodyTopLevel>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
@@ -253,20 +216,22 @@ async fn handler13(
  */
 
 #[derive(Deserialize, JsonSchema, Serialize)]
+#[allow(dead_code)]
 struct NeverDuplicatedTop {
-    _b: NeverDuplicatedNext,
+    b: NeverDuplicatedNext,
 }
 
 #[derive(Deserialize, JsonSchema, Serialize)]
+#[allow(dead_code)]
 struct NeverDuplicatedNext {
-    _v: bool,
+    v: bool,
 }
 
 #[endpoint {
     method = PUT,
     path = "/dup7",
 }]
-async fn handler14(
+async fn handler12(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedTop>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
@@ -277,7 +242,7 @@ async fn handler14(
     method = GET,
     path = "/dup8",
 }]
-async fn handler15(
+async fn handler13(
     _rqctx: Arc<RequestContext<()>>,
 ) -> Result<HttpResponseOk<NeverDuplicatedTop>, HttpError> {
     unimplemented!();
@@ -294,7 +259,7 @@ struct AllPath {
     path = "/ceci_nes_pas_une_endpoint/{path:.*}",
     unpublished = true,
 }]
-async fn handler16(
+async fn handler14(
     _rqctx: Arc<RequestContext<()>>,
     _path: Path<AllPath>,
 ) -> Result<HttpResponseOk<NeverDuplicatedTop>, HttpError> {
@@ -317,8 +282,6 @@ fn make_api() -> Result<ApiDescription<()>, String> {
     api.register(handler12)?;
     api.register(handler13)?;
     api.register(handler14)?;
-    api.register(handler15)?;
-    api.register(handler16)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Oxide Computer Company
+// Copyright 2021 Oxide Computer Company
 
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseAccepted,
@@ -283,6 +283,24 @@ async fn handler15(
     unimplemented!();
 }
 
+#[allow(dead_code)]
+#[derive(JsonSchema, Deserialize)]
+struct AllPath {
+    path: String,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/ceci_nes_pas_une_endpoint/{path:.*}",
+    unpublished = true,
+}]
+async fn handler16(
+    _rqctx: Arc<RequestContext<()>>,
+    _path: Path<AllPath>,
+) -> Result<HttpResponseOk<NeverDuplicatedTop>, HttpError> {
+    unimplemented!();
+}
+
 fn make_api() -> Result<ApiDescription<()>, String> {
     let mut api = ApiDescription::new();
     api.register(handler1)?;
@@ -300,6 +318,7 @@ fn make_api() -> Result<ApiDescription<()>, String> {
     api.register(handler13)?;
     api.register(handler14)?;
     api.register(handler15)?;
+    api.register(handler16)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -68,51 +68,9 @@
         }
       }
     },
-    "/dup3": {
-      "put": {
-        "operationId": "handler10",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/dup4": {
-      "put": {
-        "operationId": "handler11",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
     "/dup5": {
       "put": {
-        "operationId": "handler12",
+        "operationId": "handler10",
         "requestBody": {
           "content": {
             "application/json": {
@@ -132,7 +90,7 @@
     },
     "/dup6": {
       "put": {
-        "operationId": "handler13",
+        "operationId": "handler11",
         "requestBody": {
           "content": {
             "application/json": {
@@ -152,7 +110,7 @@
     },
     "/dup7": {
       "put": {
-        "operationId": "handler14",
+        "operationId": "handler12",
         "requestBody": {
           "content": {
             "application/json": {
@@ -172,7 +130,7 @@
     },
     "/dup8": {
       "get": {
-        "operationId": "handler15",
+        "operationId": "handler13",
         "responses": {
           "200": {
             "description": "successful operation",
@@ -318,21 +276,7 @@
           },
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -341,7 +285,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -372,21 +316,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -395,7 +325,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -415,25 +345,25 @@
       "BodyParam": {
         "type": "object",
         "properties": {
-          "_any": {},
-          "_x": {
+          "any": {},
+          "x": {
             "type": "string"
           }
         },
         "required": [
-          "_any",
-          "_x"
+          "any",
+          "x"
         ]
       },
       "NeverDuplicatedBodyNextLevel": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedBodyTopLevel": {
@@ -450,12 +380,12 @@
       "NeverDuplicatedNext": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedResponseNextLevel": {
@@ -483,12 +413,12 @@
       "NeverDuplicatedTop": {
         "type": "object",
         "properties": {
-          "_b": {
+          "b": {
             "$ref": "#/components/schemas/NeverDuplicatedNext"
           }
         },
         "required": [
-          "_b"
+          "b"
         ]
       },
       "Response": {
@@ -523,17 +453,6 @@
         },
         "required": [
           "items"
-        ]
-      },
-      "NeverDuplicatedParamNextLevel": {
-        "type": "object",
-        "properties": {
-          "_v": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "_v"
         ]
       }
     }

--- a/dropshot/tests/test_openapi_old.json
+++ b/dropshot/tests/test_openapi_old.json
@@ -60,51 +60,9 @@
         }
       }
     },
-    "/dup3": {
-      "put": {
-        "operationId": "handler10",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/dup4": {
-      "put": {
-        "operationId": "handler11",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "_b",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NeverDuplicatedParamNextLevel"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
     "/dup5": {
       "put": {
-        "operationId": "handler12",
+        "operationId": "handler10",
         "requestBody": {
           "content": {
             "application/json": {
@@ -124,7 +82,7 @@
     },
     "/dup6": {
       "put": {
-        "operationId": "handler13",
+        "operationId": "handler11",
         "requestBody": {
           "content": {
             "application/json": {
@@ -144,7 +102,7 @@
     },
     "/dup7": {
       "put": {
-        "operationId": "handler14",
+        "operationId": "handler12",
         "requestBody": {
           "content": {
             "application/json": {
@@ -164,7 +122,7 @@
     },
     "/dup8": {
       "get": {
-        "operationId": "handler15",
+        "operationId": "handler13",
         "responses": {
           "200": {
             "description": "successful operation",
@@ -310,21 +268,7 @@
           },
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -333,7 +277,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -364,21 +308,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "_destro",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              }
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "_tomax",
+            "name": "tomax",
             "required": true,
             "schema": {
               "type": "string"
@@ -387,7 +317,7 @@
           },
           {
             "in": "query",
-            "name": "_xamot",
+            "name": "xamot",
             "schema": {
               "type": "string"
             },
@@ -407,25 +337,25 @@
       "BodyParam": {
         "type": "object",
         "properties": {
-          "_any": {},
-          "_x": {
+          "any": {},
+          "x": {
             "type": "string"
           }
         },
         "required": [
-          "_any",
-          "_x"
+          "any",
+          "x"
         ]
       },
       "NeverDuplicatedBodyNextLevel": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedBodyTopLevel": {
@@ -442,12 +372,12 @@
       "NeverDuplicatedNext": {
         "type": "object",
         "properties": {
-          "_v": {
+          "v": {
             "type": "boolean"
           }
         },
         "required": [
-          "_v"
+          "v"
         ]
       },
       "NeverDuplicatedResponseNextLevel": {
@@ -475,12 +405,12 @@
       "NeverDuplicatedTop": {
         "type": "object",
         "properties": {
-          "_b": {
+          "b": {
             "$ref": "#/components/schemas/NeverDuplicatedNext"
           }
         },
         "required": [
-          "_b"
+          "b"
         ]
       },
       "Response": {
@@ -515,17 +445,6 @@
         },
         "required": [
           "items"
-        ]
-      },
-      "NeverDuplicatedParamNextLevel": {
-        "type": "object",
-        "properties": {
-          "_v": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "_v"
         ]
       }
     }


### PR DESCRIPTION
This will match paths such as `/foo/bar` and `/foo/bar/baz.css`

We can use this to serve static assets such as css, html, and image
files.

Express uses this syntax: `/foo/bar/:rest(.*)`
Dropwizard / Jersey / JAX-RS does: `/foo/bar/{rest:.*}`
Actix does: `/foo/bar/{rest:.*}`

This also adds support for a tag (unpublished = true) in the #[endpoint]
macro to omit certain endpoints from the OpenAPI output. This is both
useful for non-API endpoints and necessary in that OpenAPI doesn't
support any type of multi-segment matching of routes.