### PR TITLE
[logging] switch to camino Utf8PathBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "camino"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +295,7 @@ dependencies = [
  "async-trait",
  "base64 0.20.0",
  "bytes",
+ "camino",
  "chrono",
  "dropshot_endpoint",
  "expectorate",

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -15,6 +15,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.60"
 base64 = "0.20.0"
 bytes = "1"
+camino = { version = "1.1.1", features = ["serde1"] }
 futures = "0.3.25"
 hostname = "0.3.0"
 http = "0.2.8"

--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -5,6 +5,7 @@
  * they're provided because they're commonly wanted by consumers of this crate.
  */
 
+use camino::Utf8PathBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use slog::Drain;
@@ -25,7 +26,7 @@ pub enum ConfigLogging {
     /** Bunyan-formatted output to a specified file. */
     File {
         level: ConfigLoggingLevel,
-        path: String,
+        path: Utf8PathBuf,
         if_exists: ConfigLoggingIfExists,
     },
 }

--- a/dropshot/tests/common/mod.rs
+++ b/dropshot/tests/common/mod.rs
@@ -37,7 +37,7 @@ pub fn test_setup(
 pub fn create_log_context(test_name: &str) -> LogContext {
     let log_config = ConfigLogging::File {
         level: ConfigLoggingLevel::Debug,
-        path: "UNUSED".to_string(),
+        path: "UNUSED".into(),
         if_exists: ConfigLoggingIfExists::Fail,
     };
     LogContext::new(test_name, &log_config)

--- a/dropshot/tests/fail/bad_endpoint4.stderr
+++ b/dropshot/tests/fail/bad_endpoint4.stderr
@@ -28,13 +28,13 @@ error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>
    |
    = help: the following other types implement trait `serde::de::Deserialize<'de>`:
              &'a [u8]
+             &'a camino::Utf8Path
              &'a std::path::Path
              &'a str
              ()
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
            and $N others
    = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
 note: required by a bound in `dropshot::Query`

--- a/dropshot/tests/fail/bad_endpoint5.stderr
+++ b/dropshot/tests/fail/bad_endpoint5.stderr
@@ -6,13 +6,13 @@ error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>
    |
    = help: the following other types implement trait `serde::de::Deserialize<'de>`:
              &'a [u8]
+             &'a camino::Utf8Path
              &'a std::path::Path
              &'a str
              ()
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
            and $N others
    = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
 note: required by a bound in `dropshot::Query`

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -873,7 +873,7 @@ async fn start_example(path: &str, port: u16) -> ExampleContext {
         path,
         &ConfigLogging::File {
             level: ConfigLoggingLevel::Info,
-            path: "UNUSED".to_string(),
+            path: "UNUSED".into(),
             if_exists: ConfigLoggingIfExists::Fail,
         },
     );


### PR DESCRIPTION
We repeatedly assert and assume that logging paths are valid UTF-8, and
use a `String` in the deserializable log even though that isn't the most
appropriate use.

Use [camino](https://docs.rs/camino/latest/camino/) to assert the use of `Utf8PathBuf` at the type-level.
This is a breaking change from the Rust API point of view, but
existing config files should work without changes since a `Utf8PathBuf`
is equivalent to a `String` with `PathBuf` semantics.
