### PR TITLE
[tls] Allow refreshing TLS configuration information at runtime

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,7 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.8.0\...HEAD[Full list of commits]
 
+* https://github.com/oxidecomputer/dropshot/pull/502[#502] Dropshot exposes a `refresh_tls` method to update the TLS certificates being used by a running server.
 * https://github.com/oxidecomputer/dropshot/pull/452[#452] Dropshot no longer enables the `slog` cargo features `max_level_trace` and `release_max_level_debug`. Previously, clients were unable to set a release log level of `trace`; now they can. However, clients that did not select their own max log levels will see behavior change from the levels Dropshot was choosing to the default levels of `slog` itself (`debug` for debug builds and `info` for release builds).
 * https://github.com/oxidecomputer/dropshot/pull/451[#451] There are now response types to support 302 ("Found"), 303 ("See Other"), and 307 ("Temporary Redirect") HTTP response codes.  See `HttpResponseFound`, `HttpResponseSeeOther`, and `HttpResponseTemporaryRedirect`.
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,12 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.8.0\...HEAD[Full list of commits]
 
-* https://github.com/oxidecomputer/dropshot/pull/502[#502] Dropshot exposes a `refresh_tls` method to update the TLS certificates being used by a running server.
+=== Breaking Changes
+
+* https://github.com/oxidecomputer/dropshot/pull/502[#502] Dropshot exposes a `refresh_tls` method to update the TLS certificates being used by a running server. If you previously tried to access `DropshotState.tls`, you can access the `DropshotState.using_tls()` method instead.
+
+=== Other notable Changes
+
 * https://github.com/oxidecomputer/dropshot/pull/452[#452] Dropshot no longer enables the `slog` cargo features `max_level_trace` and `release_max_level_debug`. Previously, clients were unable to set a release log level of `trace`; now they can. However, clients that did not select their own max log levels will see behavior change from the levels Dropshot was choosing to the default levels of `slog` itself (`debug` for debug builds and `info` for release builds).
 * https://github.com/oxidecomputer/dropshot/pull/451[#451] There are now response types to support 302 ("Found"), 303 ("See Other"), and 307 ("Temporary Redirect") HTTP response codes.  See `HttpResponseFound`, `HttpResponseSeeOther`, and `HttpResponseTemporaryRedirect`.
 * https://github.com/oxidecomputer/dropshot/pull/503[#503] Add an optional `deprecated` field to the `#[endpoint]` macro.

