### PR TITLE
better handling of nullable

### DIFF
--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -155,6 +155,7 @@
             "in": "query",
             "name": "limit",
             "schema": {
+              "nullable": true,
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
               "format": "uint32",
@@ -166,6 +167,7 @@
             "in": "query",
             "name": "page_token",
             "schema": {
+              "nullable": true,
               "description": "Token returned by previous call to retreive the subsequent page",
               "type": "string"
             },
@@ -279,6 +281,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -319,6 +322,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -439,6 +443,7 @@
             }
           },
           "next_page": {
+            "nullable": true,
             "description": "token used to fetch the next page of results (if any)",
             "type": "string"
           }

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -163,6 +163,7 @@
             "in": "query",
             "name": "limit",
             "schema": {
+              "nullable": true,
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
               "format": "uint32",
@@ -174,6 +175,7 @@
             "in": "query",
             "name": "page_token",
             "schema": {
+              "nullable": true,
               "description": "Token returned by previous call to retreive the subsequent page",
               "type": "string"
             },
@@ -287,6 +289,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -327,6 +330,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -447,6 +451,7 @@
             }
           },
           "next_page": {
+            "nullable": true,
             "description": "token used to fetch the next page of results (if any)",
             "type": "string"
           }

--- a/dropshot/tests/test_openapi_old.json
+++ b/dropshot/tests/test_openapi_old.json
@@ -155,6 +155,7 @@
             "in": "query",
             "name": "limit",
             "schema": {
+              "nullable": true,
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
               "format": "uint32",
@@ -166,6 +167,7 @@
             "in": "query",
             "name": "page_token",
             "schema": {
+              "nullable": true,
               "description": "Token returned by previous call to retreive the subsequent page",
               "type": "string"
             },
@@ -279,6 +281,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -319,6 +322,7 @@
             "in": "query",
             "name": "xamot",
             "schema": {
+              "nullable": true,
               "type": "string"
             },
             "style": "form"
@@ -439,6 +443,7 @@
             }
           },
           "next_page": {
+            "nullable": true,
             "description": "token used to fetch the next page of results (if any)",
             "type": "string"
           }

--- a/dropshot/tests/test_pagination_schema.json
+++ b/dropshot/tests/test_pagination_schema.json
@@ -29,6 +29,7 @@
             "in": "query",
             "name": "limit",
             "schema": {
+              "nullable": true,
               "description": "Maximum number of items returned by a single call",
               "type": "integer",
               "format": "uint32",
@@ -40,6 +41,7 @@
             "in": "query",
             "name": "page_token",
             "schema": {
+              "nullable": true,
               "description": "Token returned by previous call to retreive the subsequent page",
               "type": "string"
             },
@@ -87,6 +89,7 @@
             }
           },
           "next_page": {
+            "nullable": true,
             "description": "token used to fetch the next page of results (if any)",
             "type": "string"
           }


### PR DESCRIPTION
It turns out schemars does a decent job of handling nullable... but only if we convert the generator to a `RootSchema`. This is an improvement on #152 after I spent time more time vibing with the schemars code.