### PR TITLE
Expose 'using_tls' from HttpServer

### DIFF
--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -577,6 +577,10 @@ impl<C: ServerContext> HttpServer<C> {
         &self.app_state.private
     }
 
+    pub fn using_tls(&self) -> bool {
+        self.app_state.using_tls()
+    }
+
     /// Update TLS certificates for a running HTTPS server.
     pub async fn refresh_tls(&self, config: &ConfigTls) -> Result<(), String> {
         let acceptor = &self


### PR DESCRIPTION
This is already accessible from the `DropshotState` which is normally provided in endpoint handlers, but it's now plumbed through the `HttpServer` as well. This makes it useful for callers managing servers, in addition to simply implementing endpoints.