### PR TITLE
allow for options method

### DIFF
--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -31,6 +31,7 @@ enum MethodType {
     PATCH,
     POST,
     PUT,
+    OPTIONS,
 }
 
 impl MethodType {
@@ -41,6 +42,7 @@ impl MethodType {
             MethodType::PATCH => "PATCH",
             MethodType::POST => "POST",
             MethodType::PUT => "PUT",
+            MethodType::OPTIONS => "OPTIONS",
         }
     }
 }
@@ -73,7 +75,7 @@ const USAGE: &str = "Endpoint handlers must have the following signature:
 /// ```ignore
 /// #[endpoint {
 ///     // Required fields
-///     method = { DELETE | GET | PATCH | POST | PUT },
+///     method = { DELETE | GET | OPTIONS | PATCH | POST | PUT },
 ///     path = "/path/name/with/{named}/{variables}",
 ///
 ///     // Optional tags for the API description


### PR DESCRIPTION
this is a method of fixing https://github.com/oxidecomputer/dropshot/issues/344 in that the user has to define options on endpoints

it would be nicer if somehow these were generated but since response headers can be defined programmatically on the fly I can't think of a way to generate them, so rather this turns on the ability to add OPTIONS as a method