### PR TITLE
Fix conflation of () which serializes to the JSON value `null` and a return that produces no content

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@ https://github.com/oxidecomputer/dropshot/compare/v0.6.0\...HEAD[Full list of co
 
 * https://github.com/oxidecomputer/dropshot/pull/197[#197] Endpoints using wildcard path params (i.e. those using the `/foo/{bar:.*}` syntax) previously could be included in OpenAPI output albeit in a form that was invalid. Specifying a wildcard path **without** also specifying `unpublished = true` is now a **compile-time error**.
 
+=== Other notable changes
+
+* https://github.com/oxidecomputer/dropshot/pull/198[#198] Responses that used `()` (the unit type) as their `Body` type parameter previously (and inaccurately) were represented in OpenAPI as an empty `responseBody`. They are now more accurately represented as a body whose value is `null` (4 bytes). We encourage those use cases to instead use either `HttpResponseUpdatedNoContent` or `HttpResponseDeleted` both of which have empty response bodies. If there are other situations where you would like a response type with no body, please file an issue.
+
 == 0.6.0 (released 2021-11-18)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.5.1\...v0.6.0[Full list of commits]

--- a/dropshot/src/from_map.rs
+++ b/dropshot/src/from_map.rs
@@ -475,6 +475,8 @@ mod test {
 
     #[test]
     fn test_deep() {
+        #![allow(dead_code)]
+
         #[derive(Deserialize, Debug)]
         struct A {
             b: B,
@@ -494,6 +496,8 @@ mod test {
     }
     #[test]
     fn test_missing_data1() {
+        #![allow(dead_code)]
+
         #[derive(Deserialize, Debug)]
         struct A {
             aaa: String,
@@ -513,6 +517,8 @@ mod test {
     }
     #[test]
     fn test_missing_data2() {
+        #![allow(dead_code)]
+
         #[derive(Deserialize, Debug)]
         struct A {
             aaa: String,
@@ -576,6 +582,8 @@ mod test {
     }
     #[test]
     fn wherefore_art_thou_a_valid_sequence_when_in_fact_you_are_a_lone_value() {
+        #![allow(dead_code)]
+
         #[derive(Deserialize, Debug)]
         struct A {
             b: Vec<String>,

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -1232,7 +1232,7 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> From<HttpResponseOk<T>>
 }
 
 /**
- * An "empty" type used to represent responses that have no associatd data
+ * An "empty" type used to represent responses that have no associated data
  * payload.
  */
 #[derive(Serialize)]

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -1232,13 +1232,36 @@ impl<T: JsonSchema + Serialize + Send + Sync + 'static> From<HttpResponseOk<T>>
 }
 
 /**
+ * An "empty" type used to represent responses that have no associatd data
+ * payload.
+ */
+#[derive(Serialize)]
+pub struct Empty;
+
+impl JsonSchema for Empty {
+    fn schema_name() -> String {
+        "Empty".to_string()
+    }
+
+    fn json_schema(
+        _: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        schemars::schema::Schema::Bool(false)
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
+/**
  * `HttpResponseDeleted` represents an HTTP 204 "No Content" response, intended
  * for use when an API operation has successfully deleted an object.
  */
 pub struct HttpResponseDeleted();
 
 impl HttpTypedResponse for HttpResponseDeleted {
-    type Body = ();
+    type Body = Empty;
     const STATUS_CODE: StatusCode = StatusCode::NO_CONTENT;
     const DESCRIPTION: &'static str = "successful deletion";
 }
@@ -1256,8 +1279,9 @@ impl From<HttpResponseDeleted> for HttpHandlerResult {
  * has nothing to return.
  */
 pub struct HttpResponseUpdatedNoContent();
+
 impl HttpTypedResponse for HttpResponseUpdatedNoContent {
-    type Body = ();
+    type Body = Empty;
     const STATUS_CODE: StatusCode = StatusCode::NO_CONTENT;
     const DESCRIPTION: &'static str = "resource updated";
 }

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -1311,7 +1311,6 @@ mod test {
         api_description::ApiEndpointParameterMetadata, ApiEndpointParameter,
         ApiEndpointParameterLocation, PaginationParams,
     };
-    use hyper::body::HttpBody;
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 

--- a/dropshot/src/pagination.rs
+++ b/dropshot/src/pagination.rs
@@ -644,6 +644,7 @@ mod test {
         }
 
         #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
         struct MyOptionalScanParams {
             the_field: Option<String>,
             only_good: Option<String>,
@@ -799,6 +800,7 @@ mod test {
          * precedence (and it's not clear how else this could work).
          */
         #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
         struct SketchyScanParams {
             page_token: String,
         }

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -20,8 +20,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -74,8 +74,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -94,8 +94,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -114,8 +114,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -243,7 +243,18 @@
         "operationId": "handler1",
         "responses": {
           "200": {
-            "description": "successful operation"
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -299,7 +310,18 @@
         },
         "responses": {
           "202": {
-            "description": "successfully enqueued operation"
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -331,6 +353,27 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          }
+        }
+      }
+    },
+    "/unit_please": {
+      "get": {
+        "operationId": "handler15",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -133,7 +133,7 @@ async fn handler6(
 async fn handler7(
     _rqctx: Arc<RequestContext<()>>,
     _dump: UntypedBody,
-) -> Result<HttpResponseOk<()>, HttpError> {
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     unimplemented!();
 }
 
@@ -195,7 +195,7 @@ struct NeverDuplicatedBodyNextLevel {
 async fn handler10(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedBodyTopLevel>,
-) -> Result<HttpResponseOk<()>, HttpError> {
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     unimplemented!();
 }
 
@@ -206,7 +206,7 @@ async fn handler10(
 async fn handler11(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedBodyTopLevel>,
-) -> Result<HttpResponseOk<()>, HttpError> {
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     unimplemented!();
 }
 
@@ -234,7 +234,7 @@ struct NeverDuplicatedNext {
 async fn handler12(
     _rqctx: Arc<RequestContext<()>>,
     _b: TypedBody<NeverDuplicatedTop>,
-) -> Result<HttpResponseOk<()>, HttpError> {
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     unimplemented!();
 }
 
@@ -266,6 +266,16 @@ async fn handler14(
     unimplemented!();
 }
 
+#[endpoint {
+    method = GET,
+    path = "/unit_please",
+}]
+async fn handler15(
+    _rqctx: Arc<RequestContext<()>>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    unimplemented!();
+}
+
 fn make_api() -> Result<ApiDescription<()>, String> {
     let mut api = ApiDescription::new();
     api.register(handler1)?;
@@ -282,6 +292,7 @@ fn make_api() -> Result<ApiDescription<()>, String> {
     api.register(handler12)?;
     api.register(handler13)?;
     api.register(handler14)?;
+    api.register(handler15)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -28,8 +28,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -82,8 +82,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -102,8 +102,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -122,8 +122,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation"
+          "204": {
+            "description": "resource updated"
           }
         }
       }
@@ -251,7 +251,18 @@
         "operationId": "handler1",
         "responses": {
           "200": {
-            "description": "successful operation"
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -307,7 +318,18 @@
         },
         "responses": {
           "202": {
-            "description": "successfully enqueued operation"
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -339,6 +361,27 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          }
+        }
+      }
+    },
+    "/unit_please": {
+      "get": {
+        "operationId": "handler15",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
We've used `()` as a sentinel value that means that an endpoint produces no response body. In fact, however, `()` serializes to the JSON value `null`. We ran into this in progenitor because some endpoints (inadvertently) produced `null` and would therefore deserialize into `()`, but the endpoints that produce no data can't be properly deserialized into `()` because there is no data.

This PR distinguishes between endpoints that return `()` and those that actually return nothing.

I could easily be persuaded that a better way to address this disparity would be simply to special case response bodies that are simply `()` and have them return zero-length response bodies. This may, however, be non-intuitive (in a different way that the proposed solution is non-intuitive, perhaps), *and* may be hard to reliably in all cases such as if one had a newtype alias for `()`.