### PR TITLE
Expose way for request handlers to determine if the request came over HTTP or HTTPS.

### DIFF
--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -68,6 +68,8 @@ pub struct DropshotState<C: ServerContext> {
     pub log: Logger,
     /** bound local address for the server. */
     pub local_addr: SocketAddr,
+    /** are requests served over HTTPS */
+    pub tls: bool,
 }
 
 /**
@@ -253,6 +255,7 @@ impl<C: ServerContext> InnerHttpServerStarter<C> {
             router: api.into_router(),
             log: log.new(o!("local_addr" => local_addr)),
             local_addr,
+            tls: false,
         });
 
         let make_service = ServerConnectionHandler::new(app_state.clone());
@@ -503,6 +506,7 @@ impl<C: ServerContext> InnerHttpsServerStarter<C> {
             router: api.into_router(),
             log: logger,
             local_addr,
+            tls: true,
         });
 
         let make_service = ServerConnectionHandler::new(Arc::clone(&app_state));


### PR DESCRIPTION
Added a new flag on `DropshotState` so that a request handler can determine what type of server it is currently running in. There's unfortunately no standard header or such in HTTP/1.1 (HTTP/2 does expose it via the :scheme pseudo-header).

Some motivation: In omicron, we currently stand up both an HTTP and HTTPS dropshot server with the same ApiEndpoints and thus handlers. For device auth, we need to [construct absolute URIs](https://github.com/oxidecomputer/omicron/blob/418f2df3087ab662b4feae26bf4f8ca7a0ecf0f8/nexus/db-model/src/device_auth.rs#L35-L43) for part of the response. We currently just have it hardcoded as http as we can't determine which to use. (*)

(*) Keeping both the http & https endpoints is temporary AFAIK so we could just change the hardcoded scheme later but the same premise still holds in general.

cc @plotnick 