### PR TITLE
[tests] Avoid port collision

### DIFF
--- a/dropshot/tests/test_config.rs
+++ b/dropshot/tests/test_config.rs
@@ -410,7 +410,7 @@ async fn test_config_bind_address_https_buffer() {
         ConfigBindServerHttps { log, certs, serialized_certs, serialized_key };
 
     /* This must be different than the bind_port used in the http test. */
-    let bind_port = 12218;
+    let bind_port = 12219;
     test_config_bind_server::<_, ConfigBindServerHttps>(test_config, bind_port)
         .await;
 


### PR DESCRIPTION
This is a short-term fix to #516  .

`test_config_bind_server` -- a primary helper function for the config tests -- does the following:

- Tries to start a client before a server starts
- Starts a server, then immediately stops it
- Tries to connect to that server, and validates that it can't (because it was shut down?)
- Creates a server at `bind_port + 1`:
https://github.com/oxidecomputer/dropshot/blob/9e12b7074299f9f1c8cc7b1f0eac02ed04679d81/dropshot/tests/test_config.rs#L220-L225
- Tries to connect to the old bind port server (still failing)
- Closes the new server
- Tries to connect to the new bind port server (should fail again, because it has shut down)

This PR fixes this issue *expediently* by ensuring all the selected ports are at an offset of at least "2" away from each other to avoid trampling.

**I strongly think we should change the structure of this test, to avoid this hard-coded port selection**. However, this fix should stop the test flakes from occurring.

Fixes https://github.com/oxidecomputer/dropshot/issues/516