### PR TITLE
allow endpoints to be marked as deprecated

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ https://github.com/oxidecomputer/dropshot/compare/v0.8.0\...HEAD[Full list of co
 
 * https://github.com/oxidecomputer/dropshot/pull/452[#452] Dropshot no longer enables the `slog` cargo features `max_level_trace` and `release_max_level_debug`. Previously, clients were unable to set a release log level of `trace`; now they can. However, clients that did not select their own max log levels will see behavior change from the levels Dropshot was choosing to the default levels of `slog` itself (`debug` for debug builds and `info` for release builds).
 * https://github.com/oxidecomputer/dropshot/pull/451[#451] There are now response types to support 302 ("Found"), 303 ("See Other"), and 307 ("Temporary Redirect") HTTP response codes.  See `HttpResponseFound`, `HttpResponseSeeOther`, and `HttpResponseTemporaryRedirect`.
+* https://github.com/oxidecomputer/dropshot/pull/503[#503] Add an optional `deprecated` field to the `#[endpoint]` macro.
 
 == 0.8.0 (released 2022-09-09)
 

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -47,6 +47,7 @@ pub struct ApiEndpoint<Context: ServerContext> {
     pub tags: Vec<String>,
     pub extension_mode: ExtensionMode,
     pub visible: bool,
+    pub deprecated: bool,
 }
 
 impl<'a, Context: ServerContext> ApiEndpoint<Context> {
@@ -80,6 +81,7 @@ impl<'a, Context: ServerContext> ApiEndpoint<Context> {
             tags: vec![],
             extension_mode: func_parameters.extension_mode,
             visible: true,
+            deprecated: false,
         }
     }
 
@@ -100,6 +102,11 @@ impl<'a, Context: ServerContext> ApiEndpoint<Context> {
 
     pub fn visible(mut self, visible: bool) -> Self {
         self.visible = visible;
+        self
+    }
+
+    pub fn deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = deprecated;
         self
     }
 }
@@ -588,6 +595,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
             operation.summary = endpoint.summary.clone();
             operation.description = endpoint.description.clone();
             operation.tags = endpoint.tags.clone();
+            operation.deprecated = endpoint.deprecated;
 
             operation.parameters = endpoint
                 .parameters

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -824,6 +824,7 @@ mod test {
             tags: vec![],
             extension_mode: Default::default(),
             visible: true,
+            deprecated: false,
         }
     }
 

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -408,6 +408,36 @@
         }
       }
     },
+    "/test/deprecated": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "handler24",
+        "responses": {
+          "307": {
+            "description": "redirect (temporary redirect)",
+            "headers": {
+              "location": {
+                "description": "HTTP \"Location\" header",
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "deprecated": true
+      }
+    },
     "/test/man/{x}": {
       "delete": {
         "tags": [

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -455,6 +455,18 @@ async fn handler23(
     Ok(http_response_temporary_redirect(String::from("/path3")).unwrap())
 }
 
+#[endpoint {
+    method = GET,
+    path = "/test/deprecated",
+    tags = [ "it"],
+    deprecated = true,
+}]
+async fn handler24(
+    _rqctx: Arc<RequestContext<()>>,
+) -> Result<HttpResponseTemporaryRedirect, HttpError> {
+    unimplemented!()
+}
+
 fn make_api(
     maybe_tag_config: Option<TagConfig>,
 ) -> Result<ApiDescription<()>, String> {
@@ -487,6 +499,7 @@ fn make_api(
     api.register(handler21)?;
     api.register(handler22)?;
     api.register(handler23)?;
+    api.register(handler24)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -416,6 +416,36 @@
         }
       }
     },
+    "/test/deprecated": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "handler24",
+        "responses": {
+          "307": {
+            "description": "redirect (temporary redirect)",
+            "headers": {
+              "location": {
+                "description": "HTTP \"Location\" header",
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "deprecated": true
+      }
+    },
     "/test/man/{x}": {
       "delete": {
         "tags": [

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -102,12 +102,14 @@ const USAGE: &str = "Endpoint handlers must have the following signature:
 ///     method = { DELETE | GET | OPTIONS | PATCH | POST | PUT },
 ///     path = "/path/name/with/{named}/{variables}",
 ///
-///     // Optional tags for the API description
+///     // Optional tags for the operation's description
 ///     tags = [ "all", "your", "OpenAPI", "tags" ],
-///     // A value of `true` causes the API to be omitted from the API description
-///     unpublished = { true | false },
 ///     // Specifies the media type used to encode the request body
 ///     content_type = { "application/json" | "application/x-www-form-urlencoded" }
+///     // A value of `true` marks the operation as deprecated
+///     deprecated = { true | false },
+///     // A value of `true` causes the operation to be omitted from the API description
+///     unpublished = { true | false },
 /// }]
 /// ```
 ///


### PR DESCRIPTION
This lets us specify an endpoint as deprecated. The alternative path I considered was to use the rust built-in `#[deprecated]` attribute, but that seemed too cute.

I took the opportunity to simplify some of the `serde` use.