### PR TITLE
Remove outdated doc comment referencing panic-on-drop behavior

### DIFF
--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -533,10 +533,6 @@ impl<C: ServerContext> Service<&TlsConn> for ServerConnectionHandler<C> {
 
 /**
  * A running Dropshot HTTP server.
- *
- * # Panics
- *
- * Panics if dropped without invoking `close`.
  */
 pub struct HttpServer<C: ServerContext> {
     probe_registration: ProbeRegistration,


### PR DESCRIPTION
The behavior when an `HttpServer` is dropped was changed in #103, making this comment no long correct.