### PR TITLE
more stringent checking of ItemFn signature fields

### DIFF
--- a/dropshot/tests/fail/bad_endpoint13.rs
+++ b/dropshot/tests/fail/bad_endpoint13.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+trait Stuff {
+    fn do_stuff();
+}
+
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn bad_response_type<S: Stuff + Sync + Send + 'static>(
+    _: Arc<RequestContext<S>>,
+) -> Result<HttpResponseOk<String>, HttpError> {
+    S::do_stuff();
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint13.stderr
+++ b/dropshot/tests/fail/bad_endpoint13.stderr
@@ -1,0 +1,5 @@
+error: generics are not permitted for endpoint handlers
+  --> $DIR/bad_endpoint13.rs:19:27
+   |
+19 | async fn bad_response_type<S: Stuff + Sync + Send + 'static>(
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -114,11 +114,43 @@ fn do_endpoint(
 
     let ast: ItemFn = syn::parse2(item.clone())?;
 
+    if ast.sig.constness.is_some() {
+        return Err(Error::new_spanned(
+            ast.sig.constness,
+            "endpoint handlers may not be const functions",
+        ));
+    }
+
     if ast.sig.asyncness.is_none() {
         return Err(Error::new_spanned(
             ast.sig.fn_token,
             "endpoint handler functions must be async",
         ));
+    }
+
+    if ast.sig.unsafety.is_some() {
+        return Err(Error::new_spanned(
+            ast.sig.unsafety,
+            "endpoint handlers may not be unsafe",
+        ));
+    }
+
+    if ast.sig.abi.is_some() {
+        return Err(Error::new_spanned(
+            ast.sig.abi,
+            "endpoint handler may not use an alternate ABI",
+        ));
+    }
+
+    if !ast.sig.generics.params.is_empty() {
+        return Err(Error::new_spanned(
+            ast.sig.generics,
+            "generics are not permitted for endpoint handlers",
+        ));
+    }
+
+    if ast.sig.variadic.is_some() {
+        return Err(Error::new_spanned(ast.sig.variadic, "no language C here"));
     }
 
     let name = &ast.sig.ident;


### PR DESCRIPTION
closes #132 

This adds a test for generics and also examines other fields we weren't checking for. I explicitly did not add tests for those fields because I don't think we really care about the stability of that output, but I'd be happy to if folks think it would be beneficial. The `fail` tests already take kind of a long time so I'm loth to add more.