### PR TITLE
minor doc fixes

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -519,15 +519,15 @@
  *
  * Once in place, the probes can be seen via DTrace. For example, running:
  *
- * ```ignore
+ * ```text
  * $ cargo +nightly run --example basic --features usdt-probes
  * ```
  *
  * And making several requests to it with `curl`, we can see the DTrace
  * probes with an invocation like:
  *
- * ```ignore
- * # dtrace -Zq -n 'dropshot*:::request_* { printf("%s\n", copyinstr(arg0)); }'
+ * ```text
+ * ## dtrace -Zq -n 'dropshot*:::request_* { printf("%s\n", copyinstr(arg0)); }'
  * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","method":"GET","path":"/counter","query":null}}
  * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","status_code":200,"message":""}}
  * {"ok":{"id":"9050e30a-1ce3-4d6f-be1c-69a11c618800","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:41101","method":"PUT","path":"/counter","query":null}}


### PR DESCRIPTION
This fixes a warning during rust doc generation:

```
warning: could not parse code block as Rust code
   --> dropshot/src/lib.rs:529:4
    |
529 |    * ```ignore
    |  ____^
530 | |  * ## dtrace -Zq -n 'dropshot*:::request_* { printf("%s\n", copyinstr(arg0)); }'
531 | |  * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","method":"GET","path...
532 | |  * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","status_code":200,"m...
...   |
536 | |  * {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","status_code":204,"m...
537 | |  * ```
    | |______^
    |
    = note: `#[warn(rustdoc::invalid_rust_codeblocks)]` on by default
help: `ignore` code blocks require valid Rust code for syntax highlighting; mark blocks that do not contain Rust code as text: ```text
   --> dropshot/src/lib.rs:529:4
    |
529 |  * ```ignore
    |    ^^^
    = note: error from rustc: unterminated character literal
```

And this fixes an issue where the actual `dtrace` invocation  was hidden because the line starts with a `#`. I discovered by looking at the rustdoc source that `##` means "don't ignore, but turn me into a single `#`".