### PR TITLE
update release tooling for cargo-release v0.21.1

### DIFF
--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -85,7 +85,7 @@ Here's how to cut a release.
 cargo install cargo-release
 ----
 +
-Make sure you have a compatible version.  These instructions were written for v0.21.1.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, [check the changelog to make sure it's compatible](https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md).
+Make sure you have a compatible version.  These instructions were written for v0.21.1.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md[check the changelog to make sure it's compatible].
 +
 **You should be able to just run:**
 +

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -85,25 +85,25 @@ Here's how to cut a release.
 cargo install cargo-release
 ----
 +
-If you're daring, just run:
+**You should be able to just run:**
 +
 [source,text]
 ----
-$ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND
+$ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv --execute RELEASE_KIND|NEW_VERSION
 ----
 +
 If you want to be extra careful, you can do this in a dry-run form.  First, check that the log output here looks right (and especially that you got the version number that you expected!):
 +
 [source,text]
 ----
-$ cargo release --dry-run --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND
+$ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND|NEW_VERSION
 ----
 +
-Now, run `cargo release` for real (i.e. no `--dry-run`), but without publishing to crates.io or pushing the git tags:
+Now, run `cargo release` for real (i.e. with `--execute`), but without publishing to crates.io or pushing the git tags:
 +
 [source,text]
 ----
-$ cargo release --skip-push --skip-publish --prev-tag-name=PREV_RELEASE_TAG -vv minor
+$ cargo release --execute --no-push --no-publish --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND|NEW_VERSION
 ----
 +
 Inspect the resulting commits and the new tags from above.  There should be four commits: one to each of "dropshot" and "dropshot_endpoint" that sets the version to the one you specified, and one that sets the version to the _next_ version.  For example, if the current version is 0.5.1 and you're publishing 0.5.2, the repo will start at 0.5.2-pre, you'll see one commit that sets it to 0.5.2, and then you'll see one that sets it to 0.5.3-pre.
@@ -120,7 +120,7 @@ and do the release again with the publish step:
 +
 [source,text]
 ----
-$ cargo release --skip-push --prev-tag-name=PREV_RELEASE_TAG -vv minor
+$ cargo release --execute --no-push --prev-tag-name=PREV_RELEASE_TAG -vv minor
 ----
 +
 At this point, the new crates should be published to crates.io.  Check and
@@ -140,8 +140,8 @@ We could automate more of this with a script that takes a commit, checks the Git
 
 === What if something goes wrong
 
-At the end of the day, the release is just a git tag and the crates.io publish.
+At the end of the day, the release is just a few commits that update the crate versions, a git tag, and the crates.io publish.
 
-If something went wrong prior to the crates.io publish, then you can `git reset` to the commit you started with, delete your local tag, and try again.  (If you followed the above steps, you won't have pushed any git tags, so there's nothing on GitHub to undo.)
+If something went wrong prior to the crates.io publish, then you can `git reset` your local clone to the commit you started with, delete your local tag, and try again.  (If you followed the above steps, you won't have pushed any git tags, so there's nothing on GitHub to undo.)
 
 If something went wrong after the crates.io publish, you could try to fix up the Git state to match what it should be.  Or you could yank the version you published, reset your local state, and try again.

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -85,6 +85,8 @@ Here's how to cut a release.
 cargo install cargo-release
 ----
 +
+Make sure you have a compatible version.  These instructions were written for v0.21.1.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, [check the changelog to make sure it's compatible](https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md).
++
 **You should be able to just run:**
 +
 [source,text]

--- a/dropshot_endpoint/release.toml
+++ b/dropshot_endpoint/release.toml
@@ -1,3 +1,3 @@
 # Overrides the cargo-release config file from the root of this repo.
 pre-release-replacements = []
-disable-tag = true
+tag = false

--- a/release.toml
+++ b/release.toml
@@ -19,4 +19,4 @@ tag-prefix=""
 dev-version = true
 dev-version-ext = "dev"
 allow-branch = [ "main" ]
-shared-versio = true
+shared-version = true

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,5 @@
 # This file is used by cargo-release.
+# This version is written for cargo-release 0.21.1.
 
 # Update the change log to reflect the new release and set us up for the next release.
 pre-release-replacements = [
@@ -10,9 +11,12 @@ pre-release-replacements = [
   {file="../CHANGELOG.adoc", search="// cargo-release: next header goes here \\(do not change this line\\)", replace="// cargo-release: next header goes here (do not change this line)\n\n== Unreleased changes (release date TBD)\n\nhttps://github.com/oxidecomputer/dropshot/compare/{{tag_name}}\\...HEAD[Full list of commits]", exactly=1},
 ]
 
-disable-push = true
+push = false
 pre-release-commit-message = "release {{crate_name}} {{version}}"
 post-release-commit-message = "starting {{crate_name}} {{next_version}} after releasing {{version}}"
 tag-message = "release {{crate_name}} {{version}}"
 tag-prefix=""
+dev-version = true
 dev-version-ext = "dev"
+allow-branch = [ "main" ]
+shared-versio = true

--- a/release.toml
+++ b/release.toml
@@ -12,11 +12,12 @@ pre-release-replacements = [
 ]
 
 push = false
-pre-release-commit-message = "release {{crate_name}} {{version}}"
-post-release-commit-message = "starting {{crate_name}} {{next_version}} after releasing {{version}}"
-tag-message = "release {{crate_name}} {{version}}"
+pre-release-commit-message = "release {{version}}"
+post-release-commit-message = "starting {{next_version}} after releasing {{version}}"
+tag-message = "release {{version}}"
 tag-prefix=""
 dev-version = true
 dev-version-ext = "dev"
 allow-branch = [ "main" ]
 shared-version = true
+consolidate-commits = true


### PR DESCRIPTION
The original release tooling was built for cargo-release 0.13.10.  There have been [a number of breaking changes since then](https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md), including to the config file format.  Since new contributors (or maintainers) are unlikely to install old versions of this tool, we should probably keep this up-to-date.