### PR TITLE
use explicit carets in Cargo files to work around Dependabot

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -11,28 +11,32 @@ keywords = ["rest", "openapi", "async"]
 categories = ["network-programming", "web-programming::http-server"]
 
 [dependencies]
-async-trait = "0.1.51"
-base64 = "0.13.0"
-bytes = "1"
-futures = "0.3.1"
-hostname = "0.3.0"
-http = "0.2.0"
-indexmap = "1.0.0"
-openapiv3 = "0.5.0"
-paste = "1.0.0"
-percent-encoding = "2.1.0"
-proc-macro2 = "1.0.27"
-serde_json = "1.0.68"
-serde_urlencoded = "0.7.0"
-slog-async = "2.4.0"
-slog-bunyan = "2.2.0"
-slog-json = "2.4.0"
-slog-term = "2.5.0"
-syn = "1.0.73"
-toml = "0.5.6"
+#
+# Use explicit carets ("^") in the versions below in order to keep Dependabot
+# from updating them unnecessarily.
+#
+async-trait = "^0.1.24"
+base64 = "^0.13.0"
+bytes = "^1"
+futures = "^0.3.1"
+hostname = "^0.3.0"
+http = "^0.2.0"
+indexmap = "^1.0.0"
+openapiv3 = "^0.5.0"
+paste = "^1.0.0"
+percent-encoding = "^2.1.0"
+proc-macro2 = "^1.0.27"
+serde_json = "^1.0.64"
+serde_urlencoded = "^0.7.0"
+slog-async = "^2.4.0"
+slog-bunyan = "^2.2.0"
+slog-json = "^2.3.0"
+slog-term = "^2.5.0"
+syn = "^1.0.73"
+toml = "^0.5.6"
 
 [dependencies.chrono]
-version = "0.4.0"
+version = "^0.4.0"
 features = [ "serde" ]
 
 [dependencies.dropshot_endpoint]
@@ -40,39 +44,39 @@ version = "^0.5.2-dev"
 path = "../dropshot_endpoint"
 
 [dependencies.hyper]
-version = "0.14"
+version = "^0.14"
 features = [ "full" ]
 
 [dependencies.serde]
-version = "1.0.130"
+version = "^1.0.126"
 features = [ "derive" ]
 
 [dependencies.slog]
-version = "2.5.0"
+version = "^2.5.0"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.tokio]
-version = "1.0"
+version = "^1.0"
 features = [ "full" ]
 
 [dependencies.uuid]
-version = "0.8.0"
+version = "^0.8.0"
 features = [ "serde", "v4" ]
 
 [dependencies.schemars]
-version = "0.8.0"
+version = "^0.8.0"
 features = [ "uuid" ]
 
 [dev-dependencies]
-expectorate = "1.0.2"
-lazy_static = "1.4.0"
-libc = "0.2.104"
-mime_guess = "2.0.3"
-subprocess = "0.2.8"
+expectorate = "^1.0.2"
+lazy_static = "^1.4.0"
+libc = "^0.2.71"
+mime_guess = "^2.0.3"
+subprocess = "^0.2.4"
 # Version subsequent to 1.0.46 cause our "fail" tests to vary in the face of
 # minor, internal code changes. See dtolnay/trybuild#136.
 trybuild = "=1.0.46"
 
 [dev-dependencies.schemars]
-version = "0.8.0"
+version = "^0.8.0"
 features = [ "chrono", "uuid" ]

--- a/dropshot_endpoint/Cargo.toml
+++ b/dropshot_endpoint/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-serde_tokenstream = "0.1.0"
+serde_tokenstream = "^0.1.0"
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
[When Cargo looks at dependency semver strings, it treats strings with no operator as having an implicit leading caret.](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)  However, Dependabot seems not to treat it this way, leading to the problems I mentioned in #156.

This change adds an explicit caret to all of our implicit caret dependencies.  I also went back and undid the recent Cargo.toml changes that Dependabot made.  This change should be safe because we tested these versions a week ago (and this PR will test them again).  The benefit is that it eases the constraint on consumers, since we accept a wider range of versions.

Going forward, the hope is that:

- For Dropshot users, it behaves like other libraries: Cargo.toml is only updated when we really depend on a newer version of something or when a semver-incompatible dependency update comes out.  This allows consumers to use a range of versions.
- By using Dependabot (and working around this issue), we also get the benefit of finding out pretty quickly when dependency changes have broken Dropshot
- By checking in Cargo.lock, when we find out about such breakage, it's in a Dependabot PR, not because the "main" branch build has broken.

I'm not totally sure whether this will work.  I'm going by a few data points from #156 and dependabot/dependabot-core#4009.  But this is pretty low risk and easy to undo.