### PR TITLE
Implement websocket support in Dropshot as an Extractor and #[channel] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -177,6 +186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,12 +215,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -248,6 +286,7 @@ dependencies = [
  "dropshot_endpoint",
  "expectorate",
  "futures",
+ "futures-util",
  "hostname",
  "http",
  "hyper",
@@ -269,6 +308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -278,8 +318,10 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite",
  "toml",
  "trybuild",
+ "tungstenite",
  "usdt",
  "uuid",
  "version_check",
@@ -458,6 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -939,7 +991,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -1312,10 +1364,32 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1624,6 +1698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1777,25 @@ dependencies = [
  "serde_json",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1 0.10.0",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]
@@ -1826,6 +1931,12 @@ dependencies = [
  "syn",
  "usdt-impl",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -27,6 +27,7 @@ rustls = "0.20.6"
 rustls-pemfile = "1.0.1"
 serde_json = "1.0.83"
 serde_urlencoded = "0.7.1"
+sha1 = "0.10.1"
 slog-async = "2.4.0"
 slog-bunyan = "2.4.0"
 slog-json = "2.6.1"
@@ -84,6 +85,10 @@ trybuild = "1.0.64"
 # Used by the https examples and tests
 pem = "1.1"
 rcgen = "0.9.3"
+# Used in a doc-test demonstrating the WebsocketUpgrade extractor.
+tungstenite = "0.17.3"
+tokio-tungstenite = "0.17.2"
+futures-util = "0.3.21"
 
 [dev-dependencies.rustls]
 version = "0.20.6"

--- a/dropshot/examples/websocket.rs
+++ b/dropshot/examples/websocket.rs
@@ -1,0 +1,95 @@
+// Copyright 2022 Oxide Computer Company
+/*!
+ * Example use of Dropshot with a websocket endpoint.
+ */
+
+use dropshot::channel;
+use dropshot::ApiDescription;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpServerStarter;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use futures_util::SinkExt;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::Arc;
+use tungstenite::protocol::Role;
+use tungstenite::Message;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    /*
+     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
+     * since it's available and won't expose this server outside the host.  We
+     * request port 0, which allows the operating system to pick any available
+     * port.
+     */
+    let config_dropshot: ConfigDropshot = Default::default();
+
+    /*
+     * For simplicity, we'll configure an "info"-level logger that writes to
+     * stderr assuming that it's a terminal.
+     */
+    let config_logging =
+        ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
+    let log = config_logging
+        .to_logger("example-basic")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    /*
+     * Build a description of the API.
+     */
+    let mut api = ApiDescription::new();
+    api.register(example_api_websocket_counter).unwrap();
+
+    /*
+     * Set up the server.
+     */
+    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+        .map_err(|error| format!("failed to create server: {}", error))?
+        .start();
+
+    /*
+     * Wait for the server to stop.  Note that there's not any code to shut down
+     * this server, so we should never get past this point.
+     */
+    server.await
+}
+
+/*
+ * HTTP API interface
+ */
+
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    start: Option<u8>,
+}
+
+/**
+ * An eternally-increasing sequence of bytes, wrapping on overflow, starting
+ * from the value given for the query parameter "start."
+ */
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/counter",
+}]
+async fn example_api_websocket_counter(
+    _rqctx: Arc<RequestContext<()>>,
+    upgraded: WebsocketConnection,
+    qp: Query<QueryParams>,
+) -> dropshot::WebsocketChannelResult {
+    let mut ws = tokio_tungstenite::WebSocketStream::from_raw_socket(
+        upgraded.into_inner(),
+        Role::Server,
+        None,
+    )
+    .await;
+    let mut count = qp.into_inner().start.unwrap_or(0);
+    while ws.send(Message::Binary(vec![count])).await.is_ok() {
+        count = count.wrapping_add(1);
+    }
+    Ok(())
+}

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -611,6 +611,7 @@ mod router;
 mod server;
 mod to_map;
 mod type_util;
+mod websocket;
 
 pub mod test_util;
 
@@ -624,6 +625,7 @@ pub use api_description::ApiEndpointParameter;
 pub use api_description::ApiEndpointParameterLocation;
 pub use api_description::ApiEndpointResponse;
 pub use api_description::EndpointTagPolicy;
+pub use api_description::ExtensionMode;
 pub use api_description::OpenApiDefinition;
 pub use api_description::TagConfig;
 pub use api_description::TagDetails;
