### PR TITLE
update test output for Rust 1.56

### DIFF
--- a/dropshot/tests/fail/bad_endpoint10.stderr
+++ b/dropshot/tests/fail/bad_endpoint10.stderr
@@ -2,10 +2,13 @@ error[E0271]: type mismatch resolving `<String as TypeEq>::This == HttpError`
   --> $DIR/bad_endpoint10.rs:16:6
    |
 16 | ) -> Result<HttpResponseOk<()>, String> {
-   |      ^^^^^^
-   |      |
-   |      expected struct `HttpError`, found struct `String`
-   |      required by this bound in `validate_result_error_type`
+   |      ^^^^^^ expected struct `HttpError`, found struct `String`
+   |
+note: required by a bound in `validate_result_error_type`
+  --> $DIR/bad_endpoint10.rs:16:6
+   |
+16 | ) -> Result<HttpResponseOk<()>, String> {
+   |      ^^^^^^ required by this bound in `validate_result_error_type`
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
   --> $DIR/bad_endpoint10.rs:14:10
@@ -13,7 +16,8 @@ error[E0277]: the trait bound `fn(Arc<RequestContext<()>>) -> impl Future {<impl
 14 | async fn bad_error_type(
    |          ^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>) -> impl Future {<impl From<bad_error_type> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_error_type}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+note: required by a bound in `ApiEndpoint::<Context>::new`
+  --> $DIR/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
-   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
+54 |         FuncParams: Extractor + 'static,
+   |                                 ^^^^^^^ required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -1,17 +1,21 @@
 error[E0277]: the trait bound `String: Extractor` is not satisfied
   --> $DIR/bad_endpoint3.rs:17:12
    |
+17 |     param: String,
+   |            ^^^^^^ the trait `Extractor` is not implemented for `String`
+   |
+note: required by a bound in `need_extractor`
+  --> $DIR/bad_endpoint3.rs:11:1
+   |
 11 | / #[endpoint {
 12 | |     method = GET,
 13 | |     path = "/test",
 14 | | }]
-   | |__- required by this bound in `need_extractor`
+   | |__^ required by this bound in `need_extractor`
 ...
 17 |       param: String,
-   |              ^^^^^^
-   |              |
-   |              the trait `Extractor` is not implemented for `String`
-   |              required by a bound in this
+   |              ------ required by a bound in this
+   = note: this error originates in the attribute macro `endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
   --> $DIR/bad_endpoint3.rs:15:10
@@ -19,7 +23,8 @@ error[E0277]: the trait bound `fn(Arc<RequestContext<()>>, String) -> impl Futur
 15 | async fn bad_endpoint(
    |          ^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for `fn(Arc<RequestContext<()>>, String) -> impl Future {<impl From<bad_endpoint> for ApiEndpoint<<Arc<RequestContext<()>> as RequestContextArgument>::Context>>::from::bad_endpoint}`
    |
-  ::: $WORKSPACE/dropshot/src/api_description.rs
+note: required by a bound in `ApiEndpoint::<Context>::new`
+  --> $DIR/api_description.rs:54:33
    |
-   |         FuncParams: Extractor + 'static,
-   |                                 ------- required by this bound in `ApiEndpoint::<Context>::new`
+54 |         FuncParams: Extractor + 'static,
+   |                                 ^^^^^^^ required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -4,10 +4,11 @@ error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfi
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
+note: required by a bound in `dropshot::Query`
+   --> $DIR/handler.rs:547:48
     |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                                                ---------- required by this bound in `dropshot::Query`
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                                                ^^^^^^^^^^ required by this bound in `dropshot::Query`
 
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
    --> $DIR/bad_endpoint4.rs:24:14
@@ -15,9 +16,9 @@ error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>
 24  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                             ---------------- required by this bound in `dropshot::Query`
-    |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
+note: required by a bound in `dropshot::Query`
+   --> $DIR/handler.rs:547:29
+    |
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>
 26  |     _params: Query<QueryParams>,
     |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
     |
-   ::: $WORKSPACE/dropshot/src/handler.rs
-    |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                             ---------------- required by this bound in `dropshot::Query`
-    |
     = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
+note: required by a bound in `dropshot::Query`
+   --> $DIR/handler.rs:547:29
+    |
+547 | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+    |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
 25   | ) -> Result<HttpResponseOk<Ret>, HttpError> {
      |             ^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
      |
-    ::: $WORKSPACE/dropshot/src/handler.rs
+note: required by a bound in `HttpResponseOk`
+    --> $DIR/handler.rs:1216:43
      |
-     | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
-     |                                           --------- required by this bound in `HttpResponseOk`
+1216 | pub struct HttpResponseOk<T: JsonSchema + Serialize + Send + Sync + 'static>(
+     |                                           ^^^^^^^^^ required by this bound in `HttpResponseOk`


### PR DESCRIPTION
Prior to this, the tests passed on 1.55.  On 1.56, I was getting failures.  This change fixes that.