### PR TITLE
Add testing helper for DELETE requests

### DIFF
--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -614,6 +614,25 @@ pub async fn objects_post<S: Serialize + Debug, T: DeserializeOwned>(
 }
 
 /**
+ * Issues an HTTP DELETE to the specified object URL to delete an object.
+ */
+pub async fn object_delete<T: DeserializeOwned>(
+    client: &ClientTestContext,
+    object_url: &str,
+) -> T {
+    let mut response = client
+        .make_request_with_body(
+            Method::DELETE,
+            &object_url,
+            "".into(),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    read_json::<T>(&mut response).await
+}
+
+/**
  * Iterate a paginated collection.
  */
 pub async fn iter_collection<T: Clone + DeserializeOwned>(

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -18,8 +18,10 @@
 use dropshot::endpoint;
 use dropshot::test_util::read_json;
 use dropshot::test_util::read_string;
+use dropshot::test_util::object_delete;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
+use dropshot::HttpResponseDeleted;
 use dropshot::HttpResponseOk;
 use dropshot::Path;
 use dropshot::Query;
@@ -52,6 +54,7 @@ fn demo_api() -> ApiDescription<usize> {
     api.register(demo_handler_path_param_uuid).unwrap();
     api.register(demo_handler_path_param_u32).unwrap();
     api.register(demo_handler_untyped_body).unwrap();
+    api.register(demo_handler_delete).unwrap();
 
     /*
      * We don't need to exhaustively test these cases, as they're tested by unit
@@ -603,6 +606,20 @@ async fn test_untyped_body() {
 }
 
 /*
+ * Test delete request
+ */
+#[tokio::test]
+async fn test_delete_request() {
+    let api = demo_api();
+    let testctx = common::test_setup("test_delete_request", api);
+    let client = &testctx.client_testctx;
+
+    object_delete::<()>(&client, "/testing/delete").await;
+
+    testctx.teardown().await;
+}
+
+/*
  * Demo handler functions
  */
 
@@ -763,6 +780,16 @@ async fn demo_handler_path_param_impossible(
     path_params: Path<DemoPathImpossible>,
 ) -> Result<Response<Body>, HttpError> {
     http_echo(&path_params.into_inner())
+}
+
+#[endpoint {
+    method = DELETE,
+    path = "/testing/delete",
+}]
+async fn demo_handler_delete(
+    _rqctx: RequestCtx,
+) -> Result<HttpResponseDeleted, HttpError> {
+    Ok(HttpResponseDeleted())
 }
 
 fn http_echo<T: Serialize>(t: &T) -> Result<Response<Body>, HttpError> {


### PR DESCRIPTION
This introduces test_util.object_delete(), to go along with the existing test_util helpers. It's helpful for testing CRUD APIs.