### PR TITLE
Add `wait_for_shutdown` method to await server termination

### DIFF
--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -1,0 +1,101 @@
+// Copyright 2020 Oxide Computer Company
+
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::HttpServerStarter;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let config_dropshot: ConfigDropshot = Default::default();
+    let config_logging =
+        ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
+    let log = config_logging
+        .to_logger("example-self-referential")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    let mut api = ApiDescription::new();
+    api.register(example_api_get_counter).unwrap();
+
+    let api_context = Arc::new(ExampleContext::new());
+
+    // Set up the server.
+    //
+    // Note that we split the "closer" from the "server", so we can continue
+    // to reference the server while simultaneously waiting for it to shut down.
+    let server =
+        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+            .map_err(|error| format!("failed to create server: {}", error))?
+            .start();
+    let (server, closer) = server.get_closer();
+    let (server, joiner) = server.get_joiner();
+
+    tokio::task::spawn(async move {
+        loop {
+            // We can access the server's data while simultaneously awaiting
+            // its termination.
+            let value =
+                server.app_private().counter.fetch_add(1, Ordering::SeqCst);
+            const TIMEOUT: u64 = 5;
+            if value >= TIMEOUT {
+                println!("Terminating now");
+                break;
+            } else {
+                println!("Terminating in {} seconds", TIMEOUT - value);
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        }
+        // Once the timeout has been reached, we stop the server ourselves.
+        closer.close().await.unwrap();
+    });
+
+    // Wait for the server to stop.
+    joiner.await
+}
+
+/**
+ * Application-specific example context (state shared by handler functions)
+ */
+struct ExampleContext {
+    counter: AtomicU64,
+}
+
+impl ExampleContext {
+    pub fn new() -> ExampleContext {
+        ExampleContext { counter: AtomicU64::new(0) }
+    }
+}
+
+/*
+ * HTTP API interface
+ */
+
+#[derive(Deserialize, Serialize, JsonSchema)]
+struct CounterValue {
+    counter: u64,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/counter",
+}]
+async fn example_api_get_counter(
+    rqctx: Arc<RequestContext<Arc<ExampleContext>>>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    let api_context = rqctx.context();
+
+    Ok(HttpResponseOk(CounterValue {
+        counter: api_context.counter.load(Ordering::SeqCst),
+    }))
+}

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -1,5 +1,7 @@
 // Copyright 2020 Oxide Computer Company
 
