### PR TITLE
Update stderr files for trybuild 1.0.66

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,9 +1766,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e13556ba7dba80b3c76d1331989a341290c77efcf688eca6c307ee3066383dd"
+checksum = "73eed6b6ca6cc8a32ee81f4f8828b726bfaef43e8932e1dc14ad00530471965d"
 dependencies = [
  "glob",
  "once_cell",

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -1,44 +1,44 @@
 error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
-   --> tests/fail/bad_endpoint4.rs:24:14
-    |
-24  |     _params: Query<QueryParams>,
-    |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
-    |
-    = help: the following other types implement trait `schemars::JsonSchema`:
-              &'a T
-              &'a mut T
-              ()
-              (T0, T1)
-              (T0, T1, T2)
-              (T0, T1, T2, T3)
-              (T0, T1, T2, T3, T4)
-              (T0, T1, T2, T3, T4, T5)
-            and 145 others
+  --> tests/fail/bad_endpoint4.rs:24:14
+   |
+24 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `schemars::JsonSchema`:
+             &'a T
+             &'a mut T
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+           and 145 others
 note: required by a bound in `dropshot::Query`
-   --> src/handler.rs
-    |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                                                ^^^^^^^^^^ required by this bound in `dropshot::Query`
+  --> src/handler.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                                                ^^^^^^^^^^ required by this bound in `dropshot::Query`
 
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> tests/fail/bad_endpoint4.rs:24:14
-    |
-24  |     _params: Query<QueryParams>,
-    |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
-    |
-    = help: the following other types implement trait `serde::de::Deserialize<'de>`:
-              &'a [u8]
-              &'a std::path::Path
-              &'a str
-              ()
-              (T0, T1)
-              (T0, T1, T2)
-              (T0, T1, T2, T3)
-              (T0, T1, T2, T3, T4)
-            and 220 others
-    = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
+  --> tests/fail/bad_endpoint4.rs:24:14
+   |
+24 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             &'a [u8]
+             &'a std::path::Path
+             &'a str
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and 220 others
+   = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
 note: required by a bound in `dropshot::Query`
-   --> src/handler.rs
-    |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`
+  --> src/handler.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -1,22 +1,22 @@
 error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
-   --> tests/fail/bad_endpoint5.rs:26:14
-    |
-26  |     _params: Query<QueryParams>,
-    |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
-    |
-    = help: the following other types implement trait `serde::de::Deserialize<'de>`:
-              &'a [u8]
-              &'a std::path::Path
-              &'a str
-              ()
-              (T0, T1)
-              (T0, T1, T2)
-              (T0, T1, T2, T3)
-              (T0, T1, T2, T3, T4)
-            and 220 others
-    = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
+  --> tests/fail/bad_endpoint5.rs:26:14
+   |
+26 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             &'a [u8]
+             &'a std::path::Path
+             &'a str
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and 220 others
+   = note: required because of the requirements on the impl of `serde::de::DeserializeOwned` for `QueryParams`
 note: required by a bound in `dropshot::Query`
-   --> src/handler.rs
-    |
-    | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
-    |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`
+  --> src/handler.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `dropshot::Query`

--- a/dropshot/tests/fail/bad_endpoint7.stderr
+++ b/dropshot/tests/fail/bad_endpoint7.stderr
@@ -1,22 +1,22 @@
 error[E0277]: the trait bound `Ret: serde::ser::Serialize` is not satisfied
-    --> tests/fail/bad_endpoint7.rs:25:13
-     |
-25   | ) -> Result<HttpResponseOk<Ret>, HttpError> {
-     |             ^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
-     |
-     = help: the following other types implement trait `serde::ser::Serialize`:
-               &'a T
-               &'a mut T
-               ()
-               (T0, T1)
-               (T0, T1, T2)
-               (T0, T1, T2, T3)
-               (T0, T1, T2, T3, T4)
-               (T0, T1, T2, T3, T4, T5)
-             and 220 others
-     = note: required because of the requirements on the impl of `dropshot::handler::HttpResponseContent` for `Ret`
+  --> tests/fail/bad_endpoint7.rs:25:13
+   |
+25 | ) -> Result<HttpResponseOk<Ret>, HttpError> {
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `Ret`
+   |
+   = help: the following other types implement trait `serde::ser::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+           and 220 others
+   = note: required because of the requirements on the impl of `dropshot::handler::HttpResponseContent` for `Ret`
 note: required by a bound in `HttpResponseOk`
-    --> src/handler.rs
-     |
-     | pub struct HttpResponseOk<T: HttpResponseContent + Send + Sync + 'static>(
-     |                              ^^^^^^^^^^^^^^^^^^^ required by this bound in `HttpResponseOk`
+  --> src/handler.rs
+   |
+   | pub struct HttpResponseOk<T: HttpResponseContent + Send + Sync + 'static>(
+   |                              ^^^^^^^^^^^^^^^^^^^ required by this bound in `HttpResponseOk`


### PR DESCRIPTION
With https://github.com/dtolnay/trybuild/issues/86 fixed.

Without this PR, the current stderr files would still pass against either version of trybuild, because trybuild compares them against all old implementations of the normalization heuristic in sequence. However, the current stderr files could fail if code in dropshot/src/handler.rs moves around and changes the number of digits in the line number. After this PR, these tests would no longer fail if code in handler.rs gets moved around.