### PR TITLE
Adds remote-address connection info to server

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...HEAD[Full list of co
 * https://github.com/oxidecomputer/dropshot/pull/105[#105] When generating an OpenAPI spec, Dropshot now uses references rather than inline schemas to represent request and response bodies.
 * https://github.com/oxidecomputer/dropshot/pull/103[#103] When the Dropshot server is dropped before having been shut down, Dropshot now attempts to gracefully shut down rather than panic.
 * https://github.com/oxidecomputer/dropshot/pull/110[#110] Wildcard paths are now supported. Consumers may take over routing (e.g. for file serving) by annotating a path component: `/static/{path:.*}`. The `path` member should then be of type `Vec<String>` and it will be filled in with all path components following `/static/`.
+* https://github.com/oxidecomputer/dropshot/pull/148[#148] Adds local/remote addresses to loggers, including those passed in the context to actual endpoint handlers. This fixes https://github.com/oxidecomputer/dropshot/issues/46[#46], allowing logs for a client to be correlated from connection to completion.
 
 === Breaking Changes
 

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -472,7 +472,11 @@ impl<C: ServerContext> Service<Request<Body>> for ServerRequestHandler<C> {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        Box::pin(http_request_handle_wrap(Arc::clone(&self.server), self.remote_addr, req))
+        Box::pin(http_request_handle_wrap(
+            Arc::clone(&self.server),
+            self.remote_addr,
+            req,
+        ))
     }
 }
 


### PR DESCRIPTION
- Reworks how a `hyper::Server` is created, to get access to the local
  address before starting the server itself. This allows it to be put
  into the key-value pairs for the server's logger, so they're printed
  on each subsequent message.
- Updates the internal connection/request handler types to get the
  remote address and store it in the logger passed to the request
  handling functions. The remote address is also printed on each
  subsequent log message.