### PR TITLE
Incorrect endpoint return types result in indecipherable errors

### DIFF
--- a/dropshot/tests/fail/bad_endpoint10.rs
+++ b/dropshot/tests/fail/bad_endpoint10.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_error_type(
+    _: Arc<RequestContext<()>>,
+) -> Result<HttpResponseOk<()>, String> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint10.stderr
+++ b/dropshot/tests/fail/bad_endpoint10.stderr
@@ -5,7 +5,7 @@ error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
    |      ^^^^^^
    |      |
    |      expected struct `HttpError`, found struct `String`
-   |      required by this bound in `validate_return_type`
+   |      required by this bound in `validate_result_error_type`
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
   --> $DIR/bad_endpoint10.rs:14:10

--- a/dropshot/tests/fail/bad_endpoint10.stderr
+++ b/dropshot/tests/fail/bad_endpoint10.stderr
@@ -1,0 +1,19 @@
+error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
+  --> $DIR/bad_endpoint10.rs:16:6
+   |
+16 | ) -> Result<HttpResponseOk<()>, String> {
+   |      ^^^^^^
+   |      |
+   |      expected struct `HttpError`, found struct `String`
+   |      required by this bound in `validate_return_type`
+
+error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
+  --> $DIR/bad_endpoint10.rs:14:10
+   |
+14 | async fn bad_error_type(
+   |          ^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}`
+   |
+  ::: $WORKSPACE/dropshot/src/api_description.rs
+   |
+   |         FuncParams: Extractor + 'static,
+   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint11.rs
+++ b/dropshot/tests/fail/bad_endpoint11.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_no_result(_: Arc<RequestContext<()>>) {}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint11.stderr
+++ b/dropshot/tests/fail/bad_endpoint11.stderr
@@ -1,0 +1,13 @@
+error: Endpoint must return a Result
+Endpoint handlers must have the following signature:
+    async fn bad_no_result(
+        rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
+        [query_params: Query<Q>,]
+        [path_params: Path<P>,]
+        [body_param: TypedBody<J>,]
+        [body_param: UntypedBody<J>,]
+    ) -> Result<HttpResponse*, HttpError>
+  --> $DIR/bad_endpoint11.rs:13:1
+   |
+13 | async fn bad_no_result(_: Arc<RequestContext<()>>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/dropshot/tests/fail/bad_endpoint12.rs
+++ b/dropshot/tests/fail/bad_endpoint12.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_response_type(
+    _: Arc<RequestContext<()>>,
+) -> Result<String, HttpError> {
+    Ok("aok".to_string())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint12.stderr
+++ b/dropshot/tests/fail/bad_endpoint12.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `String: dropshot::handler::HttpTypedResponse` is not satisfied
+  --> $DIR/bad_endpoint12.rs:16:6
+   |
+16 | ) -> Result<String, HttpError> {
+   |      ^^^^^^ the trait `dropshot::handler::HttpTypedResponse` is not implemented for `String`
+   |
+   = note: required because of the requirements on the impl of `HttpResponse` for `String`
+note: required because of the requirements on the impl of `ResultTrait` for `Result<String, HttpError>`
+  --> $DIR/bad_endpoint12.rs:16:6
+   |
+16 | ) -> Result<String, HttpError> {
+   |      ^^^^^^

--- a/dropshot/tests/fail/bad_endpoint6.rs
+++ b/dropshot/tests/fail/bad_endpoint6.rs
@@ -20,8 +20,12 @@ struct Ret {
     method = GET,
     path = "/test",
 }]
-async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
-    Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
+async fn bad_endpoint(
+    _rqctx: Arc<RequestContext<()>>,
+) -> Result<HttpResponseOk<Ret>, HttpError> {
+    // Validate that compiler errors show up with useful context and aren't
+    // obscured by the macro.
+    Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
 }
 
 fn main() {}

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -1,54 +1,21 @@
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-  --> $DIR/bad_endpoint6.rs:24:23
+error: expected identifier, found `"Oxide"`
+  --> $DIR/bad_endpoint6.rs:28:29
    |
-24 |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-   |
-   = note: required by `HttpResponseOk`
+28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ---   ^^^^^^^ expected identifier
+   |                       |
+   |                       while parsing this struct
 
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint6.rs:24:8
-     |
-24   |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
-     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-    ::: $WORKSPACE/dropshot/src/handler.rs
-     |
-     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                           --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint6.rs:24:5
-     |
-24   |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-    ::: $WORKSPACE/dropshot/src/handler.rs
-     |
-     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                           --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint6.rs:23:98
-     |
-23   |   async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
-     |  __________________________________________________________________________________________________^
-24   | |     Ok(HttpResponseOk(Ret { x: "Oxide".to_string(), y: 0x1de }))
-25   | | }
-     | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-    ::: $WORKSPACE/dropshot/src/handler.rs
-     |
-     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                             --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint6.rs:23:10
+error: expected identifier, found `0x1de`
+  --> $DIR/bad_endpoint6.rs:28:50
    |
-23 | async fn bad_endpoint(_rqctx: Arc<RequestContext<()>>) -> Result<HttpResponseOk<Ret>, HttpError> {
-   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
+28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ---                        ^^^^^ expected identifier
+   |                       |
+   |                       while parsing this struct
+
+error: expected identifier or integer
+  --> $DIR/bad_endpoint6.rs:28:29
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
-   |
-   |         FuncParams: Extractor + 'static,
-   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
+28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                             ^^^^^^^

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -1,68 +1,10 @@
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-  --> $DIR/bad_endpoint7.rs:26:23
-   |
-26 |       Ok(HttpResponseOk(Ret {
-   |  _______________________^
-27 | |         x: "Oxide".to_string(),
-28 | |         y: 0x1de,
-29 | |     }))
-   | |_____^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-   |
-   = note: required by `HttpResponseOk`
-
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint7.rs:26:8
+    --> $DIR/bad_endpoint7.rs:25:6
      |
-26   |       Ok(HttpResponseOk(Ret {
-     |  ________^
-27   | |         x: "Oxide".to_string(),
-28   | |         y: 0x1de,
-29   | |     }))
-     | |______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+25   | ) -> Result<HttpResponseOk<Ret>, HttpError> {
+     |      ^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
      |
     ::: $WORKSPACE/dropshot/src/handler.rs
      |
-     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                             --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint7.rs:26:5
-     |
-26   | /     Ok(HttpResponseOk(Ret {
-27   | |         x: "Oxide".to_string(),
-28   | |         y: 0x1de,
-29   | |     }))
-     | |_______^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-    ::: $WORKSPACE/dropshot/src/handler.rs
-     |
-     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                             --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint7.rs:25:45
-     |
-25   |   ) -> Result<HttpResponseOk<Ret>, HttpError> {
-     |  _____________________________________________^
-26   | |     Ok(HttpResponseOk(Ret {
-27   | |         x: "Oxide".to_string(),
-28   | |         y: 0x1de,
-29   | |     }))
-30   | | }
-     | |_^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-    ::: $WORKSPACE/dropshot/src/handler.rs
-     |
-     |   pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                             --------- required by this bound in `HttpResponseOk`
-
-error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint7.rs:23:10
-   |
-23 | async fn bad_endpoint(
-   |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
-   |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
-   |
-   |         FuncParams: Extractor + 'static,
-   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
+     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           --------- required by this bound in `HttpResponseOk`

--- a/dropshot/tests/fail/bad_endpoint9.stderr
+++ b/dropshot/tests/fail/bad_endpoint9.stderr
@@ -1,4 +1,10 @@
 error[E0277]: the trait bound `dropshot::Query<QueryParams>: RequestContextArgument` is not satisfied
+  --> $DIR/bad_endpoint9.rs:25:14
+   |
+25 |     _params: Query<QueryParams>,
+   |              ^^^^^ the trait `RequestContextArgument` is not implemented for `dropshot::Query<QueryParams>`
+
+error[E0277]: the trait bound `dropshot::Query<QueryParams>: RequestContextArgument` is not satisfied
   --> $DIR/bad_endpoint9.rs:20:1
    |
 20 | / #[endpoint {

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -259,7 +259,6 @@ fn do_endpoint(
                         type E = EE;
                     }
 
-
                     // This is not strictly necessary as we'll try to use
                     // #ret_ty as ResultTrait below. This does, however,
                     // produce a cleaner error message as type definition


### PR DESCRIPTION
A few weeks ago, @bnaecker hit some errors building a dropshot client that were very challenging to interpret. The problem was that the return type for his endpoint had a `String` as the `Result` error type rather than a `dropshot::HttpError`. The new build tests 10, 11, and 12 add different forms of this return type error. Without the fixes in here, this is what the output looks like.

<details>
 <summary>Expand for details</summary>

```
test tests/fail/bad_endpoint10.rs ... wip

NOTE: writing the following output to `wip/bad_endpoint10.stderr`.
Move this file to `tests/fail/bad_endpoint10.stderr` to accept it as correct.
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
  --> $DIR/bad_endpoint10.rs:14:10
   |
14 | async fn bad_error_type(
   |          ^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}`
   |
  ::: $WORKSPACE/dropshot/src/api_description.rs
   |
   |         FuncParams: Extractor + 'static,
   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

test tests/fail/bad_endpoint11.rs ... wip

NOTE: writing the following output to `wip/bad_endpoint11.stderr`.
Move this file to `tests/fail/bad_endpoint11.stderr` to accept it as correct.
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_no_result> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_no_result}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
  --> $DIR/bad_endpoint11.rs:13:10
   |
13 | async fn bad_no_result(_: Arc<RequestContext<()>>) {}
   |          ^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_no_result> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_no_result}`
   |
  ::: $WORKSPACE/dropshot/src/api_description.rs
   |
   |         FuncParams: Extractor + 'static,
   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

test tests/fail/bad_endpoint12.rs ... wip

NOTE: writing the following output to `wip/bad_endpoint12.stderr`.
Move this file to `tests/fail/bad_endpoint12.stderr` to accept it as correct.
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_response_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_response_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
  --> $DIR/bad_endpoint12.rs:14:10
   |
14 | async fn bad_response_type(
   |          ^^^^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_response_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_response_type}`
   |
  ::: $WORKSPACE/dropshot/src/api_description.rs
   |
   |         FuncParams: Extractor + 'static,
   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```
</details>

In particular this error seems like it can easily send one down the wrong path:

```
   |         FuncParams: Extractor + 'static,
   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
```

The new code in the dropshot endpoint macro injects specific checks for return types and reinstates checks for the first parameter of type `Arc<RequestContext<T>>`

Note that at some point bad_endpoint6.rs was modified to be identical to bad_endpoint5.rs. This also restores (and comments) the intent with bad_endpoint6.rs to show a compiler error in the user code without the macro obscuring it (which earlier versions of the macro did).