### PR TITLE
Remove max log level features on slog dependency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.8.0\...HEAD[Full list of commits]
 
+=== Other notable changes
+
+* https://github.com/oxidecomputer/dropshot/pull/452[#452] Dropshot no longer enables the `slog` cargo features `max_level_trace` and `release_max_level_debug`. Previously, clients were unable to set a release log level of `trace`; now they can. However, clients that did not select their own max log levels will see behavior change from the levels Dropshot was choosing to the default levels of `slog` itself (`debug` for debug builds and `info` for release builds).
+
 == 0.8.0 (released 2022-09-09)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.7.0\...v0.8.0[Full list of commits]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -96,6 +96,10 @@ features = [ "dangerous_configuration" ]
 version = "0.8.10"
 features = [ "chrono", "uuid1" ]
 
+[dev-dependencies.slog]
+version = "2.5.0"
+features = [ "max_level_trace", "release_max_level_debug" ]
+
 # This is required for the build.rs script to check for an appropriate compiler
 # version so that `usdt` can be built on stable rust.
 [build-dependencies]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -28,6 +28,7 @@ rustls-pemfile = "1.0.1"
 serde_json = "1.0.85"
 serde_urlencoded = "0.7.1"
 sha1 = "0.10.5"
+slog = "2.5.0"
 slog-async = "2.4.0"
 slog-bunyan = "2.4.0"
 slog-json = "2.6.1"
@@ -50,10 +51,6 @@ features = [ "full" ]
 [dependencies.serde]
 version = "1.0.145"
 features = [ "derive" ]
-
-[dependencies.slog]
-version = "2.5.0"
-features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.tokio]
 version = "1.16"


### PR DESCRIPTION
With these features in place, it wasn't possible for a consumer of `dropshot` to build a release binary that includes `trace!()` logs. Cargo features are additive, meaning `release_max_level_debug` was set for any crate that had dropshot in its dependency tree, and slog's evaluation of this feature set stops at the highest max level limit.