### PR TITLE
do our best to emit macro output even in the face of errors

### DIFF
--- a/dropshot/tests/fail/bad_endpoint1.stderr
+++ b/dropshot/tests/fail/bad_endpoint1.stderr
@@ -1,6 +1,5 @@
-error: Endpoint requires arguments
-Endpoint handlers must have the following signature:
-    async fn bad_endpoint(
+error: Endpoint handlers must have the following signature:
+    async fn(
         rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
         [query_params: Query<Q>,]
         [path_params: Path<P>,]
@@ -11,3 +10,9 @@ Endpoint handlers must have the following signature:
    |
 20 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Endpoint requires arguments
+  --> $DIR/bad_endpoint1.rs:20:22
+   |
+20 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
+   |                      ^^

--- a/dropshot/tests/fail/bad_endpoint10.stderr
+++ b/dropshot/tests/fail/bad_endpoint10.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
-  --> $DIR/bad_endpoint10.rs:16:6
+  --> tests/fail/bad_endpoint10.rs:16:6
    |
 16 | ) -> Result<HttpResponseOk<()>, String> {
    |      ^^^^^^
@@ -8,12 +8,12 @@ error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
    |      required by this bound in `validate_result_error_type`
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint10.rs:14:10
+  --> tests/fail/bad_endpoint10.rs:14:10
    |
 14 | async fn bad_error_type(
    |          ^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+  ::: src/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
+54 |         FuncParams: Extractor + 'static,
    |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint11.stderr
+++ b/dropshot/tests/fail/bad_endpoint11.stderr
@@ -1,12 +1,17 @@
-error: Endpoint must return a Result
-Endpoint handlers must have the following signature:
-    async fn bad_no_result(
+error: Endpoint handlers must have the following signature:
+    async fn(
         rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
         [query_params: Query<Q>,]
         [path_params: Path<P>,]
         [body_param: TypedBody<J>,]
         [body_param: UntypedBody<J>,]
     ) -> Result<HttpResponse*, HttpError>
+  --> $DIR/bad_endpoint11.rs:13:1
+   |
+13 | async fn bad_no_result(_: Arc<RequestContext<()>>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Endpoint must return a Result
   --> $DIR/bad_endpoint11.rs:13:1
    |
 13 | async fn bad_no_result(_: Arc<RequestContext<()>>) {}

--- a/dropshot/tests/fail/bad_endpoint13.rs
+++ b/dropshot/tests/fail/bad_endpoint13.rs
@@ -20,7 +20,7 @@ async fn bad_response_type<S: Stuff + Sync + Send + 'static>(
     _: Arc<RequestContext<S>>,
 ) -> Result<HttpResponseOk<String>, HttpError> {
     S::do_stuff();
-    Ok(HttpResponseOk(()))
+    panic!()
 }
 
 fn main() {}

--- a/dropshot/tests/fail/bad_endpoint13.stderr
+++ b/dropshot/tests/fail/bad_endpoint13.stderr
@@ -1,5 +1,34 @@
+error: Endpoint handlers must have the following signature:
+    async fn(
+        rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
+        [query_params: Query<Q>,]
+        [path_params: Path<P>,]
+        [body_param: TypedBody<J>,]
+        [body_param: UntypedBody<J>,]
+    ) -> Result<HttpResponse*, HttpError>
+  --> $DIR/bad_endpoint13.rs:19:1
+   |
+19 | / async fn bad_response_type<S: Stuff + Sync + Send + 'static>(
+20 | |     _: Arc<RequestContext<S>>,
+21 | | ) -> Result<HttpResponseOk<String>, HttpError> {
+   | |______________________________________________^
+
 error: generics are not permitted for endpoint handlers
   --> $DIR/bad_endpoint13.rs:19:27
    |
 19 | async fn bad_response_type<S: Stuff + Sync + Send + 'static>(
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `S` in this scope
+  --> $DIR/bad_endpoint13.rs:20:27
+   |
+20 |     _: Arc<RequestContext<S>>,
+   |           -               ^ not found in this scope
+   |           |
+   |           help: you might be missing a type parameter: `<S>`
+
+error[E0412]: cannot find type `S` in this scope
+  --> $DIR/bad_endpoint13.rs:20:27
+   |
+20 |     _: Arc<RequestContext<S>>,
+   |                           ^ not found in this scope

--- a/dropshot/tests/fail/bad_endpoint2.stderr
+++ b/dropshot/tests/fail/bad_endpoint2.stderr
@@ -1,13 +1,38 @@
-error: Expected a non-receiver argument
-Endpoint handlers must have the following signature:
-    async fn bad_endpoint(
+error: Endpoint handlers must have the following signature:
+    async fn(
         rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
         [query_params: Query<Q>,]
         [path_params: Path<P>,]
         [body_param: TypedBody<J>,]
         [body_param: UntypedBody<J>,]
     ) -> Result<HttpResponse*, HttpError>
+  --> $DIR/bad_endpoint2.rs:13:1
+   |
+13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Expected a non-receiver argument
   --> $DIR/bad_endpoint2.rs:13:23
    |
 13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
    |                       ^^^^
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/bad_endpoint2.rs:13:23
+   |
+13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+   |                       ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/bad_endpoint2.rs:13:23
+   |
+9  | #[endpoint {
+   | ---------- `Self` type implicitly declared here, by this `impl`
+...
+13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
+   |                       ^^^^
+   |                       |
+   |                       use of generic parameter from outer function
+   |                       use a type here instead

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: Extractor` is not satisfied
-  --> $DIR/bad_endpoint3.rs:17:12
+  --> tests/fail/bad_endpoint3.rs:17:12
    |
 11 | / #[endpoint {
 12 | |     method = GET,
@@ -14,12 +14,12 @@ error[E0277]: the trait bound `String: Extractor` is not satisfied
    |              required by a bound in this
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint3.rs:15:10
+  --> tests/fail/bad_endpoint3.rs:15:10
    |
 15 | async fn bad_endpoint(
    |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+  ::: src/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
+54 |         FuncParams: Extractor + 'static,
    |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -1,23 +1,23 @@
 error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
-   --> $DIR/bad_endpoint4.rs:24:14
+   --> tests/fail/bad_endpoint4.rs:24:14
     |
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:48
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                                                ---------- required by this bound in `dropshot::Query`
 
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> $DIR/bad_endpoint4.rs:24:14
+   --> tests/fail/bad_endpoint4.rs:24:14
     |
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:29
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                             ---------------- required by this bound in `dropshot::Query`
     |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -1,12 +1,12 @@
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> $DIR/bad_endpoint5.rs:26:14
+   --> tests/fail/bad_endpoint5.rs:26:14
     |
 26  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:29
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                             ---------------- required by this bound in `dropshot::Query`
     |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint6.rs
+++ b/dropshot/tests/fail/bad_endpoint6.rs
@@ -7,9 +7,10 @@ use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::RequestContext;
 use schemars::JsonSchema;
+use serde::Serialize;
 use std::sync::Arc;
 
-#[derive(JsonSchema)]
+#[derive(JsonSchema, Serialize)]
 #[allow(dead_code)]
 struct Ret {
     x: String,

--- a/dropshot/tests/fail/bad_endpoint6.stderr
+++ b/dropshot/tests/fail/bad_endpoint6.stderr
@@ -1,21 +1,21 @@
 error: expected identifier, found `"Oxide"`
-  --> $DIR/bad_endpoint6.rs:28:29
+  --> $DIR/bad_endpoint6.rs:29:29
    |
-28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+29 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
    |                       ---   ^^^^^^^ expected identifier
    |                       |
    |                       while parsing this struct
 
 error: expected identifier, found `0x1de`
-  --> $DIR/bad_endpoint6.rs:28:50
+  --> $DIR/bad_endpoint6.rs:29:50
    |
-28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+29 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
    |                       ---                        ^^^^^ expected identifier
    |                       |
    |                       while parsing this struct
 
-error: expected identifier or integer
-  --> $DIR/bad_endpoint6.rs:28:29
+error[E0063]: missing fields `x` and `y` in initializer of `Ret`
+  --> $DIR/bad_endpoint6.rs:29:23
    |
-28 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
-   |                             ^^^^^^^
+29 |     Ok(HttpResponseOk(Ret { "Oxide".to_string(), 0x1de }))
+   |                       ^^^ missing `x` and `y`

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint7.rs:25:13
+    --> tests/fail/bad_endpoint7.rs:25:13
      |
 25   | ) -> Result<HttpResponseOk<Ret>, HttpError> {
      |             ^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
      |
-    ::: $WORKSPACE/dropshot/src/handler.rs
+    ::: src/handler.rs:1216:43
      |
-     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+1216 | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
      |                                           --------- required by this bound in `HttpResponseOk`

--- a/dropshot/tests/fail/bad_endpoint8.stderr
+++ b/dropshot/tests/fail/bad_endpoint8.stderr
@@ -1,3 +1,18 @@
+error: Endpoint handlers must have the following signature:
+    async fn(
+        rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
+        [query_params: Query<Q>,]
+        [path_params: Path<P>,]
+        [body_param: TypedBody<J>,]
+        [body_param: UntypedBody<J>,]
+    ) -> Result<HttpResponse*, HttpError>
+  --> $DIR/bad_endpoint8.rs:20:1
+   |
+20 | / fn bad_endpoint(
+21 | |     _rqctx: Arc<RequestContext<()>>,
+22 | | ) -> Result<HttpResponseOk<Ret>, HttpError> {
+   | |___________________________________________^
+
 error: endpoint handler functions must be async
   --> $DIR/bad_endpoint8.rs:20:1
    |

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -20,7 +20,10 @@ use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
 use serde_tokenstream::Error;
 use syn::spanned::Spanned;
-use syn::ItemFn;
+
+use syn_parsing::ItemFnForSignature;
+
+mod syn_parsing;
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
@@ -54,20 +57,14 @@ struct Metadata {
 }
 
 const DROPSHOT: &str = "dropshot";
-
-fn usage(err_msg: &str, fn_name: &str) -> String {
-    format!(
-        "{}\nEndpoint handlers must have the following signature:
-    async fn {}(
+const USAGE: &str = "Endpoint handlers must have the following signature:
+    async fn(
         rqctx: std::sync::Arc<dropshot::RequestContext<MyContext>>,
         [query_params: Query<Q>,]
         [path_params: Path<P>,]
         [body_param: TypedBody<J>,]
         [body_param: UntypedBody<J>,]
-    ) -> Result<HttpResponse*, HttpError>",
-        err_msg, fn_name
-    )
-}
+    ) -> Result<HttpResponse*, HttpError>";
 
 /// This attribute transforms a handler function into a Dropshot endpoint
 /// suitable to be used as a parameter to
@@ -98,59 +95,72 @@ pub fn endpoint(
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     match do_endpoint(attr.into(), item.into()) {
-        Ok(result) => result.into(),
         Err(err) => err.to_compile_error().into(),
+        Ok((endpoint, errors)) => {
+            let compiler_errors =
+                errors.iter().map(|err| err.to_compile_error());
+
+            let output = quote! {
+                #endpoint
+                #( #compiler_errors )*
+            };
+
+            output.into()
+        }
     }
 }
 
 fn do_endpoint(
     attr: TokenStream,
     item: TokenStream,
-) -> Result<TokenStream, Error> {
+) -> Result<(TokenStream, Vec<Error>), Error> {
     let metadata = from_tokenstream::<Metadata>(&attr)?;
 
     let method = metadata.method.as_str();
     let path = metadata.path;
 
-    let ast: ItemFn = syn::parse2(item.clone())?;
+    let ast: ItemFnForSignature = syn::parse2(item.clone())?;
+
+    let mut errors = Vec::new();
 
     if ast.sig.constness.is_some() {
-        return Err(Error::new_spanned(
-            ast.sig.constness,
+        errors.push(Error::new_spanned(
+            &ast.sig.constness,
             "endpoint handlers may not be const functions",
         ));
     }
 
     if ast.sig.asyncness.is_none() {
-        return Err(Error::new_spanned(
-            ast.sig.fn_token,
+        errors.push(Error::new_spanned(
+            &ast.sig.fn_token,
             "endpoint handler functions must be async",
         ));
     }
 
     if ast.sig.unsafety.is_some() {
-        return Err(Error::new_spanned(
-            ast.sig.unsafety,
+        errors.push(Error::new_spanned(
+            &ast.sig.unsafety,
             "endpoint handlers may not be unsafe",
         ));
     }
 
     if ast.sig.abi.is_some() {
-        return Err(Error::new_spanned(
-            ast.sig.abi,
+        errors.push(Error::new_spanned(
+            &ast.sig.abi,
             "endpoint handler may not use an alternate ABI",
         ));
     }
 
     if !ast.sig.generics.params.is_empty() {
-        return Err(Error::new_spanned(
-            ast.sig.generics,
+        errors.push(Error::new_spanned(
+            &ast.sig.generics,
             "generics are not permitted for endpoint handlers",
         ));
     }
 
     if ast.sig.variadic.is_some() {
-        return Err(Error::new_spanned(ast.sig.variadic, "no language C here"));
+        errors
+            .push(Error::new_spanned(&ast.sig.variadic, "no language C here"));
     }
 
     let name = &ast.sig.ident;
@@ -195,26 +205,28 @@ fn do_endpoint(
 
     let dropshot = get_crate(metadata._dropshot_crate);
 
-    let first_arg = ast.sig.inputs.first().ok_or_else(|| {
-        Error::new_spanned(
-            (&ast.sig).into_token_stream(),
-            usage("Endpoint requires arguments", &name_str),
-        )
-    })?;
-    let first_arg_type = {
-        match first_arg {
-            syn::FnArg::Typed(syn::PatType {
-                attrs: _,
-                pat: _,
-                colon_token: _,
-                ty,
-            }) => ty,
-            _ => {
-                return Err(Error::new(
-                    first_arg.span(),
-                    usage("Expected a non-receiver argument", &name_str),
-                ));
-            }
+    let first_arg = match ast.sig.inputs.first() {
+        Some(syn::FnArg::Typed(syn::PatType {
+            attrs: _,
+            pat: _,
+            colon_token: _,
+            ty,
+        })) => quote! {
+                <#ty as #dropshot::RequestContextArgument>::Context
+        },
+        Some(first_arg @ syn::FnArg::Receiver(_)) => {
+            errors.push(Error::new(
+                first_arg.span(),
+                "Expected a non-receiver argument",
+            ));
+            quote! { () }
+        }
+        None => {
+            errors.push(Error::new(
+                ast.sig.paren_token.span,
+                "Endpoint requires arguments",
+            ));
+            quote! { () }
         }
     };
 
@@ -264,12 +276,13 @@ fn do_endpoint(
         })
         .collect::<Vec<_>>();
 
-    let ret_check = match ast.sig.output {
+    let ret_check = match &ast.sig.output {
         syn::ReturnType::Default => {
-            return Err(Error::new_spanned(
-                (&ast.sig).into_token_stream(),
-                usage("Endpoint must return a Result", &name_str),
+            errors.push(Error::new_spanned(
+                &ast.sig,
+                "Endpoint must return a Result",
             ));
+            quote! {}
         }
         syn::ReturnType::Type(_, ret_ty) => {
             let span = ret_ty.span();
@@ -332,13 +345,30 @@ fn do_endpoint(
         #visibility const #name: #name = #name {};
     };
 
+    let construct = if errors.is_empty() {
+        quote! {
+            #dropshot::ApiEndpoint::new(
+                #name_str.to_string(),
+                #name,
+                #dropshot::Method::#method_ident,
+                #path,
+            )
+            #description
+            #(#tags)*
+            #visible
+        }
+    } else {
+        quote! {
+            unreachable!()
+        }
+    };
+
     // The final TokenStream returned will have a few components that reference
     // `#name`, the name of the function to which this macro was applied...
     let stream = quote! {
         // ... type validation for parameter and return types
         #(#param_checks)*
         #ret_check
-
 
         // ... a struct type called `#name` that has no members
         #[allow(non_camel_case_types, missing_docs)]
@@ -352,27 +382,22 @@ fn do_endpoint(
         // ... an impl of `From<#name>` for ApiEndpoint that allows the constant
         // `#name` to be passed into `ApiDescription::register()`
         impl From<#name>
-            for #dropshot::ApiEndpoint<
-                <#first_arg_type as #dropshot::RequestContextArgument>::Context
-            >
+            for #dropshot::ApiEndpoint< #first_arg >
         {
             fn from(_: #name) -> Self {
                 #item
 
-                #dropshot::ApiEndpoint::new(
-                    #name_str.to_string(),
-                    #name,
-                    #dropshot::Method::#method_ident,
-                    #path,
-                )
-                #description
-                #(#tags)*
-                #visible
+                #construct
             }
         }
     };
 
-    Ok(stream)
+    // Prepend the usage message if any errors were detected.
+    if !errors.is_empty() {
+        errors.insert(0, Error::new_spanned(&ast.sig, USAGE));
+    }
+
+    Ok((stream, errors))
 }
 
 fn get_crate(var: Option<String>) -> TokenStream {
@@ -437,7 +462,7 @@ mod tests {
 
     #[test]
     fn test_endpoint_basic() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c"
@@ -449,7 +474,8 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        )
+        .unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<Arc<RequestContext<()> > as dropshot::RequestContextArgument>::Context) ;
@@ -514,12 +540,13 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
     fn test_endpoint_context_fully_qualified_names() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c"
@@ -531,7 +558,7 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        ).unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<std::sync::Arc<dropshot::RequestContext<()> > as dropshot::RequestContextArgument>::Context) ;
@@ -592,12 +619,13 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
     fn test_endpoint_with_query() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c"
@@ -611,7 +639,8 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        )
+        .unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<Arc<RequestContext<std::i32> > as dropshot::RequestContextArgument>::Context) ;
@@ -687,12 +716,13 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
     fn test_endpoint_pub_crate() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c"
