### PR TITLE
Simplify test of TLS negotation failure

### DIFF
--- a/dropshot/tests/test_tls.rs
+++ b/dropshot/tests/test_tls.rs
@@ -209,59 +209,29 @@ async fn test_tls_aborted_negotiation() {
     let uri: hyper::Uri =
         format!("https://localhost:{}/", port).parse().unwrap();
 
-    // Make the client abort connections in interesting ways
-    let errors = [
-        // We don't send InappropriateMessage and InappropriateHandshakeMessage
-        // since it triggers a debug_assert on the client side, as it's not an
-        // expected error to be returned from the verifier.
-        rustls::Error::CorruptMessage,
-        rustls::Error::CorruptMessagePayload(
-            rustls::internal::msgs::enums::ContentType::Handshake,
-        ),
-        rustls::Error::NoCertificatesPresented,
-        rustls::Error::UnsupportedNameType,
-        rustls::Error::DecryptError,
-        rustls::Error::EncryptError,
-        rustls::Error::PeerIncompatibleError(
-            "test_tls_aborted_negotiation".to_string(),
-        ),
-        rustls::Error::PeerMisbehavedError(
-            "test_tls_aborted_negotiation".to_string(),
-        ),
-        rustls::Error::InvalidCertificateEncoding,
-        rustls::Error::InvalidCertificateSignatureType,
-        rustls::Error::InvalidCertificateSignature,
-        rustls::Error::InvalidCertificateData(
-            "test_tls_aborted_negotiation".to_string(),
-        ),
-        rustls::Error::General("test_tls_aborted_negotiation".to_string()),
-        rustls::Error::HandshakeNotComplete,
-        rustls::Error::PeerSentOversizedRecord,
-        rustls::Error::NoApplicationProtocol,
-    ];
-    for error in errors {
-        let verifier_called = Arc::new(AtomicUsize::new(0));
-        let verifier_called_clone = verifier_called.clone();
-        let cert_verifier = move |_end_entity: &rustls::Certificate,
-                                  _intermediates: &[rustls::Certificate],
-                                  _server_name: &rustls::ServerName,
-                                  _scts: &mut dyn Iterator<Item = &[u8]>,
-                                  _ocsp_response: &[u8],
-                                  _now: SystemTime|
-              -> Result<
-            rustls::client::ServerCertVerified,
-            rustls::Error,
-        > {
-            // Tracking to ensure this method was invoked
-            verifier_called_clone.fetch_add(1, Ordering::SeqCst);
+    // Configure a client that will fail to verify the server's cert, therefore
+    // aborting the connection partway through negotitation
+    let verifier_called = Arc::new(AtomicUsize::new(0));
+    let verifier_called_clone = verifier_called.clone();
+    let cert_verifier = move |_end_entity: &rustls::Certificate,
+                              _intermediates: &[rustls::Certificate],
+                              _server_name: &rustls::ServerName,
+                              _scts: &mut dyn Iterator<Item = &[u8]>,
+                              _ocsp_response: &[u8],
+                              _now: SystemTime|
+          -> Result<
+        rustls::client::ServerCertVerified,
+        rustls::Error,
+    > {
+        // Tracking to ensure this method was invoked
+        verifier_called_clone.fetch_add(1, Ordering::SeqCst);
 
-            Err(error.clone())
-        };
-        let client =
-            make_https_client(CertificateVerifier(Box::new(cert_verifier)));
-        client.get(uri.clone()).await.unwrap_err();
-        assert_eq!(verifier_called.load(Ordering::SeqCst), 1);
-    }
+        Err(rustls::Error::InvalidCertificateData("test error".to_string()))
+    };
+    let client =
+        make_https_client(CertificateVerifier(Box::new(cert_verifier)));
+    client.get(uri.clone()).await.unwrap_err();
+    assert_eq!(verifier_called.load(Ordering::SeqCst), 1);
 
     // Send a valid request and make sure it still works
     let client = make_https_client(make_pki_verifier(&certs));


### PR DESCRIPTION
We construct a client that will disconnect after failing to verify the
server's cert. There's no need to test returning a variety of error
types from the cert verification callback.

This works around a breaking change released found in upgrading rustls
from 0.20.4 to 0.20.5, although based on
https://github.com/rustls/rustls/issues/1041 it's possible 0.20.5 may
end up being yanked to avoid breaking other dependents similarly.