### PR TITLE
ClientTestContext could expose client and log

### DIFF
--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -48,11 +48,11 @@ const ALLOWED_HEADER_NAMES: [&str; 4] =
  */
 pub struct ClientTestContext {
     /** actual bind address of the HTTP server under test */
-    bind_address: SocketAddr,
+    pub bind_address: SocketAddr,
     /** HTTP client, used for making requests against the test server */
-    client: Client<HttpConnector>,
+    pub client: Client<HttpConnector>,
     /** logger for the test suite HTTP client */
-    client_log: Logger,
+    pub client_log: Logger,
 }
 
 impl ClientTestContext {


### PR DESCRIPTION
These fields were initially private to avoid being part of an API.  Exposing them publicly makes it much easier to prototype things like #165 outside of Dropshot (as in oxidecomputer/omicron#403).  We're still pre-1.0 and it's not a big deal to break the API if we want to remove this later, especially since even fewer consumers probably use this interface than use Dropshot.