### PR TITLE
make usdt an optional dependency

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -60,6 +60,7 @@ features = [ "full" ]
 
 [dependencies.usdt]
 version = "0.3.2"
+optional = true
 default-features = false
 
 [dependencies.uuid]

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -578,6 +578,7 @@ pub(crate) struct ResponseInfo {
     message: String,
 }
 
+#[cfg(feature = "usdt-probes")]
 #[usdt::provider(provider = "dropshot")]
 mod probes {
     use crate::{RequestInfo, ResponseInfo};

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -162,25 +162,26 @@ impl<C: ServerContext> HttpServerStarter<C> {
         };
         info!(self.app_state.log, "listening");
 
-        let probe_registration = if cfg!(feature = "usdt-probes") {
-            match usdt::register_probes() {
-                Ok(_) => {
-                    debug!(
-                        self.app_state.log,
-                        "successfully registered DTrace USDT probes"
-                    );
-                    ProbeRegistration::Succeeded
-                }
-                Err(e) => {
-                    let msg = e.to_string();
-                    error!(
-                        self.app_state.log,
-                        "failed to register DTrace USDT probes: {}", msg
-                    );
-                    ProbeRegistration::Failed(msg)
-                }
+        #[cfg(feature = "usdt-probes")]
+        let probe_registration = match usdt::register_probes() {
+            Ok(_) => {
+                debug!(
+                    self.app_state.log,
+                    "successfully registered DTrace USDT probes"
+                );
+                ProbeRegistration::Succeeded
             }
-        } else {
+            Err(e) => {
+                let msg = e.to_string();
+                error!(
+                    self.app_state.log,
+                    "failed to register DTrace USDT probes: {}", msg
+                );
+                ProbeRegistration::Failed(msg)
+            }
+        };
+        #[cfg(not(feature = "usdt-probes"))]
+        let probe_registration = {
             debug!(
                 self.app_state.log,
                 "DTrace USDT probes compiled out, not registering"


### PR DESCRIPTION
I noticed that progenitor (which uses dropshot for testing... with some irony) was pulling in `usdt` as I tried to hunt down the source of a stale `uuid` v0.8 use.

I'm not quite sure this is right, so I'd appreciate a careful look.