--- a/dropshot/examples/pagination-multiple-sorts.rs
+++ b/dropshot/examples/pagination-multiple-sorts.rs
@@ -377,7 +377,7 @@ impl ProjectCollection {
             let name = format!("project{:03}", n);
             let project = Arc::new(Project {
                 name: name.clone(),
-                mtime: Utc.timestamp_millis(timestamp),
+                mtime: Utc.timestamp_millis_opt(timestamp).unwrap(),
             });
             /*
              * To make this dataset at least somewhat interesting in terms of

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -565,12 +565,17 @@ impl<C: ServerContext> HttpServer<C> {
     }
 
     /// Update TLS certificates for a running HTTPS server.
-    pub async fn refresh_tls(&self, config: &ConfigTls) {
-        if let Some(acceptor) = &self.app_state.tls_acceptor {
-            *acceptor.lock().await = TlsAcceptor::from(Arc::new(
-                rustls::ServerConfig::try_from(config).unwrap(),
-            ));
-        }
+    pub async fn refresh_tls(&self, config: &ConfigTls) -> Result<(), String> {
+        let acceptor = &self
+            .app_state
+            .tls_acceptor
+            .as_ref()
+            .ok_or_else(|| "Not configured for TLS".to_string())?;
+
+        *acceptor.lock().await = TlsAcceptor::from(Arc::new(
+            rustls::ServerConfig::try_from(config).unwrap(),
+        ));
+        Ok(())
     }
 
     /**

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -68,8 +68,14 @@ pub struct DropshotState<C: ServerContext> {
     pub log: Logger,
     /** bound local address for the server. */
     pub local_addr: SocketAddr,
-    /** are requests served over HTTPS */
-    pub tls: bool,
+    /** Identifies how to accept TLS connections */
+    pub(crate) tls_acceptor: Option<Arc<Mutex<TlsAcceptor>>>,
+}
+
+impl<C: ServerContext> DropshotState<C> {
+    pub fn using_tls(&self) -> bool {
+        self.tls_acceptor.is_some()
+    }
 }
 
 /**
@@ -255,7 +261,7 @@ impl<C: ServerContext> InnerHttpServerStarter<C> {
             router: api.into_router(),
             log: log.new(o!("local_addr" => local_addr)),
             local_addr,
-            tls: false,
+            tls_acceptor: None,
         });
 
         let make_service = ServerConnectionHandler::new(app_state.clone());
@@ -337,7 +343,7 @@ struct HttpsAcceptor {
 impl HttpsAcceptor {
     pub fn new(
         log: slog::Logger,
-        tls_acceptor: TlsAcceptor,
+        tls_acceptor: Arc<Mutex<TlsAcceptor>>,
         tcp_listener: TcpListener,
     ) -> HttpsAcceptor {
         HttpsAcceptor {
@@ -351,7 +357,7 @@ impl HttpsAcceptor {
 
     fn new_stream(
         log: slog::Logger,
-        tls_acceptor: TlsAcceptor,
+        tls_acceptor: Arc<Mutex<TlsAcceptor>>,
         tcp_listener: TcpListener,
     ) -> impl Stream<Item = std::io::Result<TlsConn>> {
         stream! {
@@ -402,6 +408,8 @@ impl HttpsAcceptor {
                         };
 
                         let tls_negotiation = tls_acceptor
+                            .lock()
+                            .await
                             .accept(socket)
                             .map_ok(move |stream| TlsConn::new(stream, addr));
                         tls_negotiations.push(tls_negotiation);
@@ -481,11 +489,11 @@ impl<C: ServerContext> InnerHttpsServerStarter<C> {
         private: C,
         log: &Logger,
     ) -> Result<InnerHttpsServerStarterNewReturn<C>, GenericError> {
-        let acceptor = TlsAcceptor::from(Arc::new(
+        let acceptor = Arc::new(Mutex::new(TlsAcceptor::from(Arc::new(
             // Unwrap is safe here because we cannot enter this code path
             // without a TLS configuration
             rustls::ServerConfig::try_from(config.tls.as_ref().unwrap())?,
-        ));
+        ))));
 
         let tcp = {
             let listener = std::net::TcpListener::bind(&config.bind_address)?;
@@ -498,7 +506,8 @@ impl<C: ServerContext> InnerHttpsServerStarter<C> {
 
         let local_addr = tcp.local_addr()?;
         let logger = log.new(o!("local_addr" => local_addr));
-        let https_acceptor = HttpsAcceptor::new(logger.clone(), acceptor, tcp);
+        let https_acceptor =
+            HttpsAcceptor::new(logger.clone(), acceptor.clone(), tcp);
 
         let app_state = Arc::new(DropshotState {
             private,
@@ -506,7 +515,7 @@ impl<C: ServerContext> InnerHttpsServerStarter<C> {
             router: api.into_router(),
             log: logger,
             local_addr,
-            tls: true,
+            tls_acceptor: Some(acceptor),
         });
 
         let make_service = ServerConnectionHandler::new(Arc::clone(&app_state));
@@ -553,6 +562,15 @@ impl<C: ServerContext> HttpServer<C> {
 
     pub fn app_private(&self) -> &C {
         &self.app_state.private
+    }
+
+    /// Update TLS certificates for a running HTTPS server.
+    pub async fn refresh_tls(&self, config: &ConfigTls) {
+        if let Some(acceptor) = &self.app_state.tls_acceptor {
+            *acceptor.lock().await = TlsAcceptor::from(Arc::new(
+                rustls::ServerConfig::try_from(config).unwrap(),
+            ));
+        }
     }
 
     /**

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -334,7 +334,7 @@ mod tests {
                     IpAddr::V6(Ipv6Addr::LOCALHOST),
                     8080,
                 ),
-                tls: false,
+                tls_acceptor: None,
             }),
             request: Arc::new(Mutex::new(
                 Request::builder()

--- a/dropshot/tests/test_tls.rs
+++ b/dropshot/tests/test_tls.rs
@@ -267,7 +267,7 @@ async fn test_tls_refresh_certificates() {
     };
 
     // Refresh the server to use the new certificate chain.
-    server.refresh_tls(&config).await;
+    server.refresh_tls(&config).await.unwrap();
 
     // Client requests which have already been accepted should succeed.
     https_client.request(https_request_maker()).await.unwrap();


### PR DESCRIPTION
Adds a `refresh_tls` method to `HttpServer`, which allows TLS information to be updated for a running server.

Fixes https://github.com/oxidecomputer/dropshot/issues/491