### PR TITLE
make HttpTypedResponse pub use

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -633,6 +633,7 @@ pub use handler::HttpResponseDeleted;
 pub use handler::HttpResponseHeaders;
 pub use handler::HttpResponseOk;
 pub use handler::HttpResponseUpdatedNoContent;
+pub use handler::HttpTypedResponse;
 pub use handler::NoHeaders;
 pub use handler::Path;
 pub use handler::Query;

--- a/dropshot/tests/fail/bad_endpoint12.stderr
+++ b/dropshot/tests/fail/bad_endpoint12.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `String: dropshot::handler::HttpTypedResponse` is not satisfied
+error[E0277]: the trait bound `String: HttpTypedResponse` is not satisfied
   --> tests/fail/bad_endpoint12.rs:16:6
    |
 16 | ) -> Result<String, HttpError> {
-   |      ^^^^^^ the trait `dropshot::handler::HttpTypedResponse` is not implemented for `String`
+   |      ^^^^^^ the trait `HttpTypedResponse` is not implemented for `String`
    |
    = note: required because of the requirements on the impl of `HttpResponse` for `String`
 note: required because of the requirements on the impl of `ResultTrait` for `Result<String, HttpError>`


### PR DESCRIPTION
I am trying to refactor some code and clean up some stuff and making this public would allow me to pass in a generic places that must implement this trait, such that then I can pass HttpResponseOk{Etc} around as a generic