+//! An example which demonstrates a server that can manage its own lifecycle.
+
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -40,7 +40,6 @@ async fn main() -> Result<(), String> {
         HttpServerStarter::new(&config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
-    let (server, close_handle) = server.take_close_handle();
     let shutdown = server.wait_for_shutdown();
 
     tokio::task::spawn(async move {
@@ -59,13 +58,10 @@ async fn main() -> Result<(), String> {
             }
         }
         // Once the timeout has been reached, we stop the server ourselves.
-        close_handle.close().await.unwrap();
-
-        // This background task can also wait for the server to stop
-        let _ = server.await;
+        server.close().await.unwrap();
     });
 
-    // Wait for the server to stop.
+    // From a separate task, wait for the server to stop.
     shutdown.await
 }
 

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -1,6 +1,6 @@
-// Copyright 2020 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
-//! An example which demonstrates a server that can manage its own lifecycle.
+//! An example that demonstrates server shutdown (and waiting for shutdown).
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -33,9 +33,6 @@ async fn main() -> Result<(), String> {
     let api_context = Arc::new(ExampleContext::new());
 
     // Set up the server.
-    //
-    // Note that we split the "closer" from the "server", so we can continue
-    // to reference the server while simultaneously waiting for it to shut down.
     let server =
         HttpServerStarter::new(&config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -671,7 +671,6 @@ pub use pagination::PaginationParams;
 pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
-pub use server::{CloseHandle, Uncloseable};
 pub use server::{HttpServer, HttpServerStarter};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -672,9 +672,7 @@ pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
 pub use server::{Closeable, Joinable, Uncloseable, Unjoinable};
-pub use server::{
-    HttpServer, HttpServerCloser, HttpServerJoiner, HttpServerStarter,
-};
+pub use server::{HttpServer, HttpServerStarter};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;
 pub use websocket::WebsocketConnectionRaw;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -671,7 +671,7 @@ pub use pagination::PaginationParams;
 pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
-pub use server::{Closeable, Uncloseable};
+pub use server::{CloseHandle, Uncloseable};
 pub use server::{HttpServer, HttpServerStarter};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -671,7 +671,7 @@ pub use pagination::PaginationParams;
 pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
-pub use server::{Closeable, Joinable, Uncloseable, Unjoinable};
+pub use server::{Closeable, Uncloseable};
 pub use server::{HttpServer, HttpServerStarter};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -671,7 +671,10 @@ pub use pagination::PaginationParams;
 pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
-pub use server::{HttpServer, HttpServerStarter};
+pub use server::{Closeable, Joinable, Uncloseable, Unjoinable};
+pub use server::{
+    HttpServer, HttpServerCloser, HttpServerJoiner, HttpServerStarter,
+};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;
 pub use websocket::WebsocketConnectionRaw;

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -555,7 +555,6 @@ type SharedBoxFuture<T> = Shared<Pin<Box<dyn Future<Output = T> + Send>>>;
 ///
 /// The generic traits represent the following:
 /// - C: Caller-supplied server context
-/// - Closer: Identifies if the server is directly closeable.
 pub struct HttpServer<C: ServerContext> {
     probe_registration: ProbeRegistration,
     app_state: Arc<DropshotState<C>>,
@@ -603,7 +602,7 @@ impl<C: ServerContext> HttpServer<C> {
 
     /// Returns a future which completes when the server has shut down.
     ///
-    /// This function does not cause the server to shut down, it just waits for
+    /// This function does not cause the server to shut down. It just waits for
     /// the shutdown to happen.
     ///
     /// To trigger a shutdown, Call [HttpServer::close] (which also awaits shutdown).

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -28,7 +28,6 @@ use hyper::Response;
 use rustls;
 use std::convert::TryFrom;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::pin::Pin;
@@ -201,9 +200,10 @@ impl<C: ServerContext> HttpServerStarter<C> {
             probe_registration,
             app_state: self.app_state,
             local_addr: self.local_addr,
-            closer: Some(HttpServerCloser { close_channel: Some(tx) }),
-            joiner: Some(HttpServerJoiner { join_handle: Some(join_handle) }),
-            _phantom: PhantomData,
+            closer: Closeable(HttpServerCloser { close_channel: Some(tx) }),
+            joiner: Joinable(HttpServerJoiner {
+                join_handle: Some(join_handle),
+            }),
         }
     }
 }
@@ -545,52 +545,33 @@ impl<C: ServerContext> Service<&TlsConn> for ServerConnectionHandler<C> {
     }
 }
 
-/// Marker trait used to control whether or not an HTTP server can be closed.
-pub trait Closer: Send + Sync + Unpin + 'static {}
-
-/// Implements [Closer] and identifies that the server can be closed.
+/// Identifies that the server can be closed.
 ///
 /// This implies:
 /// - [HttpServer::close] can be called
-pub struct Closeable {}
+pub struct Closeable(HttpServerCloser);
 
-/// Implements [Closer] and identifies that the server cannot be closed
-/// directly.
+/// Identifies that the server cannot be closed directly.
 pub struct Uncloseable {}
 
-impl Closer for Closeable {}
-impl Closer for Uncloseable {}
+/// Identifies that the server can be joined
+pub struct Joinable(HttpServerJoiner);
 
-/// Marker trait used to control whether or not an HTTP server can be joined.
-pub trait Joiner: Send + Sync + 'static {}
-
-/// Implements [Joiner] and identifies that the server can be joined
-pub struct Joinable {}
-
-/// Implements [Joiner] and identifies that the server cannot be joined
-/// directly.
+/// Identifies that the server cannot be joined directly.
 pub struct Unjoinable {}
-
-impl Joiner for Joinable {}
-impl Joiner for Unjoinable {}
 
 /// A running Dropshot HTTP server.
 ///
 /// The generic traits represent the following:
 /// - C: Caller-supplied server context
-/// - CL: A marker trait identifying if the server struct is [Closeable].
-/// - J: A merker trait identifying if the server struct is [Joinable].
-pub struct HttpServer<
-    C: ServerContext,
-    CL: Closer = Closeable,
-    J: Joiner = Joinable,
-> {
+/// - Closer: Identifies if the server is directly closeable.
+/// - Joiner: Identifies if the server is directly joinable.
+pub struct HttpServer<C: ServerContext, Closer = Closeable, Joiner = Joinable> {
     probe_registration: ProbeRegistration,
     app_state: Arc<DropshotState<C>>,
     local_addr: SocketAddr,
-    closer: Option<HttpServerCloser>,
-    joiner: Option<HttpServerJoiner>,
-    _phantom: PhantomData<(CL, J)>,
+    closer: Closer,
+    joiner: Joiner,
 }
 
 /// Represents the ability to close a running HTTP server.
@@ -621,7 +602,7 @@ pub struct HttpServerJoiner {
     join_handle: Option<tokio::task::JoinHandle<Result<(), hyper::Error>>>,
 }
 
-impl<C: ServerContext, CL: Closer, J: Joiner> HttpServer<C, CL, J> {
+impl<C: ServerContext, Closer, Joiner> HttpServer<C, Closer, Joiner> {
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
@@ -654,19 +635,18 @@ impl<C: ServerContext, CL: Closer, J: Joiner> HttpServer<C, CL, J> {
     }
 }
 
-impl<C: ServerContext, CL: Closer> HttpServer<C, CL, Joinable> {
+impl<C: ServerContext, Closer> HttpServer<C, Closer, Joinable> {
     /// Separates the [HttpServer] from the [HttpServerJoining] object which is
     /// capable of joining it.
     pub fn get_joiner(
         self,
-    ) -> (HttpServer<C, CL, Unjoinable>, HttpServerJoiner) {
+    ) -> (HttpServer<C, Closer, Unjoinable>, HttpServerJoiner) {
         let HttpServer {
             probe_registration,
             app_state,
             local_addr,
             closer,
             joiner,
-            _phantom: PhantomData,
         } = self;
 
         (
@@ -675,25 +655,25 @@ impl<C: ServerContext, CL: Closer> HttpServer<C, CL, Joinable> {
                 app_state,
                 local_addr,
                 closer,
-                joiner: None,
-                _phantom: PhantomData,
+                joiner: Unjoinable {},
             },
-            joiner.unwrap(),
+            joiner.0,
         )
     }
 }
 
-impl<C: ServerContext, J: Joiner> HttpServer<C, Closeable, J> {
+impl<C: ServerContext, Joiner> HttpServer<C, Closeable, Joiner> {
     /// Separates the [HttpServer] from the [HttpServerCloser] object which is
     /// capable of closing it.
-    pub fn get_closer(self) -> (HttpServer<C, Uncloseable>, HttpServerCloser) {
+    pub fn get_closer(
+        self,
+    ) -> (HttpServer<C, Uncloseable, Joiner>, HttpServerCloser) {
         let HttpServer {
             probe_registration,
             app_state,
             local_addr,
             closer,
             joiner,
-            _phantom: PhantomData,
         } = self;
 
         (
@@ -701,20 +681,19 @@ impl<C: ServerContext, J: Joiner> HttpServer<C, Closeable, J> {
                 probe_registration,
                 app_state,
                 local_addr,
-                closer: None,
+                closer: Uncloseable {},
                 joiner,
-                _phantom: PhantomData,
             },
-            closer.unwrap(),
+            closer.0,
         )
     }
 }
 
 impl<C: ServerContext> HttpServer<C, Closeable, Joinable> {
     /// Signals the currently running server to stop and waits for it to exit.
-    pub async fn close(mut self) -> Result<(), String> {
-        let mut closer = self.closer.take().expect("already took closer");
-        let mut joiner = self.joiner.take().expect("already took joiner");
+    pub async fn close(self) -> Result<(), String> {
+        let mut closer = self.closer.0;
+        let mut joiner = self.joiner.0;
 
         closer
             .close_channel
@@ -775,36 +754,25 @@ impl FusedFuture for HttpServerJoiner {
     }
 }
 
-impl<C: ServerContext, CL: Closer> Future for HttpServer<C, CL, Joinable> {
+impl<C: ServerContext, Closer> Future for HttpServer<C, Closer, Joinable>
+where
+    Closer: Unpin,
+{
     type Output = Result<(), String>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let server = Pin::into_inner(self);
-        let mut joiner = server
-            .joiner
-            .take()
-            .expect("polling a server which has already closed");
-        let mut handle = joiner
-            .join_handle
-            .take()
-            .expect("polling a server future which has already completed");
-        let poll = handle.poll_unpin(cx).map(|result| {
-            result
-                .map_err(|error| format!("waiting for server: {}", error))?
-                .map_err(|error| format!("server stopped: {}", error))
-        });
-
-        if poll.is_pending() {
-            joiner.join_handle.replace(handle);
-            server.joiner.replace(joiner);
-        }
-        return poll;
+        let joiner = Pin::new(&mut server.joiner.0);
+        joiner.poll(cx)
     }
 }
 
-impl<C: ServerContext, CL: Closer> FusedFuture for HttpServer<C, CL, Joinable> {
+impl<C: ServerContext, Closer> FusedFuture for HttpServer<C, Closer, Joinable>
+where
+    Closer: Unpin,
+{
     fn is_terminated(&self) -> bool {
-        self.closer.is_none()
+        self.joiner.0.is_terminated()
     }
 }
 


### PR DESCRIPTION
- Allows callers to await completion of a server separate from owning the server object.

Fixes https://github.com/oxidecomputer/dropshot/issues/536