### PR TITLE
Add `object_update` fn to `test_utils`

### DIFF
--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -620,6 +620,21 @@ pub async fn objects_post<S: Serialize + Debug, T: DeserializeOwned>(
 }
 
 /**
+ * Issues an HTTP PUT to the specified collection URL to update an object.
+ */
+pub async fn object_update<S: Serialize + Debug, T: DeserializeOwned>(
+    client: &ClientTestContext,
+    object_url: &str,
+    input: S,
+    status: StatusCode,
+) {
+    client
+        .make_request(Method::PUT, &object_url, Some(input), status)
+        .await
+        .unwrap();
+}
+
+/**
  * Issues an HTTP DELETE to the specified object URL to delete an object.
  */
 pub async fn object_delete(client: &ClientTestContext, object_url: &str) {

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -622,7 +622,7 @@ pub async fn objects_post<S: Serialize + Debug, T: DeserializeOwned>(
 /**
  * Issues an HTTP PUT to the specified collection URL to update an object.
  */
-pub async fn object_update<S: Serialize + Debug, T: DeserializeOwned>(
+pub async fn object_put<S: Serialize + Debug, T: DeserializeOwned>(
     client: &ClientTestContext,
     object_url: &str,
     input: S,


### PR DESCRIPTION
Adds an `update` option to the suite of `objects` helpers. The only real different here is I've passed the `status` as a param because PUTs could result in 200 or 204 on success. 