### PR TITLE
Unused endpoints should produce a lint warning

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,7 +21,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of co
 === Breaking Changes
 
 * https://github.com/oxidecomputer/dropshot/pull/100[#100] The type used for the "limit" argument for paginated resources has changed.  This limit refers to the number of items that an HTTP client can ask for in a single request to a paginated endpoint.  The limit is now 4294967295, where it may have previously been larger.  This is not expected to affect consumers because this limit is far larger than practical.  For details, see #100.
-* https://github.com/oxidecomputer/dropshot/pull/116[#116] Unused, non-`pub` endpoints from the `#[endpoint { ... }]` macro now produce a lint warning. This is *technically* a breaking change for those who may have had unused endpoints and compiled with `#[deny(warning)]` or `#[deny(dead_code)]` thus implicitly relying on the *absence* of a warning about the endpoint being unused.
+* https://github.com/oxidecomputer/dropshot/pull/116[#116] Unused, non-`pub` endpoints from the `&#35;[endpoint { ... }]` macro now produce a lint warning. This is *technically* a breaking change for those who may have had unused endpoints and compiled with `&#35;[deny(warning)]` or `&#35;[deny(dead_code)]` thus implicitly relying on the *absence* of a warning about the endpoint being unused.
 
 == 0.5.1 (released 2021-03-18)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of co
 === Breaking Changes
 
 * https://github.com/oxidecomputer/dropshot/pull/100[#100] The type used for the "limit" argument for paginated resources has changed.  This limit refers to the number of items that an HTTP client can ask for in a single request to a paginated endpoint.  The limit is now 4294967295, where it may have previously been larger.  This is not expected to affect consumers because this limit is far larger than practical.  For details, see #100.
+* https://github.com/oxidecomputer/dropshot/pull/116[#116] Unused, non-`pub` endpoints from the `#[endpoint { ... }]` macro now produce a lint warning. This is *technically* a breaking change for those who may have had unused endpoints and compiled with `#[deny(warning)]` or `#[deny(dead_code)]` thus implicitly relying on the *absence* of a warning about the endpoint being unused.
 
 == 0.5.1 (released 2021-03-18)
 

--- a/dropshot/tests/fail/unused_endpoint.rs
+++ b/dropshot/tests/fail/unused_endpoint.rs
@@ -1,0 +1,23 @@
+// Copyright 2021 Oxide Computer Company
+
+#![allow(unused_imports)]
+#![deny(warnings)]
+
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn unused_endpoint(
+    _rqctx: Arc<RequestContext<()>>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/unused_endpoint.rs
+++ b/dropshot/tests/fail/unused_endpoint.rs
@@ -1,15 +1,21 @@
 // Copyright 2021 Oxide Computer Company
 
-#![allow(unused_imports)]
-#![deny(warnings)]
+// For whatever reason, trybuild overrides the default disposition for the
+// dead_code lint from "warn" to "allow" so we explicitly deny it here.
+#![deny(dead_code)]
 
 use dropshot::endpoint;
-use dropshot::ApiDescription;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::RequestContext;
 use std::sync::Arc;
 
+// At some point we'd expect to see code like:
+// ```
+//     let mut api = ApiDescription::new();
+//     api.register(unused_endpoint).unwrap();
+// ```
+// Defining but not using the endpoint should cause a warning.
 #[endpoint {
     method = GET,
     path = "/test",

--- a/dropshot/tests/fail/unused_endpoint.stderr
+++ b/dropshot/tests/fail/unused_endpoint.stderr
@@ -1,0 +1,11 @@
+error: constant is never used: `unused_endpoint`
+  --> $DIR/unused_endpoint.rs:23:10
+   |
+23 | async fn unused_endpoint(
+   |          ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused_endpoint.rs:5:9
+   |
+5  | #![deny(dead_code)]
+   |         ^^^^^^^^^


### PR DESCRIPTION
Fixes #114 