@@ -706,7 +736,8 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        )
+        .unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<Arc<RequestContext<()> > as dropshot::RequestContextArgument>::Context) ;
@@ -782,12 +813,13 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
     fn test_endpoint_with_tags() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c",
@@ -800,7 +832,8 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        )
+        .unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<Arc<RequestContext<()> > as dropshot::RequestContextArgument>::Context) ;
@@ -867,12 +900,13 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
     fn test_endpoint_with_doc() {
-        let ret = do_endpoint(
+        let (item, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c"
@@ -885,7 +919,8 @@ mod tests {
                     Ok(())
                 }
             },
-        );
+        )
+        .unwrap();
         let expected = quote! {
             const _: fn() = || {
                 struct NeedRequestContext(<Arc<RequestContext<()> > as dropshot::RequestContextArgument>::Context) ;
@@ -952,7 +987,8 @@ mod tests {
             }
         };
 
-        assert_eq!(expected.to_string(), ret.unwrap().to_string());
+        assert!(errors.is_empty());
+        assert_eq!(expected.to_string(), item.to_string());
     }
 
     #[test]
@@ -1005,7 +1041,7 @@ mod tests {
 
     #[test]
     fn test_endpoint_not_async() {
-        let ret = do_endpoint(
+        let (_, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c",
@@ -1013,15 +1049,19 @@ mod tests {
             quote! {
                 fn handler_xyz(_rqctx: Arc<RequestContext>) {}
             },
-        );
+        )
+        .unwrap();
 
-        let msg = format!("{}", ret.err().unwrap());
-        assert_eq!("endpoint handler functions must be async", msg);
+        assert!(!errors.is_empty());
+        assert_eq!(
+            errors.get(1).map(ToString::to_string),
+            Some("endpoint handler functions must be async".to_string())
+        );
     }
 
     #[test]
     fn test_endpoint_bad_context_receiver() {
-        let ret = do_endpoint(
+        let (_, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c",
@@ -1029,18 +1069,19 @@ mod tests {
             quote! {
                 async fn handler_xyz(&self) {}
             },
-        );
+        )
+        .unwrap();
 
-        let msg = format!("{}", ret.err().unwrap());
+        assert!(!errors.is_empty());
         assert_eq!(
-            usage("Expected a non-receiver argument", "handler_xyz"),
-            msg
+            errors.get(1).map(ToString::to_string),
+            Some("Expected a non-receiver argument".to_string())
         );
     }
 
     #[test]
     fn test_endpoint_no_arguments() {
-        let ret = do_endpoint(
+        let (_, errors) = do_endpoint(
             quote! {
                 method = GET,
                 path = "/a/b/c",
@@ -1048,9 +1089,13 @@ mod tests {
             quote! {
                 async fn handler_xyz() {}
             },
-        );
+        )
+        .unwrap();
 
-        let msg = format!("{}", ret.err().unwrap());
-        assert_eq!(usage("Endpoint requires arguments", "handler_xyz"), msg);
+        assert!(!errors.is_empty());
+        assert_eq!(
+            errors.get(1).map(ToString::to_string),
+            Some("Endpoint requires arguments".to_string())
+        );
     }
 }

--- a/dropshot_endpoint/src/syn_parsing.rs
+++ b/dropshot_endpoint/src/syn_parsing.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Oxide Computer Company
+
+use syn::{
+    parse::{Parse, ParseStream},
+    Attribute, Signature, Visibility,
+};
+
+/// Represent an item without concern for its body which may (or may not)
+/// contain syntax errors.
+pub(crate) struct ItemFnForSignature {
+    pub attrs: Vec<Attribute>,
+    pub vis: Visibility,
+    pub sig: Signature,
+    pub _block: proc_macro2::TokenStream,
+}
+
+impl Parse for ItemFnForSignature {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let vis: Visibility = input.parse()?;
+        let sig: Signature = input.parse()?;
+        let block = input.parse()?;
+        Ok(ItemFnForSignature {
+            attrs,
+            vis,
+            sig,
+            _block: block,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::{Signature, Visibility};
+
+    use crate::syn_parsing::ItemFnForSignature;
+
+    #[test]
+    fn test_busted_function() {
+        let f = quote! {
+            fn foo(parameter: u32) -> u32 {
+                (void) printf("%s", "no language C here!");
+                return (0);
+            }
+        };
+        let ast: ItemFnForSignature = syn::parse2(f).unwrap();
+
+        let sig: Signature = syn::parse2(quote! {
+            fn foo(parameter: u32) -> u32
+        })
+        .unwrap();
+
+        assert!(ast.attrs.is_empty());
+        assert_eq!(ast.vis, Visibility::Inherited);
+        assert_eq!(ast.sig, sig);
+    }
+}


### PR DESCRIPTION
closes #134 

This restructures the `#[endpoint .. ]` macro so that it only fails in the case of some really busted input. Our goal is to do our level best to produce reasonable output in order to avoid confusing rust analyzer.

Note that this changed some of the error messages; I think these are largely improvements, but @davepacheco I'd love your opinion.

@jclulow if you're able to see if this resolves your issue that would be tremendously helpful. I played around on the latest RA, and while I was able to conjure up what you described, I'm not 100% convinced that this fixes it (i.e. and that perhaps I'm now just getting lucky). 