### PR TITLE
expose StatusCode type to consumers

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -653,5 +653,10 @@ pub use server::{HttpServer, HttpServerStarter};
 pub use handler::RequestContextArgument;
 pub use http::Method;
 
+/*
+ * Users constructing HttpError need the status code
+ */
+pub use http::StatusCode;
+
 extern crate dropshot_endpoint;
 pub use dropshot_endpoint::endpoint;


### PR DESCRIPTION
Users constructing dropshot::HttpError manually do not have access to
the StatusCode type, and instead of requiring them to keep their http
dependency in sync with dropshot expose dropshot's StatusCode. That way,
users can do:

    HttpError {
        status_code: dropshot::StatusCode::NOT_FOUND,
        ...
    }