### PR TITLE
panic in the face of type cycles

### DIFF
--- a/dropshot/src/type_util.rs
+++ b/dropshot/src/type_util.rs
@@ -144,8 +144,7 @@ fn type_resolve<'a>(
         if set.contains(ref_schema) {
             eprintln!("{:#?}", schema);
             eprintln!(
-                "consider #[schemars(rename = \"...\")] or \
-                 #[schemars(transparent)]"
+                "consider #[serde(rename = \"...\")] or #[serde(transparent)]"
             );
             panic!("type reference cycle detected");
         }

--- a/dropshot/src/type_util.rs
+++ b/dropshot/src/type_util.rs
@@ -4,6 +4,8 @@
  * Utility functions for working with JsonSchema types.
  */
 
+use std::collections::HashSet;
+
 use indexmap::IndexMap;
 use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec};
 
@@ -93,7 +95,7 @@ pub fn type_is_string_enum(
             object: None,
             reference: None,
             extensions: _,
-        }) if matches!(instance_type.as_ref(), InstanceType::Array) => {
+        }) if instance_type.as_ref() == &InstanceType::Array => {
             match array_validation.as_ref() {
                 schemars::schema::ArrayValidation {
                     items:
@@ -119,10 +121,11 @@ pub fn type_is_string_enum(
     }
 }
 
-pub fn type_resolve<'a>(
+fn type_resolve<'a>(
     mut schema: &'a Schema,
     dependencies: &'a IndexMap<String, Schema>,
 ) -> &'a Schema {
+    let mut set = HashSet::new();
     while let Schema::Object(SchemaObject {
         metadata: _,
         instance_type: None,
@@ -138,6 +141,15 @@ pub fn type_resolve<'a>(
         extensions: _,
     }) = schema
     {
+        if set.contains(ref_schema) {
+            eprintln!("{:#?}", schema);
+            eprintln!(
+                "consider #[schemars(rename = \"...\")] or \
+                 #[schemars(transparent)]"
+            );
+            panic!("type reference cycle detected");
+        }
+        set.insert(ref_schema);
         const PREFIX: &str = "#/components/schemas/";
         assert!(ref_schema.starts_with(PREFIX));
         schema = dependencies
@@ -145,4 +157,48 @@ pub fn type_resolve<'a>(
             .unwrap_or_else(|| panic!("invalid reference {}", ref_schema));
     }
     schema
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexMap;
+    use schemars::schema::{Schema, SchemaObject};
+
+    use super::type_resolve;
+
+    #[test]
+    #[should_panic(expected = "type reference cycle detected")]
+    fn test_reflexive_type() {
+        let name = "#/components/schemas/Selfie".to_string();
+        let schema = Schema::Object(SchemaObject {
+            reference: Some(name),
+            ..Default::default()
+        });
+
+        let mut dependencies = IndexMap::new();
+        dependencies.insert("Selfie".to_string(), schema.clone());
+        let schema_ref = &dependencies[0];
+
+        type_resolve(schema_ref, &dependencies);
+    }
+
+    #[test]
+    #[should_panic(expected = "type reference cycle detected")]
+    fn test_recursive_type() {
+        let jack_schema = Schema::Object(SchemaObject {
+            reference: Some("#/components/schemas/JohnJackson".to_string()),
+            ..Default::default()
+        });
+        let john_schema = Schema::Object(SchemaObject {
+            reference: Some("#/components/schemas/JackJohnson".to_string()),
+            ..Default::default()
+        });
+
+        let mut dependencies = IndexMap::new();
+        dependencies.insert("JackJohnson".to_string(), jack_schema);
+        dependencies.insert("JohnJackson".to_string(), john_schema);
+        let schema_ref = &dependencies[0];
+
+        type_resolve(schema_ref, &dependencies);
+    }
 }


### PR DESCRIPTION
Closes #150 

These can arise because the schemars ignores conflicting names and
doesn't use e.g. the mod to qualify the name when necessary. There are
other errors that can result from this such as overwritten types, but
this is the most acute at the moment.

@smklein I don't think this is a great solution, but it may actually be what we want. There [an issue](https://github.com/GREsau/schemars/issues/62) in schemars that describes the problem of name conflicts more generally. In this case, however, we actually don't want two types in the schema and `#[serde(transparent)]` does exactly what we want.

I'm not sure why serde (and schemars) don't do this automatically when they see `#[repr(transparent)]` but it may be that derive macros don't reliably see that attribute. See also https://github.com/serde-rs/serde/issues/1054