### PR TITLE
allow consumers to add headers to responses

### DIFF
--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -761,6 +761,7 @@ async fn http_request_handle<C: ServerContext>(
         request: Arc::new(Mutex::new(request)),
         path_variables: lookup_result.variables,
         request_id: request_id.to_string(),
+        mutable_state: std::sync::Mutex::default(),
         log: request_log,
     };
     let mut response = lookup_result.handler.handle_request(rqctx).await?;

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -51,9 +51,12 @@ impl<'a> AllowedHeader<'a> {
     }
 }
 
+pub const TEST_HEADER_1: &str = "x-dropshot-test-header-1";
+pub const TEST_HEADER_2: &str = "x-dropshot-test-header-2";
+
 // List of allowed HTTP headers in responses.
 // Used to make sure we don't leak headers unexpectedly.
-const ALLOWED_HEADERS: [AllowedHeader<'static>; 6] = [
+const ALLOWED_HEADERS: [AllowedHeader<'static>; 7] = [
     AllowedHeader::new("content-length"),
     AllowedHeader::new("content-type"),
     AllowedHeader::new("date"),
@@ -62,7 +65,8 @@ const ALLOWED_HEADERS: [AllowedHeader<'static>; 6] = [
         name: "transfer-encoding",
         value: AllowedValue::OneOf(&["chunked"]),
     },
-    AllowedHeader::new("x-dropshot-test-header"),
+    AllowedHeader::new(TEST_HEADER_1),
+    AllowedHeader::new(TEST_HEADER_2),
 ];
 
 /**

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -51,9 +51,9 @@ impl<'a> AllowedHeader<'a> {
     }
 }
 
-// List of allowed HTTP headers in responsees.
+// List of allowed HTTP headers in responses.
 // Used to make sure we don't leak headers unexpectedly.
-const ALLOWED_HEADERS: [AllowedHeader<'static>; 5] = [
+const ALLOWED_HEADERS: [AllowedHeader<'static>; 6] = [
     AllowedHeader::new("content-length"),
     AllowedHeader::new("content-type"),
     AllowedHeader::new("date"),
@@ -62,6 +62,7 @@ const ALLOWED_HEADERS: [AllowedHeader<'static>; 5] = [
         name: "transfer-encoding",
         value: AllowedValue::OneOf(&["chunked"]),
     },
+    AllowedHeader::new("x-dropshot-test-header"),
 ];
 
 /**


### PR DESCRIPTION
This it to unblock @bnaecker 

@davepacheco I can see other ways of doing this (as we discussed); this seemed the least invasive, but I'm happy to weave this in more seamlessly if it seems objectionable.