### PR TITLE
we are inadvertently generating OpenAPI documents with wildcard path parameters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.6.0\...HEAD[Full list of commits]
 
+=== Breaking Changes
+
+* https://github.com/oxidecomputer/dropshot/pull/197[#197] Endpoints using wildcard path params (i.e. those using the `/foo/{bar:.*}` syntax) previously could be included in OpenAPI output albeit in a form that was invalid. Specifying a wildcard path **without** also specifying `unpublished = true` is now a **compile-time error**.
+
 == 0.6.0 (released 2021-11-18)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...v0.6.0[Full list of commits]

--- a/dropshot/tests/fail/bad_endpoint14.rs
+++ b/dropshot/tests/fail/bad_endpoint14.rs
@@ -1,0 +1,30 @@
+// Copyright 2021 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Path;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(JsonSchema, Deserialize)]
+struct PathParams {
+    stuff: Vec<String>,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/assets/{stuff:.*}",
+}]
+async fn must_be_unpublished(
+    _: Arc<RequestContext<()>>,
+    _: Path<PathParams>,
+) -> Result<HttpResponseOk<String>, HttpError> {
+    panic!()
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint14.stderr
+++ b/dropshot/tests/fail/bad_endpoint14.stderr
@@ -1,0 +1,6 @@
+error: paths that contain a wildcard match must include 'unpublished = true'
+  --> tests/fail/bad_endpoint14.rs:20:5
+   |
+20 | /     method = GET,
+21 | |     path = "/assets/{stuff:.*}",
+   | |________________________________^

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -10,8 +10,6 @@
  */
 #![allow(clippy::style)]
 
-extern crate proc_macro;
-
 use proc_macro2::TokenStream;
 use quote::format_ident;
 use quote::quote;
@@ -395,6 +393,14 @@ fn do_endpoint(
     // Prepend the usage message if any errors were detected.
     if !errors.is_empty() {
         errors.insert(0, Error::new_spanned(&ast.sig, USAGE));
+    }
+
+    if path.contains(":.*}") && metadata.unpublished != Some(true) {
+        errors.push(Error::new_spanned(
+            &attr,
+            "paths that contain a wildcard match must include 'unpublished = \
+             true'",
+        ));
     }
 
     Ok((stream, errors))


### PR DESCRIPTION
@smklein discovered that 1. dropshot silently allows the inclusion of wildcard paths in the OpenAPI output albeit in an invalid form and 2. this leads to progenitor getting very confused.

This PR makes a wildcard path that does not specify `unpublished = true` a compile error. There's not much else we can do here as OpenAPI doesn't allow path parameters to include '/'. I considered having `unpublished = true` be implicit with wildcard path params, but that seems more confusing than a compiler error with a clear direction.