### PR TITLE
Update dependencies and expected output

### DIFF
--- a/dropshot/tests/fail/bad_endpoint10.stderr
+++ b/dropshot/tests/fail/bad_endpoint10.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
-  --> $DIR/bad_endpoint10.rs:16:6
+  --> tests/fail/bad_endpoint10.rs:16:6
    |
 16 | ) -> Result<HttpResponseOk<()>, String> {
    |      ^^^^^^
@@ -8,12 +8,12 @@ error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
    |      required by this bound in `validate_result_error_type`
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint10.rs:14:10
+  --> tests/fail/bad_endpoint10.rs:14:10
    |
 14 | async fn bad_error_type(
    |          ^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+  ::: src/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
+54 |         FuncParams: Extractor + 'static,
    |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: Extractor` is not satisfied
-  --> $DIR/bad_endpoint3.rs:17:12
+  --> tests/fail/bad_endpoint3.rs:17:12
    |
 11 | / #[endpoint {
 12 | |     method = GET,
@@ -14,12 +14,12 @@ error[E0277]: the trait bound `String: Extractor` is not satisfied
    |              required by a bound in this
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
-  --> $DIR/bad_endpoint3.rs:15:10
+  --> tests/fail/bad_endpoint3.rs:15:10
    |
 15 | async fn bad_endpoint(
    |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+  ::: src/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
+54 |         FuncParams: Extractor + 'static,
    |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -1,23 +1,23 @@
 error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
-   --> $DIR/bad_endpoint4.rs:24:14
+   --> tests/fail/bad_endpoint4.rs:24:14
     |
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:48
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                                                ---------- required by this bound in `dropshot::Query`
 
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> $DIR/bad_endpoint4.rs:24:14
+   --> tests/fail/bad_endpoint4.rs:24:14
     |
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:29
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                             ---------------- required by this bound in `dropshot::Query`
     |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -1,12 +1,12 @@
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> $DIR/bad_endpoint5.rs:26:14
+   --> tests/fail/bad_endpoint5.rs:26:14
     |
 26  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+   ::: src/handler.rs:547:29
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     |                             ---------------- required by this bound in `dropshot::Query`
     |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> $DIR/bad_endpoint7.rs:25:13
+    --> tests/fail/bad_endpoint7.rs:25:13
      |
 25   | ) -> Result<HttpResponseOk<Ret>, HttpError> {
      |             ^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
      |
-    ::: $WORKSPACE/dropshot/src/handler.rs
+    ::: src/handler.rs:1216:43
      |
-     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+1216 | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
      |                                           --------- required by this bound in `HttpResponseOk`


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/dropshot/issues/138

This is the result of checking out main, and running:

```
$ cargo update
$ TRYBUILD=overwrite cargo test
```

I believe this implies the version of our dependencies may cause different compiler output.