### PR TITLE
correct invalid OpenAPI output and add validation

### DIFF
--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -1,0 +1,27 @@
+name: validate-openapi-spec
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-openapi-spec.yml
+      - dropshot/tests/test_openapi.json
+      - dropshot/tests/test_openapi_fuller.json
+  workflow_dispatch:
+    inputs:
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install our tools
+        shell: bash
+        run: |
+          npm install -g @apidevtools/swagger-cli
+      - name: Run validation
+        shell: bash
+        run: |
+          swagger-cli validate dropshot/tests/test_openapi.json &&
+          swagger-cli validate dropshot/tests/test_openapi_fuller.json
+

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -638,6 +638,17 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         );
                     }
                 }
+            } else {
+                // If no schema was specified, the response is hand-rolled. In
+                // this case we'll fall back to the default response type.
+                operation.responses.default =
+                    Some(openapiv3::ReferenceOr::Item(openapiv3::Response {
+                        // TODO: perhaps we should require even free-form
+                        // responses to have a description since it's required
+                        // by OpenAPI.
+                        description: "".to_string(),
+                        ..Default::default()
+                    }))
             }
 
             // Drop in the operation.

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -357,6 +357,16 @@
         }
       }
     },
+    "/too/smart/for/my/own/good": {
+      "get": {
+        "operationId": "handler16",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/unit_please": {
       "get": {
         "operationId": "handler15",

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -6,6 +6,7 @@ use dropshot::{
     HttpResponseUpdatedNoContent, PaginationParams, Path, Query,
     RequestContext, ResultsPage, TypedBody, UntypedBody,
 };
+use hyper::Body;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{io::Cursor, str::from_utf8, sync::Arc};
@@ -276,6 +277,16 @@ async fn handler15(
     unimplemented!();
 }
 
+#[endpoint {
+    method = GET,
+    path = "/too/smart/for/my/own/good",
+}]
+async fn handler16(
+    _rqctx: Arc<RequestContext<()>>,
+) -> Result<http::Response<Body>, HttpError> {
+    unimplemented!();
+}
+
 fn make_api() -> Result<ApiDescription<()>, String> {
     let mut api = ApiDescription::new();
     api.register(handler1)?;
@@ -292,6 +303,7 @@ fn make_api() -> Result<ApiDescription<()>, String> {
     api.register(handler12)?;
     api.register(handler13)?;
     api.register(handler14)?;
+    api.register(handler16)?;
     api.register(handler15)?;
     Ok(api)
 }

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -365,6 +365,16 @@
         }
       }
     },
+    "/too/smart/for/my/own/good": {
+      "get": {
+        "operationId": "handler16",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/unit_please": {
       "get": {
         "operationId": "handler15",


### PR DESCRIPTION
If a consumer specifies an endpoint whose return type is `Result<http::Response<hyper::Body>, HttpError>` we would generate OpenAPI like this:

```json
"responses": {}
```

This isn't valid OpenAPI 3.0.3:

> The Responses Object MUST contain at least one response code, and it SHOULD be the response for a successful operation call.
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responses-object

This PR changes the output to this:

```json
"responses": {
  "default": {
    "description": ""
  }
}
```

It's not a **lot** better, but at least it satisfied the `swagger-cli` tool. This PR also adds the execution of that tool to make sure the output of `test_openapi` is valid.