@@ -664,6 +666,11 @@ pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
 pub use server::{HttpServer, HttpServerStarter};
+pub use websocket::WebsocketChannelResult;
+pub use websocket::WebsocketConnection;
+pub use websocket::WebsocketConnectionRaw;
+pub use websocket::WebsocketEndpointResult;
+pub use websocket::WebsocketUpgrade;
 
 /*
  * Users of the `endpoint` macro need the following macros:
@@ -672,4 +679,5 @@ pub use handler::RequestContextArgument;
 pub use http::Method;
 
 extern crate dropshot_endpoint;
+pub use dropshot_endpoint::channel;
 pub use dropshot_endpoint::endpoint;

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -822,7 +822,7 @@ mod test {
             summary: None,
             description: None,
             tags: vec![],
-            paginated: false,
+            extension_mode: Default::default(),
             visible: true,
         }
     }

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -1,0 +1,374 @@
+// Copyright 2022 Oxide Computer Company
+/*!
+ * Implements websocket upgrades as an Extractor for use in API route handler
+ * parameters to indicate that the given endpoint is meant to be upgraded to
+ * a websocket.
+ *
+ * This exposes a raw upgraded HTTP connection to a user-provided async future,
+ * which will be spawned to handle the incoming connection.
+ */
+
+use crate::api_description::ExtensionMode;
+use crate::{
+    ApiEndpointBodyContentType, Extractor, ExtractorMetadata, HttpError,
+    RequestContext, ServerContext,
+};
+use async_trait::async_trait;
+use http::header;
+use http::Response;
+use http::StatusCode;
+use hyper::upgrade::OnUpgrade;
+use hyper::Body;
+use schemars::JsonSchema;
+use serde_json::json;
+use sha1::{Digest, Sha1};
+use slog::Logger;
+use std::future::Future;
+use std::sync::Arc;
+
+/**
+ * WebsocketUpgrade is an Extractor used to upgrade and handle an HTTP request
+ * as a websocket when present in a Dropshot endpoint's function arguments.
+ *
+ * The consumer of this must call [WebsocketUpgrade::handle] for the connection
+ * to be upgraded. (This is done for you by `#[channel]`.)
+ */
+#[derive(Debug)]
+pub struct WebsocketUpgrade(Option<WebsocketUpgradeInner>);
+
+/**
+ * This is the return type of the websocket-handling future provided to
+ * [`dropshot_endpoint::channel`]
+ * (which in turn provides it to [WebsocketUpgrade::handle]).
+ */
+pub type WebsocketChannelResult =
+    Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+/**
+ * [WebsocketUpgrade::handle]'s return type.
+ * The `#[endpoint]` handler must return the value returned by
+ * [WebsocketUpgrade::handle]. (This is done for you by `#[channel]`.)
+ */
+pub type WebsocketEndpointResult = Result<Response<Body>, HttpError>;
+
+/**
+ * The upgraded connection passed as the second argument to the websocket
+ * handler function. [`WebsocketConnection::into_inner`] can be used to
+ * access the raw upgraded connection, for passing to any implementation
+ * of the websockets protocol.
+ */
+pub struct WebsocketConnection(WebsocketConnectionRaw);
+
+/// A type that implements [tokio::io::AsyncRead] + [tokio::io::AsyncWrite].
+pub type WebsocketConnectionRaw = hyper::upgrade::Upgraded;
+
+impl WebsocketConnection {
+    /// Consumes `self` and returns the held raw connection.
+    pub fn into_inner(self) -> WebsocketConnectionRaw {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct WebsocketUpgradeInner {
+    upgrade_fut: OnUpgrade,
+    accept_key: String,
+    route: String,
+    ws_log: Logger,
+}
+
+// Borrowed from tungstenite-0.17.3 (rather than taking a whole dependency for this one function)
+fn derive_accept_key(request_key: &[u8]) -> String {
+    // ... field is constructed by concatenating /key/ ...
+    // ... with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" (RFC 6455)
+    const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    let mut sha1 = Sha1::default();
+    sha1.update(request_key);
+    sha1.update(WS_GUID);
+    base64::encode(&sha1.finalize())
+}
+
+/**
+ * This `Extractor` implementation constructs an instance of `WebsocketUpgrade`
+ * from an HTTP request, and returns an error if the given request does not
+ * contain websocket upgrade headers.
+ */
+#[async_trait]
+impl Extractor for WebsocketUpgrade {
+    async fn from_request<Context: ServerContext>(
+        rqctx: Arc<RequestContext<Context>>,
+    ) -> Result<Self, HttpError> {
+        let request = &mut *rqctx.request.lock().await;
+
+        if !request
+            .headers()
+            .get(header::CONNECTION)
+            .and_then(|hv| hv.to_str().ok())
+            .map(|hv| {
+                hv.split(|c| c == ',' || c == ' ')
+                    .any(|vs| vs.eq_ignore_ascii_case("upgrade"))
+            })
+            .unwrap_or(false)
+        {
+            return Err(HttpError::for_bad_request(
+                None,
+                "expected connection upgrade".to_string(),
+            ));
+        }
+
+        if !request
+            .headers()
+            .get(header::UPGRADE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| {
+                v.split(|c| c == ',' || c == ' ')
+                    .any(|v| v.eq_ignore_ascii_case("websocket"))
+            })
+            .unwrap_or(false)
+        {
+            return Err(HttpError::for_bad_request(
+                None,
+                "unexpected protocol for upgrade".to_string(),
+            ));
+        }
+
+        if request
+            .headers()
+            .get(header::SEC_WEBSOCKET_VERSION)
+            .map(|v| v.as_bytes())
+            != Some(b"13")
+        {
+            return Err(HttpError::for_bad_request(
+                None,
+                "missing or invalid websocket version".to_string(),
+            ));
+        }
+
+        let accept_key = request
+            .headers()
+            .get(header::SEC_WEBSOCKET_KEY)
+            .map(|hv| hv.as_bytes())
+            .map(|key| derive_accept_key(key))
+            .ok_or_else(|| {
+                HttpError::for_bad_request(
+                    None,
+                    "missing websocket key".to_string(),
+                )
+            })?;
+
+        let route = request.uri().to_string();
+        let upgrade_fut = hyper::upgrade::on(request);
+        // note: this is just used in our wrapper in `handle`; if a user wants
+        // to slog in their future, they can obtain it from rqctx the same way
+        // they do in any other endpoint & let it get `move`d into the closure
+        let ws_log = rqctx.log.new(o!(
+            "upgrade" => "websocket".to_string(),
+        ));
+
+        Ok(Self(Some(WebsocketUpgradeInner {
+            upgrade_fut,
+            accept_key,
+            ws_log,
+            route,
+        })))
+    }
+
+    fn metadata(
+        _content_type: ApiEndpointBodyContentType,
+    ) -> ExtractorMetadata {
+        ExtractorMetadata {
+            parameters: vec![],
+            extension_mode: ExtensionMode::Websocket,
+        }
+    }
+}
+
+impl WebsocketUpgrade {
+    /**
+    * Upgrade the HTTP connection to a websocket and spawn a user-provided
+    * async handler to service it.
+    *
+    * This function's return value should be the basis of the return value of
+    * your endpoint's function, as it sends the headers to tell the HTTP
+    * client that we are accepting the upgrade.
+    *
+    * `handler` is a closure that accepts a [`WebsocketConnection`]
+    * and returns a future that will be spawned by this function,
+    * in which the `WebsocketConnection`'s inner `Upgraded` connection may be
+    * used with your choice of websocket-handling code operating over an
+    * [`tokio::io::AsyncRead`] + [`tokio::io::AsyncWrite`] type
+    * (e.g. `tokio_tungstenite`).
+    *
+    * ```
+      #[dropshot::endpoint { method = GET, path = "/my/ws/endpoint/{id}" }]
+      async fn my_ws_endpoint(
+          rqctx: std::sync::Arc<dropshot::RequestContext<()>>,
+          websock: dropshot::WebsocketUpgrade,
+          id: dropshot::Path<String>,
+      ) -> dropshot::WebsocketEndpointResult {
+          let logger = rqctx.log.new(slog::o!());
+          websock.handle(move |upgraded| async move {
+              slog::info!(logger, "Entered handler for ID {}", id.into_inner());
+              use futures_util::stream::StreamExt;
+              let mut ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(
+                  upgraded.into_inner(), tungstenite::protocol::Role::Server, None
+              ).await;
+              slog::info!(logger, "Received from websocket: {:?}", ws_stream.next().await);
+              Ok(())
+          })
+      }
+    * ```
+    *
+    * Note that as a consumer of this crate, you most likely do not want to
+    * call this function directly; rather, prefer to annotate your function
+    * with [`dropshot_endpoint::channel`] instead of `endpoint`.
+    */
+    pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+    where
+        C: FnOnce(WebsocketConnection) -> F + Send + 'static,
+        F: Future<Output = WebsocketChannelResult> + Send + 'static,
+    {
+        // we .take() here to tell Drop::drop that we handled the request.
+        match self.0.take() {
+            None => Err(HttpError::for_internal_error(
+                "Tried to handle websocket twice".to_string(),
+            )),
+            Some(WebsocketUpgradeInner {
+                upgrade_fut,
+                accept_key,
+                ws_log,
+                ..
+            }) => {
+                tokio::spawn(async move {
+                    match upgrade_fut.await {
+                        Ok(upgrade) => {
+                            match handler(WebsocketConnection(upgrade)).await {
+                                Ok(x) => Ok(x),
+                                Err(e) => {
+                                    error!(
+                                        ws_log,
+                                        "Error returned from handler: {:?}", e
+                                    );
+                                    Err(e)
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                ws_log,
+                                "Error upgrading connection: {:?}", e
+                            );
+                            Err(e.into())
+                        }
+                    }
+                });
+                Response::builder()
+                    .status(StatusCode::SWITCHING_PROTOCOLS)
+                    .header(header::CONNECTION, "Upgrade")
+                    .header(header::UPGRADE, "websocket")
+                    .header(header::SEC_WEBSOCKET_ACCEPT, accept_key)
+                    .body(Body::empty())
+                    .map_err(Into::into)
+            }
+        }
+    }
+}
+
+impl Drop for WebsocketUpgrade {
+    fn drop(&mut self) {
+        if let Some(inner) = self.0.take() {
+            debug!(
+                inner.ws_log,
+                "Didn't handle websocket in route {}", inner.route
+            );
+        }
+    }
+}
+
+// To indicate websocket usage by the endpoint to code generators (i.e. Progenitor)
+pub(crate) const WEBSOCKET_EXTENSION: &str = "x-dropshot-websocket";
+pub(crate) const WEBSOCKET_PARAM_SENTINEL: &str = "x-dropshot-websocket-param";
+
+impl JsonSchema for WebsocketUpgrade {
+    fn schema_name() -> String {
+        "WebsocketUpgrade".to_string()
+    }
+
+    fn json_schema(
+        _gen: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        let mut schema = schemars::schema::SchemaObject::default();
+        schema
+            .extensions
+            .insert(WEBSOCKET_PARAM_SENTINEL.to_string(), json!(true));
+        schemars::schema::Schema::Object(schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::router::HttpRouter;
+    use crate::server::{DropshotState, ServerConfig};
+    use crate::{Extractor, HttpError, RequestContext, WebsocketUpgrade};
+    use futures::lock::Mutex;
+    use http::Request;
+    use hyper::Body;
+    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn ws_upg_from_mock_rqctx() -> Result<WebsocketUpgrade, HttpError> {
+        let log = slog::Logger::root(slog::Discard, slog::o!()).new(slog::o!());
+        let fut = WebsocketUpgrade::from_request(Arc::new(RequestContext {
+            server: Arc::new(DropshotState {
+                private: (),
+                config: ServerConfig {
+                    request_body_max_bytes: 0,
+                    page_max_nitems: NonZeroU32::new(1).unwrap(),
+                    page_default_nitems: NonZeroU32::new(1).unwrap(),
+                },
+                router: HttpRouter::new(),
+                log: log.clone(),
+                local_addr: SocketAddr::new(
+                    IpAddr::V6(Ipv6Addr::LOCALHOST),
+                    8080,
+                ),
+                tls: false,
+            }),
+            request: Arc::new(Mutex::new(
+                Request::builder()
+                    .header(http::header::CONNECTION, "Upgrade")
+                    .header(http::header::UPGRADE, "websocket")
+                    .header(http::header::SEC_WEBSOCKET_VERSION, "13")
+                    .header(
+                        http::header::SEC_WEBSOCKET_KEY,
+                        "aGFjayB0aGUgcGxhbmV0IQ==",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )),
+            path_variables: Default::default(),
+            body_content_type: Default::default(),
+            request_id: "".to_string(),
+            log: log.clone(),
+        }));
+        tokio::time::timeout(Duration::from_secs(1), fut)
+            .await
+            .expect("Deadlocked in WebsocketUpgrade constructor")
+    }
+
+    #[tokio::test]
+    async fn test_ws_upg_task_is_spawned() {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        ws_upg_from_mock_rqctx()
+            .await
+            .unwrap()
+            .handle(move |_upgrade| async move { Ok(send.send(()).unwrap()) })
+            .unwrap();
+        // note: not a real connection, so we don't get our future's Ok, but we *do* spawn the task
+        let _ = tokio::time::timeout(Duration::from_secs(1), recv)
+            .await
+            .expect("Task not spawned or never completed");
+    }
+}

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -11,6 +11,7 @@ error[E0277]: the trait bound `String: Extractor` is not satisfied
              (T1,)
              TypedBody<BodyType>
              UntypedBody
+             WebsocketUpgrade
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_extractor`

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfi
               (T0, T1, T2, T3)
               (T0, T1, T2, T3, T4)
               (T0, T1, T2, T3, T4, T5)
-            and 145 others
+            and 146 others
 note: required by a bound in `dropshot::Query`
    --> src/handler.rs
     |

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -15,6 +15,7 @@
  * JSON body length)
  */
 
+use dropshot::channel;
 use dropshot::endpoint;
 use dropshot::test_util::object_delete;
 use dropshot::test_util::read_json;
@@ -32,7 +33,11 @@ use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
 use dropshot::UntypedBody;
+use dropshot::WebsocketChannelResult;
+use dropshot::WebsocketConnection;
 use dropshot::CONTENT_TYPE_JSON;
+use futures_util::SinkExt;
+use futures_util::StreamExt;
 use http::StatusCode;
 use hyper::Body;
 use hyper::Method;
@@ -41,6 +46,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
+use tokio_tungstenite::WebSocketStream;
+use tungstenite::protocol::Role;
+use tungstenite::Message;
 use uuid::Uuid;
 
 extern crate slog;
@@ -60,6 +68,7 @@ fn demo_api() -> ApiDescription<usize> {
     api.register(demo_handler_untyped_body).unwrap();
     api.register(demo_handler_delete).unwrap();
     api.register(demo_handler_headers).unwrap();
+    api.register(demo_handler_websocket).unwrap();
 
     /*
      * We don't need to exhaustively test these cases, as they're tested by unit
@@ -735,6 +744,28 @@ async fn test_header_request() {
 }
 
 /*
+ * The "test_demo_websocket" handler upgrades to a websocket and exchanges
+ * greetings with the client.
+ */
+#[tokio::test]
+async fn test_demo_websocket() {
+    let api = demo_api();
+    let testctx = common::test_setup("demo_websocket", api);
+
+    let path = format!(
+        "ws://{}/testing/websocket",
+        testctx.client_testctx.bind_address
+    );
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(path).await.unwrap();
+
+    ws.send(Message::Text("hello server".to_string())).await.unwrap();
+    let msg = ws.next().await.unwrap().unwrap();
+    assert_eq!(msg, Message::Text("hello client".to_string()));
+
+    testctx.teardown().await;
+}
+
+/*
  * Demo handler functions
  */
 
@@ -931,6 +962,27 @@ async fn demo_handler_headers(
     headers
         .append(TEST_HEADER_2, http::header::HeaderValue::from_static("howdy"));
     Ok(response)
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/testing/websocket"
+}]
+async fn demo_handler_websocket(
+    rqctx: RequestCtx,
+    upgraded: WebsocketConnection,
+) -> WebsocketChannelResult {
+    use futures_util::stream::StreamExt;
+    let mut ws_stream = WebSocketStream::from_raw_socket(
+        upgraded.into_inner(),
+        Role::Server,
+        None,
+    )
+    .await;
+    ws_stream.send(Message::Text("hello client".to_string())).await.unwrap();
+    let msg = ws_stream.next().await.unwrap().unwrap();
+    slog::info!(rqctx.log, "{}", msg);
+    Ok(())
 }
 
 fn http_echo<T: Serialize>(t: &T) -> Result<Response<Body>, HttpError> {


### PR DESCRIPTION
This allows endpoints meant for handling continuous websocket streams to be easily constructed by providing an async handler to an extractor parameter in the endpoint function definition.

This change also refactors the previous `paginated` bool to instead be a dedicated type describing whether an endpoint uses pagination or websockets Dropshot-specific extensions, aspirationally leaving room for describing any more extension modes we may add atop the basic OpenAPI.