### PR TITLE
Export ExtractorMetadata so consumers can impl Extractor

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -614,6 +614,7 @@ pub use config::ConfigDropshot;
 pub use error::HttpError;
 pub use error::HttpErrorResponseBody;
 pub use handler::Extractor;
+pub use handler::ExtractorMetadata;
 pub use handler::HttpResponse;
 pub use handler::HttpResponseAccepted;
 pub use handler::HttpResponseCreated;


### PR DESCRIPTION
You need `ExtractorMetadata` in order to be able to implement `Extractor`, e.g., if you want to write your own Cookies extractor.

https://github.com/oxidecomputer/dropshot/blob/61439b8b3ba84ff365b61d59f45254b8326a5012/dropshot/src/handler.rs#L179-L188