### PR TITLE
update CI images and maintainer docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version
@@ -22,7 +22,7 @@ jobs:
         run: cargo fmt -- --check
 
   clippy-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-12]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -94,6 +94,8 @@ Make sure you have a compatible version.  These instructions were written for v0
 $ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv --execute RELEASE_KIND|NEW_VERSION
 ----
 +
+**and then remember to push the commits and the tags!**  (You may have to temporarily allow administrators to override branch protection in order to do this.)
++
 If you want to be extra careful, you can do this in a dry-run form.  First, check that the log output here looks right (and especially that you got the version number that you expected!):
 +
 [source,text]
@@ -125,14 +127,15 @@ and do the release again with the publish step:
 $ cargo release --execute --no-push --prev-tag-name=PREV_RELEASE_TAG -vv minor
 ----
 +
-At this point, the new crates should be published to crates.io.  Check and
-push the commits and the tags.
+At this point, the new crates should be published to crates.io.  Check and push the commits and the tags.
 +
 [source,text]
 ----
 $ git push
 $ git push --tags
 ----
++
+You may have to temporarily allow administrators to override branch protection in order to do this.
 
 === Why all that checking?  Is that going overboard?
 


### PR DESCRIPTION
This change updates all of the CI images to the latest support ones.  The forcing function is that ubuntu 18.04 is being removed in a few months.  The Mac image we're using is also deprecated.

I also updated some notes in the maintainer docs related to releases because this is not the first time I forgot to push the release commits.  This change is unrelated to the CI one.