### PR TITLE
add debug for better integrations with rust tracing

### DIFF
--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -87,6 +87,7 @@ pub type HttpHandlerResult = Result<Response<Body>, HttpError>;
  * overkill since it will only really be used by one thread at a time (at all,
  * let alone mutably) and there will never be contention on the Mutex.
  */
+#[derive(Debug)]
 pub struct RequestContext<Context: ServerContext> {
     /** shared server state */
     pub server: Arc<DropshotState<Context>>,
@@ -544,6 +545,7 @@ where
  * structure of yours that implements `serde::Deserialize`.  See this module's
  * documentation for more information.
  */
+#[derive(Debug)]
 pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     inner: QueryType,
 }
@@ -615,6 +617,7 @@ where
  * structure of yours that implements `serde::Deserialize`.  See this module's
  * documentation for more information.
  */
+#[derive(Debug)]
 pub struct Path<PathType: JsonSchema + Send + Sync> {
     inner: PathType,
 }
@@ -883,6 +886,7 @@ fn schema2parameters(
  * that implements `serde::Deserialize`.  See this module's documentation for
  * more information.
  */
+#[derive(Debug)]
 pub struct TypedBody<BodyType: JsonSchema + DeserializeOwned + Send + Sync> {
     inner: BodyType,
 }
@@ -968,6 +972,7 @@ where
  * `UntypedBody` is an extractor for reading in the contents of the HTTP request
  * body and making the raw bytes directly available to the consumer.
  */
+#[derive(Debug)]
 pub struct UntypedBody {
     content: Bytes,
 }

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -56,6 +56,7 @@ impl<T: 'static> ServerContext for T where T: Send + Sync {}
 /**
  * Stores shared state used by the Dropshot server.
  */
+#[derive(Debug)]
 pub struct DropshotState<C: ServerContext> {
     /** caller-specific state */
     pub private: C,
@@ -73,6 +74,7 @@ pub struct DropshotState<C: ServerContext> {
  * Stores static configuration associated with the server
  * TODO-cleanup merge with ConfigDropshot
  */
+#[derive(Debug)]
 pub struct ServerConfig {
     /** maximum allowed size of a request body */
     pub request_body_max_bytes: usize,


### PR DESCRIPTION
It would be nice if these structs implemented Debug for usage with the rust tracing libraries.

Let me know if you want custom implementations to hide information, but seems like it should be fine