### PR TITLE
create a minimal dropshot server example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +181,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "dropshot_endpoint",
+ "dropshot_endpoint 0.6.1-dev",
  "expectorate",
  "futures",
  "hostname",
@@ -208,8 +214,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "dropshot"
+version = "0.6.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot#7da41858adaf672d82582b09751bc6f730a62da1"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "dropshot_endpoint 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot)",
+ "futures",
+ "hostname",
+ "http",
+ "hyper",
+ "indexmap",
+ "openapiv3",
+ "paste",
+ "percent-encoding",
+ "proc-macro2",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-json",
+ "slog-term",
+ "syn",
+ "tokio",
+ "toml",
+ "usdt",
+ "uuid",
+]
+
+[[package]]
 name = "dropshot_endpoint"
 version = "0.6.1-dev"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
+name = "dropshot_endpoint"
+version = "0.6.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot#7da41858adaf672d82582b09751bc6f730a62da1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -585,6 +638,22 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minimal_example"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-term",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@
 # used for registering API handler functions.
 #
 [workspace]
-members = ["dropshot", "dropshot_endpoint" ]
+members = ["dropshot", "dropshot_endpoint", "minimal_example"]
 default-members = ["dropshot", "dropshot_endpoint" ]

--- a/minimal_example/Cargo.toml
+++ b/minimal_example/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "minimal_example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dropshot = { git = "https://github.com/oxidecomputer/dropshot" }
+slog = { version = "2.7" }
+slog-term = { version = "2.8" }
+slog-async = { version = "2.7" }
+anyhow = "1.0"
+schemars = { version = "0.8", features = [ "chrono", "uuid" ] }
+serde = { version = "1.0" }
+serde_json = { version = "1.0" }
+tokio = { version = "1.15", features = [ "full" ] }
+uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/minimal_example/README.md
+++ b/minimal_example/README.md
@@ -1,0 +1,30 @@
+This directory contains a minimal dropshot server example. Run with:
+
+```
+$ cargo run -p minimal_example
+   Compiling minimal_example v0.1.0
+    Finished dev [unoptimized + debuginfo] target(s) in 2.52s
+     Running `target/debug/minimal_example`
+Jan 07 13:57:09.848 INFO Server uuid is cc33de2e-2609-48d4-94ba-5929688a4416
+Jan 07 13:57:09.848 DEBG registered endpoint, path: /hello, method: GET, local_addr: 127.0.0.1:4567
+Jan 07 13:57:09.848 INFO listening, local_addr: 127.0.0.1:4567
+Jan 07 13:57:09.848 DEBG DTrace USDT probes compiled out, not registering, local_addr: 127.0.0.1:4567
+```
+
+It will expose a single endpoint at /hello:
+
+```
+$ curl -sq http://127.0.0.1:4567/hello | jq .
+{
+  "message": "Hello from dropshot!",
+  "uuid": "cc33de2e-2609-48d4-94ba-5929688a4416"
+}
+```
+
+Note that the request was logged:
+
+```
+Jan 07 13:57:23.969 INFO accepted connection, remote_addr: 127.0.0.1:45634, local_addr: 127.0.0.1:4567
+Jan 07 13:57:23.969 TRCE incoming request, uri: /hello, method: GET, req_id: ab18568d-d22f-40bc-8ef4-3b8bb1fe0738, remote_addr: 127.0.0.1:45634, local_addr: 127.0.0.1:4567
+Jan 07 13:57:23.969 INFO request completed, response_code: 200, uri: /hello, method: GET, req_id: ab18568d-d22f-40bc-8ef4-3b8bb1fe0738, remote_addr: 127.0.0.1:45634, local_addr: 127.0.0.1:4567
+```

--- a/minimal_example/src/main.rs
+++ b/minimal_example/src/main.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use slog::Drain;
+use dropshot::{endpoint, HttpResponseOk, HttpError, RequestContext, ConfigDropshot, ApiDescription, HttpServerStarter};
+use serde::Serialize;
+use schemars::JsonSchema;
+use uuid::Uuid;
+
+// Server context is available to every endpoint
+struct ServerContext {
+    uuid: Uuid,
+}
+
+// Types returned by endpoints should at minimum derive the following
+#[derive(Serialize, JsonSchema)]
+struct HelloWorld {
+    message: String,
+    uuid: Uuid,
+}
+
+// Endpoints are defined with a method and path, and minimally require the
+// request context argument.
+#[endpoint {
+    method = GET,
+    path = "/hello"
+}]
+async fn hello_world(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>
+) -> Result<HttpResponseOk<HelloWorld>, HttpError> {
+    let apictx = rqctx.context();
+
+    let return_value = HelloWorld {
+        message: "Hello from dropshot!".to_string(),
+        uuid: apictx.uuid,
+    };
+
+    Ok(HttpResponseOk(return_value))
+}
+
+// Endpoint registration is performed in this separate function so that map_err
+// (or let Err(s) like below) can be called only once - registration returns a
+// String error and this usually needs to be wrapped in something else.
+fn register_endpoints(
+    api_description: &mut ApiDescription<Arc<ServerContext>>
+) -> Result<(), String> {
+    api_description.register(hello_world)?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+
+    let log = slog::Logger::root(drain, slog::o!());
+
+    // ConfigDropshot defines general dropshot options.
+    let config = ConfigDropshot {
+        bind_address: "127.0.0.1:4567".parse()?,
+        ..Default::default()
+    };
+
+    // Register endpoints
+    let mut api_description = ApiDescription::<Arc<ServerContext>>::new();
+
+    if let Err(s) = register_endpoints(&mut api_description) {
+        anyhow::bail!("Error from register_endpoints: {}", s);
+    }
+
+    // Define the server context in an Arc. In this case our server context is
+    // simply a random UUID.
+    let ctx = Arc::new(ServerContext { uuid: Uuid::new_v4() });
+
+    slog::info!(&log, "Server uuid is {}", &ctx.uuid);
+
+    // Build the dropshot server
+    let http_server = HttpServerStarter::new(
+        &config,
+        api_description,
+        Arc::clone(&ctx),
+        &log,
+    )?;
+
+    // Run the dropshot server and await termination.
+    if let Err(s) = http_server.start().await {
+        anyhow::bail!("Error from start(): {}", s);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
this commit adds a minimal dropshot server example that users can refer
to when starting their own projects.