### PR TITLE
Decode application/x-www-form-urlencoded bodies

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -17,6 +17,7 @@ use crate::Extractor;
 use crate::HttpErrorResponseBody;
 use crate::CONTENT_TYPE_JSON;
 use crate::CONTENT_TYPE_OCTET_STREAM;
+use crate::CONTENT_TYPE_URL_ENCODED;
 
 use http::Method;
 use http::StatusCode;
@@ -171,6 +172,8 @@ pub enum ApiEndpointBodyContentType {
     Bytes,
     /** application/json */
     Json,
+    /** application/x-www-form-urlencoded */
+    UrlEncoded,
 }
 
 impl ApiEndpointBodyContentType {
@@ -178,6 +181,7 @@ impl ApiEndpointBodyContentType {
         match self {
             ApiEndpointBodyContentType::Bytes => CONTENT_TYPE_OCTET_STREAM,
             ApiEndpointBodyContentType::Json => CONTENT_TYPE_JSON,
+            ApiEndpointBodyContentType::UrlEncoded => CONTENT_TYPE_URL_ENCODED,
         }
     }
 }

--- a/dropshot/src/http_util.rs
+++ b/dropshot/src/http_util.rs
@@ -20,6 +20,8 @@ pub const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
 pub const CONTENT_TYPE_JSON: &str = "application/json";
 /** MIME type for newline-delimited JSON data */
 pub const CONTENT_TYPE_NDJSON: &str = "application/x-ndjson";
+/** MIME type for form/urlencoded data */
+pub const CONTENT_TYPE_URL_ENCODED: &str = "application/x-www-form-urlencoded";
 
 /**
  * Reads the rest of the body from the request up to the given number of bytes.

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -234,8 +234,8 @@
  *   an instance of type `P`. `P` must implement `serde::Deserialize` and
  *   `schemars::JsonSchema`.
  * * [`TypedBody`]`<J>` extracts content from the request body by parsing the
- *   body as JSON and deserializing it into an instance of type `J`. `J` must
- *   implement `serde::Deserialize` and `schemars::JsonSchema`.
+ *   body as JSON (or form/url-encoded) and deserializing it into an instance
+ *   of type `J`. `J` must implement `serde::Deserialize` and `schemars::JsonSchema`.
  * * [`UntypedBody`] extracts the raw bytes of the request body.
  *
  * If the handler takes a `Query<Q>`, `Path<P>`, `TypedBody<J>`, or
@@ -651,6 +651,7 @@ pub use handler::UntypedBody;
 pub use http_util::CONTENT_TYPE_JSON;
 pub use http_util::CONTENT_TYPE_NDJSON;
 pub use http_util::CONTENT_TYPE_OCTET_STREAM;
+pub use http_util::CONTENT_TYPE_URL_ENCODED;
 pub use http_util::HEADER_REQUEST_ID;
 pub use logging::ConfigLogging;
 pub use logging::ConfigLoggingIfExists;

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::Ordering;
 use crate::api_description::ApiDescription;
 use crate::config::ConfigDropshot;
 use crate::error::HttpErrorResponseBody;
+use crate::http_util::CONTENT_TYPE_URL_ENCODED;
 use crate::logging::ConfigLogging;
 use crate::pagination::ResultsPage;
 use crate::server::{HttpServer, HttpServerStarter, ServerContext};
@@ -134,6 +135,26 @@ impl ClientTestContext {
         self.make_request_with_body(method, path, body, expected_status).await
     }
 
+    /**
+     * Execute an HTTP request against the test server and perform basic
+     * validation of the result like [`make_request`], but with the body
+     * form/url-encoded.
+     */
+    pub async fn make_request_url_encoded<RequestBodyType: Serialize + Debug>(
+        &self,
+        method: Method,
+        path: &str,
+        request_body: Option<RequestBodyType>,
+        expected_status: StatusCode,
+    ) -> Result<Response<Body>, HttpErrorResponseBody> {
+        let body: Body = match request_body {
+            None => Body::empty(),
+            Some(input) => serde_urlencoded::to_string(&input).unwrap().into(),
+        };
+
+        self.make_request_with_body_url_encoded(method, path, body, expected_status).await
+    }
+
     pub async fn make_request_no_body(
         &self,
         method: Method,
@@ -190,6 +211,23 @@ impl ClientTestContext {
         let uri = self.url(path);
         let request = Request::builder()
             .method(method)
+            .uri(uri)
+            .body(body)
+            .expect("attempted to construct invalid request");
+        self.make_request_with_request(request, expected_status).await
+    }
+
+    pub async fn make_request_with_body_url_encoded(
+        &self,
+        method: Method,
+        path: &str,
+        body: Body,
+        expected_status: StatusCode,
+    ) -> Result<Response<Body>, HttpErrorResponseBody> {
+        let uri = self.url(path);
+        let request = Request::builder()
+            .method(method)
+            .header(http::header::CONTENT_TYPE, CONTENT_TYPE_URL_ENCODED)
             .uri(uri)
             .body(body)
             .expect("attempted to construct invalid request");

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -247,7 +247,7 @@ async fn test_demo2json() {
         )
         .await
         .expect_err("expected failure");
-    assert!(error.message.starts_with("unable to parse body"));
+    assert!(error.message.starts_with("unable to parse JSON body"));
 
     /* Test case: invalid JSON */
     let error = testctx
@@ -260,7 +260,7 @@ async fn test_demo2json() {
         )
         .await
         .expect_err("expected failure");
-    assert!(error.message.starts_with("unable to parse body"));
+    assert!(error.message.starts_with("unable to parse JSON body"));
 
     /* Test case: bad type */
     let json_bad_type = "{ \"test1\": \"oops\", \"test2\": \"oops\" }";
@@ -275,7 +275,7 @@ async fn test_demo2json() {
         .await
         .expect_err("expected failure");
     assert!(error.message.starts_with(
-        "unable to parse body: invalid type: string \"oops\", expected u32"
+        "unable to parse JSON body: invalid type: string \"oops\", expected u32"
     ));
 
     testctx.teardown().await;
@@ -339,7 +339,7 @@ async fn test_demo3json() {
         )
         .await
         .expect_err("expected error");
-    assert!(error.message.starts_with("unable to parse body"));
+    assert!(error.message.starts_with("unable to parse JSON body"));
 
     testctx.teardown().await;
 }


### PR DESCRIPTION
This is useful for compatibility with protocols such as OAuth 2.0 and SAML, which frequently use this encoding for request bodies. It is possible to work around this by using `UntypedBody` and decoding at the application level, but handling it in dropshot seems safer and less error-prone.