### PR TITLE
Allow use of usdt probes with stable rust

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.6.0\...HEAD[Full list of co
 * https://github.com/oxidecomputer/dropshot/pull/283[#283] Add support for response headers with the `HttpResponseHeaders` type. Headers may either be defined by a struct type parameter (in which case they appear in the OpenAPI output) or *ad-hoc* added via `HttpResponseHeaders::headers_mut()`.
 * https://github.com/oxidecomputer/dropshot/pull/286[#286] OpenAPI output includes descriptions of 4xx and 5xx error responses.
 * https://github.com/oxidecomputer/dropshot/pull/296[#296] `ApiDescription` includes a `tag_config` method to specify both predefined tags with descriptions and links as well as a tag policy to ensure that endpoints, for example, only use predefined tags or have at least one tag.
+* https://github.com/oxidecomputer/dropshot/pull/317[#317] Allow use of usdt probes with stable Rust. Dropshot consumers can build with USDT probes enabled on stable compilers >= 1.59 (except on MacOS).
 
 == 0.6.0 (released 2021-11-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "trybuild",
  "usdt",
  "uuid",
+ "version_check",
 ]
 
 [[package]]
@@ -1753,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -94,5 +94,10 @@ features = [ "dangerous_configuration" ]
 version = "0.8.8"
 features = [ "chrono", "uuid" ]
 
+# This is required for the build.rs script to check for an appropriate compiler
+# version so that `usdt` can be built on stable rust.
+[build-dependencies]
+version_check = "0.9.4"
+
 [features]
 usdt-probes = ["usdt/asm"]

--- a/dropshot/build.rs
+++ b/dropshot/build.rs
@@ -1,0 +1,27 @@
+// Copyright 2022 Oxide Computer Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    // Once asm_sym is stablilized, add an additional check so that those
+    // building on macos can use the stable toolchain with any hassle.
+    //
+    // A matching rust-cfg option named `usdt_stable_asm_sym` seems appropriate.
+}

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -507,9 +507,11 @@
  * See the [`RequestInfo`] and [`ResponseInfo`] types for a complete listing
  * of what's available.
  *
- * These probes are implemented via the [`usdt`] crate, and require a nightly
- * toolchain. As such, they're behind the feature flag `"usdt-probes"`. You
- * can build Dropshot with these probes via `cargo +nightly build --features usdt-probes`.
+ * These probes are implemented via the [`usdt`] crate. They require a nightly
+ * toolchain if built on MacOS (which requires the unstable `asm_sym` feature).
+ * Otherwise a stable compiler >= v1.59 is required in order to present the
+ * necessary features.  Given these constraints, usdt functionality is behind
+ * the feature flag `"usdt-probes"`.
  *
  * > *Important:* The probes are internally registered with the DTrace kernel
  * module, making them visible via `dtrace(1M)`. This is done when an `HttpServer`
@@ -547,9 +549,13 @@
  * The `usdt` crate requires nightly, enabled if our consumer is enabling
  * DTrace probes.
  */
-#![cfg_attr(feature = "usdt-probes", feature(asm))]
+#![cfg_attr(all(feature = "usdt-probes", not(usdt_stable_asm)), feature(asm))]
 #![cfg_attr(
-    all(feature = "usdt-probes", target_os = "macos"),
+    all(
+        feature = "usdt-probes",
+        target_os = "macos",
+        not(usdt_stable_asm_sym)
+    ),
     feature(asm_sym)
 )]
 


### PR DESCRIPTION
The `usdt` crate can be built with stable toolchains as of Rust v1.59,
except on MacOS, where the still-unstable `asm_sym` feature is needed.
Dropshot should do proper compiler version detection so it too can be
built with the stable toolchain when `usdt` is enabled.