### PR TITLE
switch block-style to line-style comments

### DIFF
--- a/dropshot/examples/basic.rs
+++ b/dropshot/examples/basic.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Example use of Dropshot.
- */
+//! Example use of Dropshot.
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -23,85 +21,63 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot: ConfigDropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(example_api_get_counter).unwrap();
     api.register(example_api_put_counter).unwrap();
 
-    /*
-     * The functions that implement our API endpoints will share this context.
-     */
+    // The functions that implement our API endpoints will share this context.
     let api_context = ExampleContext::new();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server =
         HttpServerStarter::new(&config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }
 
-/**
- * Application-specific example context (state shared by handler functions)
- */
+/// Application-specific example context (state shared by handler functions)
 struct ExampleContext {
-    /** counter that can be manipulated by requests to the HTTP API */
+    /// counter that can be manipulated by requests to the HTTP API
     counter: AtomicU64,
 }
 
 impl ExampleContext {
-    /**
-     * Return a new ExampleContext.
-     */
+    /// Return a new ExampleContext.
     pub fn new() -> ExampleContext {
         ExampleContext { counter: AtomicU64::new(0) }
     }
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
-/**
- * `CounterValue` represents the value of the API's counter, either as the
- * response to a GET request to fetch the counter or as the body of a PUT
- * request to update the counter.
- */
+/// `CounterValue` represents the value of the API's counter, either as the
+/// response to a GET request to fetch the counter or as the body of a PUT
+/// request to update the counter.
 #[derive(Deserialize, Serialize, JsonSchema)]
 struct CounterValue {
     counter: u64,
 }
 
-/**
- * Fetch the current value of the counter.
- */
+/// Fetch the current value of the counter.
 #[endpoint {
     method = GET,
     path = "/counter",
@@ -116,10 +92,8 @@ async fn example_api_get_counter(
     }))
 }
 
-/**
- * Update the current value of the counter.  Note that the special value of 10
- * is not allowed (just to demonstrate how to generate an error).
- */
+/// Update the current value of the counter.  Note that the special value of 10
+/// is not allowed (just to demonstrate how to generate an error).
 #[endpoint {
     method = PUT,
     path = "/counter",

--- a/dropshot/examples/https.rs
+++ b/dropshot/examples/https.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 Oxide Computer Company
 
-/*!
- * Example use of Dropshot with TLS enabled
- */
+//! Example use of Dropshot with TLS enabled
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -25,10 +23,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
 
-/*
- * This function would not be used in a normal application. It is used to
- * generate temporary keys and certificates for the purpose of this demo.
- */
+// This function would not be used in a normal application. It is used to
+// generate temporary keys and certificates for the purpose of this demo.
 fn generate_keys() -> Result<(NamedTempFile, NamedTempFile), String> {
     let keypair =
         rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
@@ -57,20 +53,16 @@ fn generate_keys() -> Result<(NamedTempFile, NamedTempFile), String> {
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * Begin by generating TLS certificates and keys. A normal application would
-     * just pass the paths to these via ConfigDropshot.
-     */
+    // Begin by generating TLS certificates and keys. A normal application would
+    // just pass the paths to these via ConfigDropshot.
     let (cert_file, key_file) = generate_keys()?;
 
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     *
-     * In addition, we'll make this an HTTPS server.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
+    //
+    // In addition, we'll make this an HTTPS server.
     let config_dropshot = ConfigDropshot {
         tls: Some(ConfigTls::AsFile {
             cert_file: cert_file.path().to_path_buf(),
@@ -79,77 +71,57 @@ async fn main() -> Result<(), String> {
         ..Default::default()
     };
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(example_api_get_counter).unwrap();
     api.register(example_api_put_counter).unwrap();
 
-    /*
-     * The functions that implement our API endpoints will share this context.
-     */
+    // The functions that implement our API endpoints will share this context.
     let api_context = ExampleContext::new();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server =
         HttpServerStarter::new(&config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }
 
-/**
- * Application-specific example context (state shared by handler functions)
- */
+/// Application-specific example context (state shared by handler functions)
 struct ExampleContext {
-    /** counter that can be manipulated by requests to the HTTP API */
+    /// counter that can be manipulated by requests to the HTTP API
     counter: AtomicU64,
 }
 
 impl ExampleContext {
-    /**
-     * Return a new ExampleContext.
-     */
+    /// Return a new ExampleContext.
     pub fn new() -> ExampleContext {
         ExampleContext { counter: AtomicU64::new(0) }
     }
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
-/**
- * `CounterValue` represents the value of the API's counter, either as the
- * response to a GET request to fetch the counter or as the body of a PUT
- * request to update the counter.
- */
+/// `CounterValue` represents the value of the API's counter, either as the
+/// response to a GET request to fetch the counter or as the body of a PUT
+/// request to update the counter.
 #[derive(Deserialize, Serialize, JsonSchema)]
 struct CounterValue {
     counter: u64,
 }
 
-/**
- * Fetch the current value of the counter.
- */
+/// Fetch the current value of the counter.
 #[endpoint {
     method = GET,
     path = "/counter",
@@ -164,10 +136,8 @@ async fn example_api_get_counter(
     }))
 }
 
-/**
- * Update the current value of the counter.  Note that the special value of 10
- * is not allowed (just to demonstrate how to generate an error).
- */
+/// Update the current value of the counter.  Note that the special value of 10
+/// is not allowed (just to demonstrate how to generate an error).
 #[endpoint {
     method = PUT,
     path = "/counter",

--- a/dropshot/examples/index.rs
+++ b/dropshot/examples/index.rs
@@ -1,7 +1,5 @@
 // Copyright 2021 Oxide Computer Company
-/*!
- * Example use of Dropshot for matching wildcard paths to serve static content.
- */
+//! Example use of Dropshot for matching wildcard paths to serve static content.
 
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
@@ -19,41 +17,31 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot: ConfigDropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(index).unwrap();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }
 
@@ -62,9 +50,7 @@ struct AllPath {
     path: Vec<String>,
 }
 
-/**
- * Return static content for all paths.
- */
+/// Return static content for all paths.
 #[endpoint {
     method = GET,
 

--- a/dropshot/examples/module-basic.rs
+++ b/dropshot/examples/module-basic.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Example use of Dropshot.
- */
+//! Example use of Dropshot.
 
 use dropshot::ApiDescription;
 use dropshot::ConfigLogging;
@@ -14,86 +12,64 @@ use std::sync::atomic::AtomicU64;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(routes::example_api_get_counter).unwrap();
     api.register(routes::example_api_put_counter).unwrap();
 
-    /*
-     * The functions that implement our API endpoints will share this context.
-     */
+    // The functions that implement our API endpoints will share this context.
     let api_context = ExampleContext::new();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server =
         HttpServerStarter::new(&config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }
 
-/**
- * Application-specific example context (state shared by handler functions)
- */
+/// Application-specific example context (state shared by handler functions)
 pub struct ExampleContext {
-    /** counter that can be manipulated by requests to the HTTP API */
+    /// counter that can be manipulated by requests to the HTTP API
     pub counter: AtomicU64,
 }
 
 impl ExampleContext {
-    /**
-     * Return a new ExampleContext.
-     */
+    /// Return a new ExampleContext.
     pub fn new() -> ExampleContext {
         ExampleContext { counter: AtomicU64::new(0) }
     }
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
-/**
- * `CounterValue` represents the value of the API's counter, either as the
- * response to a GET request to fetch the counter or as the body of a PUT
- * request to update the counter.
- */
+/// `CounterValue` represents the value of the API's counter, either as the
+/// response to a GET request to fetch the counter or as the body of a PUT
+/// request to update the counter.
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub struct CounterValue {
     counter: u64,
 }
 
-/**
- * The routes module might be imported from another crate that publishes
- * mountable routes
- */
+/// The routes module might be imported from another crate that publishes
+/// mountable routes
 pub mod routes {
     use crate::{CounterValue, ExampleContext};
     use dropshot::endpoint;
@@ -105,11 +81,9 @@ pub mod routes {
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
-    /**
-     * Fetch the current value of the counter.
-     * NOTE: The endpoint macro inherits its module visibility from
-     * the endpoint async function definition
-     */
+    /// Fetch the current value of the counter.
+    /// NOTE: The endpoint macro inherits its module visibility from
+    /// the endpoint async function definition
     #[endpoint {
           method = GET,
           path = "/counter",
@@ -124,10 +98,8 @@ pub mod routes {
         }))
     }
 
-    /**
-     * Update the current value of the counter.  Note that the special value of 10
-     * is not allowed (just to demonstrate how to generate an error).
-     */
+    /// Update the current value of the counter.  Note that the special value of 10
+    /// is not allowed (just to demonstrate how to generate an error).
     #[endpoint {
           method = PUT,
           path = "/counter",

--- a/dropshot/examples/module-shared-context.rs
+++ b/dropshot/examples/module-shared-context.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 Oxide Computer Company
-/*!
- * Example use of Dropshot where a client wants to act on
- * a custom context object that outlives endpoint functions.
- */
+//! Example use of Dropshot where a client wants to act on
+//! a custom context object that outlives endpoint functions.
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -22,38 +20,28 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(example_api_get_counter).unwrap();
 
-    /*
-     * The functions that implement our API endpoints will share this context.
-     */
+    // The functions that implement our API endpoints will share this context.
     let api_context = Arc::new(ExampleContext::new());
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server = HttpServerStarter::new(
         &config_dropshot,
         api,
@@ -63,17 +51,15 @@ async fn main() -> Result<(), String> {
     .map_err(|error| format!("failed to create server: {}", error))?
     .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     *
-     * Even with the endpoints acting on the `ExampleContext` object,
-     * we can still hold a reference and act on the object beyond the lifetime
-     * of those endpoints.
-     *
-     * In this example, we increment the counter every five seconds,
-     * regardless of received HTTP requests.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
+    //
+    // Even with the endpoints acting on the `ExampleContext` object,
+    // we can still hold a reference and act on the object beyond the lifetime
+    // of those endpoints.
+    //
+    // In this example, we increment the counter every five seconds,
+    // regardless of received HTTP requests.
     futures::pin_mut!(server);
     loop {
         let sleep =
@@ -88,38 +74,28 @@ async fn main() -> Result<(), String> {
     Ok(())
 }
 
-/**
- * Application-specific example context (state shared by handler functions)
- */
+/// Application-specific example context (state shared by handler functions)
 pub struct ExampleContext {
-    /** counter that can be read by requests to the HTTP API */
+    /// counter that can be read by requests to the HTTP API
     pub counter: AtomicU64,
 }
 
 impl ExampleContext {
-    /**
-     * Return a new ExampleContext.
-     */
+    /// Return a new ExampleContext.
     pub fn new() -> ExampleContext {
         ExampleContext { counter: AtomicU64::new(0) }
     }
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
-/**
- * `CounterValue` represents the value of the API's counter.
- */
+/// `CounterValue` represents the value of the API's counter.
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub struct CounterValue {
     counter: u64,
 }
 
-/**
- * Fetch the current value of the counter.
- */
+/// Fetch the current value of the counter.
 #[endpoint {
       method = GET,
       path = "/counter",

--- a/dropshot/examples/pagination-basic.rs
+++ b/dropshot/examples/pagination-basic.rs
@@ -1,20 +1,18 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Example showing a relatively simple use of the pagination API
- *
- * When you run this program, it will start an HTTP server on an available local
- * port.  See the log entry to see what port it ran on.  Then use curl to use
- * it, like this:
- *
- * ```ignore
- * $ curl localhost:50568/projects
- * ```
- *
- * (Replace 50568 with whatever port your server is listening on.)
- *
- * Try passing different values of the `limit` query parameter.  Try passing the
- * next page token from the response as a query parameter, too.
- */
+//! Example showing a relatively simple use of the pagination API
+//!
+//! When you run this program, it will start an HTTP server on an available local
+//! port.  See the log entry to see what port it ran on.  Then use curl to use
+//! it, like this:
+//!
+//! ```ignore
+//! $ curl localhost:50568/projects
+//! ```
+//!
+//! (Replace 50568 with whatever port your server is listening on.)
+//!
+//! Try passing different values of the `limit` query parameter.  Try passing the
+//! next page token from the response as a query parameter, too.
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -39,39 +37,33 @@ use std::net::SocketAddr;
 use std::ops::Bound;
 use std::sync::Arc;
 
-/**
- * Object returned by our paginated endpoint
- *
- * Like anything returned by Dropshot, we must implement `JsonSchema` and
- * `Serialize`.  We also implement `Clone` to simplify the example.
- */
+/// Object returned by our paginated endpoint
+///
+/// Like anything returned by Dropshot, we must implement `JsonSchema` and
+/// `Serialize`.  We also implement `Clone` to simplify the example.
 #[derive(Clone, JsonSchema, Serialize)]
 struct Project {
     name: String,
     // lots more fields
 }
 
-/**
- * Parameters describing the client's position in a scan through all projects
- *
- * This implementation only needs the name of the last project seen, as we only
- * support listing projects in ascending order by name.
- *
- * This must be `Serialize` so that Dropshot can turn it into a page token to
- * include with each page of results, and it must be `Deserialize` to get it
- * back in a querystring.
- */
+/// Parameters describing the client's position in a scan through all projects
+///
+/// This implementation only needs the name of the last project seen, as we only
+/// support listing projects in ascending order by name.
+///
+/// This must be `Serialize` so that Dropshot can turn it into a page token to
+/// include with each page of results, and it must be `Deserialize` to get it
+/// back in a querystring.
 #[derive(Deserialize, JsonSchema, Serialize)]
 struct ProjectPage {
     name: String,
 }
 
-/**
- * API endpoint for listing projects
- *
- * This implementation stores all the projects in a BTreeMap, which makes it
- * very easy to fetch a particular range of items based on the key.
- */
+/// API endpoint for listing projects
+///
+/// This implementation stores all the projects in a BTreeMap, which makes it
+/// very easy to fetch a particular range of items based on the key.
 #[endpoint {
     method = GET,
     path = "/projects"
@@ -85,14 +77,14 @@ async fn example_list_projects(
     let tree = rqctx.context();
     let projects = match &pag_params.page {
         WhichPage::First(..) => {
-            /* Return a list of the first "limit" projects. */
+            // Return a list of the first "limit" projects.
             tree.iter()
                 .take(limit)
                 .map(|(_, project)| project.clone())
                 .collect()
         }
         WhichPage::Next(ProjectPage { name: last_seen }) => {
-            /* Return a list of the first "limit" projects after this name. */
+            // Return a list of the first "limit" projects after this name.
             tree.range((Bound::Excluded(last_seen.clone()), Bound::Unbounded))
                 .take(limit)
                 .map(|(_, project)| project.clone())
@@ -116,9 +108,7 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("failed to parse \"port\" argument: {}", e))?
         .unwrap_or(0);
 
-    /*
-     * Create 1000 projects up front.
-     */
+    // Create 1000 projects up front.
     let mut tree = BTreeMap::new();
     for n in 1..1000 {
         let name = format!("project{:03}", n);
@@ -126,9 +116,7 @@ async fn main() -> Result<(), String> {
         tree.insert(name, project);
     }
 
-    /*
-     * Run the Dropshot server.
-     */
+    // Run the Dropshot server.
     let ctx = tree;
     let config_dropshot = ConfigDropshot {
         bind_address: SocketAddr::from((Ipv4Addr::LOCALHOST, port)),

--- a/dropshot/examples/pagination-multiple-resources.rs
+++ b/dropshot/examples/pagination-multiple-resources.rs
@@ -1,9 +1,7 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Example that shows a paginated API that uses the same pagination fields on
- * multiple resources.  See the other pagination examples for more information
- * about how to run this.
- */
+//! Example that shows a paginated API that uses the same pagination fields on
+//! multiple resources.  See the other pagination examples for more information
+//! about how to run this.
 
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -31,10 +29,8 @@ use std::ops::Bound;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/*
- * Example API data model: we have three resources, each having an "id" and
- * "name".  We'll have one endpoint for each resource to list it.
- */
+// Example API data model: we have three resources, each having an "id" and
+// "name".  We'll have one endpoint for each resource to list it.
 
 #[derive(Clone, JsonSchema, Serialize)]
 struct Project {
@@ -57,12 +53,10 @@ struct Instance {
     // lots more instance-like fields
 }
 
-/*
- * In an API with many resources sharing the same identifying fields, we might
- * define a trait to get those fields.  Then we could define pagination in terms
- * of that trait.  To avoid hand-writing the impls, we use a macro.  (This might
- * be better as a "derive" procedural macro.)
- */
+// In an API with many resources sharing the same identifying fields, we might
+// define a trait to get those fields.  Then we could define pagination in terms
+// of that trait.  To avoid hand-writing the impls, we use a macro.  (This might
+// be better as a "derive" procedural macro.)
 trait HasIdentity {
     fn id(&self) -> &Uuid;
     fn name(&self) -> &str;
@@ -85,9 +79,7 @@ impl_HasIdentity!(Project);
 impl_HasIdentity!(Disk);
 impl_HasIdentity!(Instance);
 
-/*
- * Pagination-related types
- */
+// Pagination-related types
 #[derive(Deserialize, Clone, JsonSchema, Serialize)]
 struct ExScanParams {
     #[serde(default = "default_sort_mode")]
@@ -155,13 +147,11 @@ fn scan_params(p: &WhichPage<ExScanParams, ExPageSelector>) -> ExScanParams {
     }
 }
 
-/*
- * Paginated endpoints to list each type of resource.
- *
- * These could be commonized further (to the point where each of these endpoint
- * functions is just a one-line call to a generic function), but we implement
- * them separately here for clarity.
- */
+// Paginated endpoints to list each type of resource.
+//
+// These could be commonized further (to the point where each of these endpoint
+// functions is just a one-line call to a generic function), but we implement
+// them separately here for clarity.
 
 #[endpoint {
     method = GET,
@@ -274,9 +264,7 @@ where
     }
 }
 
-/*
- * General Dropshot-server boilerplate
- */
+// General Dropshot-server boilerplate
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
@@ -287,9 +275,7 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("failed to parse \"port\" argument: {}", e))?
         .unwrap_or(0);
 
-    /*
-     * Run the Dropshot server.
-     */
+    // Run the Dropshot server.
     let ctx = DataCollection::new();
     let config_dropshot = ConfigDropshot {
         bind_address: SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
@@ -311,11 +297,9 @@ async fn main() -> Result<(), String> {
     server.await
 }
 
-/**
- * Tracks a (static) collection of Projects indexed in two different ways to
- * demonstrate an endpoint that provides multiple ways to scan a large
- * collection.
- */
+/// Tracks a (static) collection of Projects indexed in two different ways to
+/// demonstrate an endpoint that provides multiple ways to scan a large
+/// collection.
 struct DataCollection {
     projects_by_name: BTreeMap<String, Arc<Project>>,
     projects_by_id: BTreeMap<Uuid, Arc<Project>>,
@@ -328,10 +312,8 @@ struct DataCollection {
 type ItemIter<'a, T> = Box<dyn Iterator<Item = Arc<T>> + 'a>;
 
 impl DataCollection {
-    /**
-     * Constructs an example collection of projects, disks, and instances to
-     * back the API endpoints
-     */
+    /// Constructs an example collection of projects, disks, and instances to
+    /// back the API endpoints
     pub fn new() -> DataCollection {
         let mut data = DataCollection {
             projects_by_id: BTreeMap::new(),
@@ -399,10 +381,8 @@ impl DataCollection {
         self.make_iter(iter)
     }
 
-    /**
-     * Helper function to turn the initial iterators produced above into what we
-     * actually need to provide consumers.
-     */
+    /// Helper function to turn the initial iterators produced above into what we
+    /// actually need to provide consumers.
     fn make_iter<'a, K, I, T>(&'a self, iter: I) -> ItemIter<'a, T>
     where
         I: Iterator<Item = (K, &'a Arc<T>)> + 'a,

--- a/dropshot/examples/pagination-multiple-sorts.rs
+++ b/dropshot/examples/pagination-multiple-sorts.rs
@@ -1,94 +1,92 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Example of an API endpoint that supports pagination using several different
- * fields as the sorting key.
- *
- * When you run this program, it will start an HTTP server on an available local
- * port.  See the log for example URLs to use.  Try passing different values of
- * the `limit` query parameter.  Try passing the `next_page` token from the
- * response as a query parameter called `page_token`, too.
- *
- * For background, see src/pagination.rs.  This example uses a resource called a
- * "Project", which only has a "name" and an "mtime" (modification time).  The
- * server creates 1,000 projects on startup and provides one API endpoint to
- * page through them.
- *
- * Initially, a client just invokes the API to list the first page of results
- * using the default sort order (we'll use limit=3 to keep the result set
- * short):
- *
- * ```ignore
- * $ curl -s http://127.0.0.1:50800/projects?limit=3 | json
- * {
- *   "next_page": "eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwMyJdfX0=",
- *   "items": [
- *     {
- *       "name": "project001",
- *       "mtime": "2020-07-13T17:35:00Z"
- *     },
- *     {
- *       "name": "project002",
- *       "mtime": "2020-07-13T17:34:59.999Z"
- *     },
- *     {
- *       "name": "project003",
- *       "mtime": "2020-07-13T17:34:59.998Z"
- *     }
- *   ]
- * }
- * ```
- *
- * This should be pretty self-explanatory: we have three projects here and
- * they're sorted in ascending order by name.  The "next_page" token is used to
- * fetch the next page of results as follows:
- *
- * ```ignore
- * $ curl -s http://127.0.0.1:50800/projects?limit=3'&'page_token=eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwMyJdfX0= | json
- * {
- *   "next_page": "eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwNiJdfX0=",
- *   "items": [
- *     {
- *       "name": "project004",
- *       "mtime": "2020-07-13T17:34:59.997Z"
- *     },
- *     {
- *       "name": "project005",
- *       "mtime": "2020-07-13T17:34:59.996Z"
- *     },
- *     {
- *       "name": "project006",
- *       "mtime": "2020-07-13T17:34:59.995Z"
- *     }
- *   ]
- * }
- * ```
- *
- * Now we have the next three projects and a new token.  We can continue this
- * way until we've listed all the projects.
- *
- * What does that page token look like?  It's implementation-defined, so you
- * shouldn't rely on the structure.  In this case, it's a base64-encoded,
- * versioned JSON structure describing the scan and the client's position in the
- * scan:
- *
- * ```ignore
- * $ echo -n 'eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwNiJdfX0=' | base64 -d | json
- * {
- *   "v": "v1",
- *   "page_start": {
- *     "name": [
- *       "ascending",
- *       "project006"
- *     ]
- *   }
- * }
- * ```
- *
- * This token says that we're scanning in ascending order of "name" and the last
- * one we saw was "project006".  Again, this is subject to change and should not
- * be relied upon.  We mention it here just to help explain how the pagination
- * mechanism works.
- */
+//! Example of an API endpoint that supports pagination using several different
+//! fields as the sorting key.
+//!
+//! When you run this program, it will start an HTTP server on an available local
+//! port.  See the log for example URLs to use.  Try passing different values of
+//! the `limit` query parameter.  Try passing the `next_page` token from the
+//! response as a query parameter called `page_token`, too.
+//!
+//! For background, see src/pagination.rs.  This example uses a resource called a
+//! "Project", which only has a "name" and an "mtime" (modification time).  The
+//! server creates 1,000 projects on startup and provides one API endpoint to
+//! page through them.
+//!
+//! Initially, a client just invokes the API to list the first page of results
+//! using the default sort order (we'll use limit=3 to keep the result set
+//! short):
+//!
+//! ```ignore
+//! $ curl -s http://127.0.0.1:50800/projects?limit=3 | json
+//! {
+//!   "next_page": "eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwMyJdfX0=",
+//!   "items": [
+//!     {
+//!       "name": "project001",
+//!       "mtime": "2020-07-13T17:35:00Z"
+//!     },
+//!     {
+//!       "name": "project002",
+//!       "mtime": "2020-07-13T17:34:59.999Z"
+//!     },
+//!     {
+//!       "name": "project003",
+//!       "mtime": "2020-07-13T17:34:59.998Z"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! This should be pretty self-explanatory: we have three projects here and
+//! they're sorted in ascending order by name.  The "next_page" token is used to
+//! fetch the next page of results as follows:
+//!
+//! ```ignore
+//! $ curl -s http://127.0.0.1:50800/projects?limit=3'&'page_token=eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwMyJdfX0= | json
+//! {
+//!   "next_page": "eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwNiJdfX0=",
+//!   "items": [
+//!     {
+//!       "name": "project004",
+//!       "mtime": "2020-07-13T17:34:59.997Z"
+//!     },
+//!     {
+//!       "name": "project005",
+//!       "mtime": "2020-07-13T17:34:59.996Z"
+//!     },
+//!     {
+//!       "name": "project006",
+//!       "mtime": "2020-07-13T17:34:59.995Z"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! Now we have the next three projects and a new token.  We can continue this
+//! way until we've listed all the projects.
+//!
+//! What does that page token look like?  It's implementation-defined, so you
+//! shouldn't rely on the structure.  In this case, it's a base64-encoded,
+//! versioned JSON structure describing the scan and the client's position in the
+//! scan:
+//!
+//! ```ignore
+//! $ echo -n 'eyJ2IjoidjEiLCJwYWdlX3N0YXJ0Ijp7Im5hbWUiOlsiYXNjZW5kaW5nIiwicHJvamVjdDAwNiJdfX0=' | base64 -d | json
+//! {
+//!   "v": "v1",
+//!   "page_start": {
+//!     "name": [
+//!       "ascending",
+//!       "project006"
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! This token says that we're scanning in ascending order of "name" and the last
+//! one we saw was "project006".  Again, this is subject to change and should not
+//! be relied upon.  We mention it here just to help explain how the pagination
+//! mechanism works.
 
 use chrono::offset::TimeZone;
 use chrono::DateTime;
@@ -122,12 +120,10 @@ use std::sync::Arc;
 #[macro_use]
 extern crate slog;
 
-/**
- * Item returned by our paginated endpoint
- *
- * Like anything returned by Dropshot, we must implement `JsonSchema` and
- * `Serialize`.  We also implement `Clone` to simplify the example.
- */
+/// Item returned by our paginated endpoint
+///
+/// Like anything returned by Dropshot, we must implement `JsonSchema` and
+/// `Serialize`.  We also implement `Clone` to simplify the example.
 #[derive(Clone, JsonSchema, Serialize)]
 struct Project {
     name: String,
@@ -135,19 +131,17 @@ struct Project {
     // lots more fields
 }
 
-/**
- * Specifies how the client wants to page through results (typically: what
- * field(s) to sort by and whether the sort should be ascending or descending)
- *
- * It's up to the consumer (e.g., this example) to decide exactly which modes
- * are supported here and what each one means.  This type represents an
- * interface that's part of the OpenAPI specification for the service.
- *
- * NOTE: To be useful, this field must be deserializable using the
- * `serde_querystring` module.  You can test this by writing test code to
- * serialize it using `serde_querystring`.  That code could fail at runtime for
- * certain types of values (e.g., enum variants that contain data).
- */
+/// Specifies how the client wants to page through results (typically: what
+/// field(s) to sort by and whether the sort should be ascending or descending)
+///
+/// It's up to the consumer (e.g., this example) to decide exactly which modes
+/// are supported here and what each one means.  This type represents an
+/// interface that's part of the OpenAPI specification for the service.
+///
+/// NOTE: To be useful, this field must be deserializable using the
+/// `serde_querystring` module.  You can test this by writing test code to
+/// serialize it using `serde_querystring`.  That code could fail at runtime for
+/// certain types of values (e.g., enum variants that contain data).
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 struct ProjectScanParams {
     #[serde(default = "default_project_sort")]
@@ -161,31 +155,29 @@ fn default_project_sort() -> ProjectSort {
 #[derive(Deserialize, Clone, JsonSchema, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum ProjectSort {
-    /** by name ascending */
+    /// by name ascending
     ByNameAscending,
-    /** by name descending */
+    /// by name descending
     ByNameDescending,
-    /** by mtime ascending, then by name ascending */
+    /// by mtime ascending, then by name ascending
     ByMtimeAscending,
-    /** by mtime descending, then by name descending */
+    /// by mtime descending, then by name descending
     ByMtimeDescending,
 }
 
-/**
- * Specifies the scan mode and the client's current position in the scan
- *
- * Dropshot uses this information to construct a page token that's sent to the
- * client with each page of results.  The client provides that page token in a
- * subsequent request for the next page of results.  Your endpoint is expected
- * to use this information to resume the scan where the previous request left
- * off.
- *
- * The most common robust and scalable implementation is to have this structure
- * include the scan mode (see above) and the last value seen the key field(s)
- * (i.e., the fields that the results are sorted by).  When you get this
- * selector back, you find the object having the next value after the one stored
- * in the token and start returning results from there.
- */
+/// Specifies the scan mode and the client's current position in the scan
+///
+/// Dropshot uses this information to construct a page token that's sent to the
+/// client with each page of results.  The client provides that page token in a
+/// subsequent request for the next page of results.  Your endpoint is expected
+/// to use this information to resume the scan where the previous request left
+/// off.
+///
+/// The most common robust and scalable implementation is to have this structure
+/// include the scan mode (see above) and the last value seen the key field(s)
+/// (i.e., the fields that the results are sorted by).  When you get this
+/// selector back, you find the object having the next value after the one stored
+/// in the token and start returning results from there.
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum ProjectScanPageSelector {
@@ -193,11 +185,9 @@ enum ProjectScanPageSelector {
     MtimeName(PaginationOrder, DateTime<Utc>, String),
 }
 
-/**
- * Given a project (typically representing the last project in a page of
- * results) and scan mode, return a page selector that can be sent to the client
- * to request the next page of results.
- */
+/// Given a project (typically representing the last project in a page of
+/// results) and scan mode, return a page selector that can be sent to the client
+/// to request the next page of results.
 fn page_selector_for(
     last_item: &Project,
     scan_params: &ProjectScanParams,
@@ -222,12 +212,10 @@ fn page_selector_for(
     }
 }
 
-/**
- * API endpoint for listing projects
- *
- * This implementation stores all the projects in a BTreeMap, which makes it
- * very easy to fetch a particular range of items based on the key.
- */
+/// API endpoint for listing projects
+///
+/// This implementation stores all the projects in a BTreeMap, which makes it
+/// very easy to fetch a particular range of items based on the key.
 #[endpoint {
     method = GET,
     path = "/projects"
@@ -303,9 +291,7 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("failed to parse \"port\" argument: {}", e))?
         .unwrap_or(0);
 
-    /*
-     * Run the Dropshot server.
-     */
+    // Run the Dropshot server.
     let ctx = ProjectCollection::new();
     let config_dropshot = ConfigDropshot {
         bind_address: SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
@@ -322,9 +308,7 @@ async fn main() -> Result<(), String> {
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 
-    /*
-     * Print out some example requests to start with.
-     */
+    // Print out some example requests to start with.
     print_example_requests(log, &server.local_addr());
 
     server.await
@@ -350,11 +334,9 @@ fn print_example_requests(log: slog::Logger, addr: &SocketAddr) {
     }
 }
 
-/**
- * Tracks a (static) collection of Projects indexed in two different ways to
- * demonstrate an endpoint that provides multiple ways to scan a large
- * collection.
- */
+/// Tracks a (static) collection of Projects indexed in two different ways to
+/// demonstrate an endpoint that provides multiple ways to scan a large
+/// collection.
 struct ProjectCollection {
     by_name: BTreeMap<String, Arc<Project>>,
     by_mtime: BTreeMap<(DateTime<Utc>, String), Arc<Project>>,
@@ -363,7 +345,7 @@ struct ProjectCollection {
 type ProjectIter<'a> = Box<dyn Iterator<Item = Arc<Project>> + 'a>;
 
 impl ProjectCollection {
-    /** Constructs an example collection of projects to back the API endpoint */
+    /// Constructs an example collection of projects to back the API endpoint
     pub fn new() -> ProjectCollection {
         let mut data = ProjectCollection {
             by_name: BTreeMap::new(),
@@ -379,12 +361,10 @@ impl ProjectCollection {
                 name: name.clone(),
                 mtime: Utc.timestamp_millis_opt(timestamp).unwrap(),
             });
-            /*
-             * To make this dataset at least somewhat interesting in terms of
-             * exercising different pagination parameters, we'll make the mtimes
-             * decrease with the names, and we'll have some objects with the same
-             * mtime.
-             */
+            // To make this dataset at least somewhat interesting in terms of
+            // exercising different pagination parameters, we'll make the mtimes
+            // decrease with the names, and we'll have some objects with the same
+            // mtime.
             if n % 10 != 0 {
                 timestamp = timestamp - 1;
             }
@@ -395,9 +375,7 @@ impl ProjectCollection {
         data
     }
 
-    /*
-     * Iterate by name (ascending, descending)
-     */
+    // Iterate by name (ascending, descending)
 
     pub fn iter_by_name_asc(&self) -> ProjectIter {
         self.make_iter(self.by_name.iter())
@@ -419,9 +397,7 @@ impl ProjectCollection {
         self.make_iter(iter)
     }
 
-    /*
-     * Iterate by mtime (ascending, descending)
-     */
+    // Iterate by mtime (ascending, descending)
 
     pub fn iter_by_mtime_asc(&self) -> ProjectIter {
         self.make_iter(self.by_mtime.iter())
@@ -452,10 +428,8 @@ impl ProjectCollection {
         self.make_iter(iter)
     }
 
-    /**
-     * Helper function to turn the initial iterators produced above into what we
-     * actually need to provide consumers.
-     */
+    /// Helper function to turn the initial iterators produced above into what we
+    /// actually need to provide consumers.
     fn make_iter<'a, K, I>(&'a self, iter: I) -> ProjectIter<'a>
     where
         I: Iterator<Item = (K, &'a Arc<Project>)> + 'a,

--- a/dropshot/examples/petstore.rs
+++ b/dropshot/examples/petstore.rs
@@ -7,9 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 fn main() -> Result<(), String> {
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(get_pet_by_id).unwrap();
     api.register(update_pet_with_form).unwrap();

--- a/dropshot/examples/schema-with-example.rs
+++ b/dropshot/examples/schema-with-example.rs
@@ -1,8 +1,6 @@
-/*!
-* Example use of dropshot to output OpenAPI compatible JSON.  This program
-* specifically illustrates how to add examples to each schema using schemars,
-* and how that will be reflected in the resultant JSON generated when ran.
-*/
+//! Example use of dropshot to output OpenAPI compatible JSON.  This program
+//! specifically illustrates how to add examples to each schema using schemars,
+//! and how that will be reflected in the resultant JSON generated when ran.
 
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk, RequestContext,
@@ -11,17 +9,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/*
- * Define 2 structs here - Bar is nested inside Foo and should result in an
- * example that looks like:
- *
- * {
- *    "id": 1,
- *    "bar": {
- *      "id: 2
- *    }
- * }
- */
+// Define 2 structs here - Bar is nested inside Foo and should result in an
+// example that looks like:
+//
+// {
+//    "id": 1,
+//    "bar": {
+//      "id: 2
+//    }
+// }
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[schemars(example = "foo_example")]

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -62,9 +62,7 @@ async fn main() -> Result<(), String> {
     shutdown.await
 }
 
-/**
- * Application-specific example context (state shared by handler functions)
- */
+/// Application-specific example context (state shared by handler functions)
 struct ExampleContext {
     counter: AtomicU64,
 }
@@ -75,9 +73,7 @@ impl ExampleContext {
     }
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 struct CounterValue {

--- a/dropshot/examples/websocket.rs
+++ b/dropshot/examples/websocket.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 Oxide Computer Company
-/*!
- * Example use of Dropshot with a websocket endpoint.
- */
+//! Example use of Dropshot with a websocket endpoint.
 
 use dropshot::channel;
 use dropshot::ApiDescription;
@@ -21,57 +19,43 @@ use tokio_tungstenite::tungstenite::Message;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot: ConfigDropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API.
-     */
+    // Build a description of the API.
     let mut api = ApiDescription::new();
     api.register(example_api_websocket_counter).unwrap();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }
 
-/*
- * HTTP API interface
- */
+// HTTP API interface
 
 #[derive(Deserialize, JsonSchema)]
 struct QueryParams {
     start: Option<u8>,
 }
 
-/**
- * An eternally-increasing sequence of bytes, wrapping on overflow, starting
- * from the value given for the query parameter "start."
- */
+/// An eternally-increasing sequence of bytes, wrapping on overflow, starting
+/// from the value given for the query parameter "start."
 #[channel {
     protocol = WEBSOCKETS,
     path = "/counter",

--- a/dropshot/examples/well-tagged.rs
+++ b/dropshot/examples/well-tagged.rs
@@ -1,11 +1,9 @@
 // Copyright 2022 Oxide Computer Company
 
-/*!
- * Example of an API that applies a rigorous tag policy in which each endpoint
- * must use exactly one of the predetermined tags. Tags are often used by
- * documentation generators; Dropshot's tag policies are intended to make
- * proper tagging innate.
- */
+//! Example of an API that applies a rigorous tag policy in which each endpoint
+//! must use exactly one of the predetermined tags. Tags are often used by
+//! documentation generators; Dropshot's tag policies are intended to make
+//! proper tagging innate.
 
 use std::sync::Arc;
 
@@ -50,27 +48,21 @@ async fn get_fryism(
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    /*
-     * We must specify a configuration with a bind address.  We'll use 127.0.0.1
-     * since it's available and won't expose this server outside the host.  We
-     * request port 0, which allows the operating system to pick any available
-     * port.
-     */
+    // We must specify a configuration with a bind address.  We'll use 127.0.0.1
+    // since it's available and won't expose this server outside the host.  We
+    // request port 0, which allows the operating system to pick any available
+    // port.
     let config_dropshot = Default::default();
 
-    /*
-     * For simplicity, we'll configure an "info"-level logger that writes to
-     * stderr assuming that it's a terminal.
-     */
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
     let config_logging =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
 
-    /*
-     * Build a description of the API -- in this case it's not much of an API!.
-     */
+    // Build a description of the API -- in this case it's not much of an API!.
     let mut api = ApiDescription::new().tag_config(TagConfig {
         allow_other_tags: false,
         endpoint_tag_policy: EndpointTagPolicy::ExactlyOne,
@@ -108,16 +100,12 @@ async fn main() -> Result<(), String> {
     api.register(get_barneyism).unwrap();
     api.register(get_fryism).unwrap();
 
-    /*
-     * Set up the server.
-     */
+    // Set up the server.
     let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut down
-     * this server, so we should never get past this point.
-     */
+    // Wait for the server to stop.  Note that there's not any code to shut down
+    // this server, so we should never get past this point.
     server.await
 }

--- a/dropshot/src/config.rs
+++ b/dropshot/src/config.rs
@@ -1,63 +1,59 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Configuration for Dropshot
- */
+//! Configuration for Dropshot
 
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-/**
- * Configuration for a Dropshot server.
- *
- * This type implements [`serde::Deserialize`] and [`serde::Serialize`] and it
- * can be composed with the consumer's configuration (whatever format that's
- * in).  For example, consumers could define a custom `MyAppConfig` for an app
- * that contains a Dropshot server:
- *
- * ```
- * use dropshot::ConfigDropshot;
- * use serde::Deserialize;
- *
- * #[derive(Deserialize)]
- * struct MyAppConfig {
- *     http_api_server: ConfigDropshot,
- *     /* ... (other app-specific config) */
- * }
- *
- * fn main() -> Result<(), String> {
- *     let my_config: MyAppConfig = toml::from_str(
- *         r##"
- *             [http_api_server]
- *             bind_address = "127.0.0.1:12345"
- *             request_body_max_bytes = 1024
- *             ## Optional, to enable TLS
- *             [http_api_server.tls]
- *             type = "AsFile"
- *             cert_file = "/path/to/certs.pem"
- *             key_file = "/path/to/key.pem"
- *
- *
- *             ## ... (other app-specific config)
- *         "##
- *     ).map_err(|error| format!("parsing config: {}", error))?;
- *
- *     let dropshot_config: &ConfigDropshot = &my_config.http_api_server;
- *     /* ... (use the config to create a server) */
- *     Ok(())
- * }
- * ```
- */
+/// Configuration for a Dropshot server.
+///
+/// This type implements [`serde::Deserialize`] and [`serde::Serialize`] and it
+/// can be composed with the consumer's configuration (whatever format that's
+/// in).  For example, consumers could define a custom `MyAppConfig` for an app
+/// that contains a Dropshot server:
+///
+/// ```
+/// use dropshot::ConfigDropshot;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyAppConfig {
+///     http_api_server: ConfigDropshot,
+///     /* ... (other app-specific config) */
+/// }
+///
+/// fn main() -> Result<(), String> {
+///     let my_config: MyAppConfig = toml::from_str(
+///         r##"
+///             [http_api_server]
+///             bind_address = "127.0.0.1:12345"
+///             request_body_max_bytes = 1024
+///             ## Optional, to enable TLS
+///             [http_api_server.tls]
+///             type = "AsFile"
+///             cert_file = "/path/to/certs.pem"
+///             key_file = "/path/to/key.pem"
+///
+///
+///             ## ... (other app-specific config)
+///         "##
+///     ).map_err(|error| format!("parsing config: {}", error))?;
+///
+///     let dropshot_config: &ConfigDropshot = &my_config.http_api_server;
+///     /* ... (use the config to create a server) */
+///     Ok(())
+/// }
+/// ```
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct ConfigDropshot {
-    /** IP address and TCP port to which to bind for accepting connections */
+    /// IP address and TCP port to which to bind for accepting connections
     pub bind_address: SocketAddr,
-    /** maximum allowed size of a request body, defaults to 1024 */
+    /// maximum allowed size of a request body, defaults to 1024
     pub request_body_max_bytes: usize,
 
-    /** If present, enables TLS with the given configuration */
+    /// If present, enables TLS with the given configuration
     pub tls: Option<ConfigTls>,
 }
 
@@ -65,15 +61,13 @@ pub struct ConfigDropshot {
 #[serde(tag = "type")]
 pub enum ConfigTls {
     AsFile {
-        /** Path to a PEM file containing a certificate chain for the
-         *  server to identify itself with. The first certificate is the
-         *  end-entity certificate, and the remaining are intermediate
-         *  certificates on the way to a trusted CA.
-         */
+        /// Path to a PEM file containing a certificate chain for the
+        ///  server to identify itself with. The first certificate is the
+        ///  end-entity certificate, and the remaining are intermediate
+        ///  certificates on the way to a trusted CA.
         cert_file: PathBuf,
-        /** Path to a PEM-encoded PKCS #8 file containing the private key the
-         *  server will use.
-         */
+        /// Path to a PEM-encoded PKCS #8 file containing the private key the
+        ///  server will use.
         key_file: PathBuf,
     },
     AsBytes {

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -1,48 +1,46 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Generic server error handling facilities
- *
- * Error handling in an API
- * ------------------------
- *
- * Our approach for managing errors within the API server balances several
- * goals:
- *
- * * Every incoming HTTP request should conclude with a response, which is
- *   either successful (200-level or 300-level status code) or a failure
- *   (400-level for client errors, 500-level for server errors).
- * * There are several different sources of errors within an API server:
- *     * The HTTP layer of the server may generate an error.  In this case, it
- *       may be just as easy to generate the appropriate HTTP response (with a
- *       400-level or 500-level status code) as it would be to generate an Error
- *       object of some kind.
- *     * An HTTP-agnostic layer of the API server code base may generate an
- *       error.  It would be nice (but not essential) if these layers did not
- *       need to know about HTTP-specific things like status codes, particularly
- *       since they may not map straightforwardly.  For example, a NotFound
- *       error from the model may not result in a 404 out the API -- it might
- *       just mean that something in the model layer needs to create an object
- *       before using it.
- *     * A library that's not part of the API server code base may generate an
- *       error.  This would include standard library interfaces returning
- *       `std::io::Error` and Hyper returning `hyper::Error`, for examples.
- * * We'd like to take advantage of Rust's built-in error handling control flow
- *   tools, like Results and the '?' operator.
- *
- * Dropshot itself is concerned only with HTTP errors.  We define `HttpError`,
- * which provides a status code, error code (via an Enum), external message (for
- * sending in the response), optional metadata, and an internal message (for the
- * log file or other instrumentation).  The HTTP layers of the request-handling
- * stack may use this struct directly.  **The set of possible error codes here
- * is part of a service's OpenAPI contract, as is the schema for any metadata.**
- * By the time an error bubbles up to the top of the request handling stack, it
- * must be an HttpError.
- *
- * For the HTTP-agnostic layers of an API server (i.e., consumers of Dropshot),
- * we recommend a separate enum to represent their errors in an HTTP-agnostic
- * way.  Consumers can provide a `From` implementation that converts these
- * errors into HttpErrors.
- */
+//! Generic server error handling facilities
+//!
+//! Error handling in an API
+//! ------------------------
+//!
+//! Our approach for managing errors within the API server balances several
+//! goals:
+//!
+//! * Every incoming HTTP request should conclude with a response, which is
+//!   either successful (200-level or 300-level status code) or a failure
+//!   (400-level for client errors, 500-level for server errors).
+//! * There are several different sources of errors within an API server:
+//!     * The HTTP layer of the server may generate an error.  In this case, it
+//!       may be just as easy to generate the appropriate HTTP response (with a
+//!       400-level or 500-level status code) as it would be to generate an Error
+//!       object of some kind.
+//!     * An HTTP-agnostic layer of the API server code base may generate an
+//!       error.  It would be nice (but not essential) if these layers did not
+//!       need to know about HTTP-specific things like status codes, particularly
+//!       since they may not map straightforwardly.  For example, a NotFound
+//!       error from the model may not result in a 404 out the API -- it might
+//!       just mean that something in the model layer needs to create an object
+//!       before using it.
+//!     * A library that's not part of the API server code base may generate an
+//!       error.  This would include standard library interfaces returning
+//!       `std::io::Error` and Hyper returning `hyper::Error`, for examples.
+//! * We'd like to take advantage of Rust's built-in error handling control flow
+//!   tools, like Results and the '?' operator.
+//!
+//! Dropshot itself is concerned only with HTTP errors.  We define `HttpError`,
+//! which provides a status code, error code (via an Enum), external message (for
+//! sending in the response), optional metadata, and an internal message (for the
+//! log file or other instrumentation).  The HTTP layers of the request-handling
+//! stack may use this struct directly.  **The set of possible error codes here
+//! is part of a service's OpenAPI contract, as is the schema for any metadata.**
+//! By the time an error bubbles up to the top of the request handling stack, it
+//! must be an HttpError.
+//!
+//! For the HTTP-agnostic layers of an API server (i.e., consumers of Dropshot),
+//! we recommend a separate enum to represent their errors in an HTTP-agnostic
+//! way.  Consumers can provide a `From` implementation that converts these
+//! errors into HttpErrors.
 
 use hyper::Error as HyperError;
 use schemars::JsonSchema;
@@ -51,67 +49,57 @@ use serde::Serialize;
 use std::error::Error;
 use std::fmt;
 
-/**
- * `HttpError` represents an error generated as part of handling an API
- * request.  When these bubble up to the top of the request handling stack
- * (which is most of the time that they're generated), these are turned into an
- * HTTP response, which includes:
- *
- *   * a status code, which is likely either 400-level (indicating a client
- *     error, like bad input) or 500-level (indicating a server error).
- *   * a structured (JSON) body, which includes:
- *       * a string error code, which identifies the underlying error condition
- *         so that clients can potentially make programmatic decisions based on
- *         the error type
- *       * a string error message, which is the human-readable summary of the
- *         issue, intended to make sense for API users (i.e., not API server
- *         developers)
- *       * optionally: additional metadata describing the issue.  For a
- *         validation error, this could include information about which
- *         parameter was invalid and why.  This should conform to a schema
- *         associated with the error code.
- *
- * It's easy to go overboard with the error codes and metadata.  Generally, we
- * should avoid creating specific codes and metadata unless there's a good
- * reason for a client to care.
- *
- * Besides that, `HttpError`s also have an internal error message, which may
- * differ from the error message that gets reported to users.  For example, if
- * the request fails because an internal database is unreachable, the client may
- * just see "internal error", while the server log would include more details
- * like "failed to acquire connection to database at 10.1.2.3".
- */
+/// `HttpError` represents an error generated as part of handling an API
+/// request.  When these bubble up to the top of the request handling stack
+/// (which is most of the time that they're generated), these are turned into an
+/// HTTP response, which includes:
+///
+///   * a status code, which is likely either 400-level (indicating a client
+///     error, like bad input) or 500-level (indicating a server error).
+///   * a structured (JSON) body, which includes:
+///       * a string error code, which identifies the underlying error condition
+///         so that clients can potentially make programmatic decisions based on
+///         the error type
+///       * a string error message, which is the human-readable summary of the
+///         issue, intended to make sense for API users (i.e., not API server
+///         developers)
+///       * optionally: additional metadata describing the issue.  For a
+///         validation error, this could include information about which
+///         parameter was invalid and why.  This should conform to a schema
+///         associated with the error code.
+///
+/// It's easy to go overboard with the error codes and metadata.  Generally, we
+/// should avoid creating specific codes and metadata unless there's a good
+/// reason for a client to care.
+///
+/// Besides that, `HttpError`s also have an internal error message, which may
+/// differ from the error message that gets reported to users.  For example, if
+/// the request fails because an internal database is unreachable, the client may
+/// just see "internal error", while the server log would include more details
+/// like "failed to acquire connection to database at 10.1.2.3".
 #[derive(Debug)]
 pub struct HttpError {
-    /*
-     * TODO-coverage add coverage in the test suite for error_code
-     * TODO-robustness should error_code just be required?  It'll be confusing
-     * to clients if it's missing sometimes.  Should this class be parametrized
-     * by some enum type?
-     * TODO-polish add cause chain for a complete log message?
-     */
-    /** HTTP status code for this error */
+    // TODO-coverage add coverage in the test suite for error_code
+    // TODO-robustness should error_code just be required?  It'll be confusing
+    // to clients if it's missing sometimes.  Should this class be parametrized
+    // by some enum type?
+    // TODO-polish add cause chain for a complete log message?
+    /// HTTP status code for this error
     pub status_code: http::StatusCode,
-    /**
-     * Optional string error code for this error.  Callers are advised to
-     * use an enum to populate this field.
-     */
+    /// Optional string error code for this error.  Callers are advised to
+    /// use an enum to populate this field.
     pub error_code: Option<String>,
-    /** Error message to be sent to API client for this error */
+    /// Error message to be sent to API client for this error
     pub external_message: String,
-    /** Error message recorded in the log for this error */
+    /// Error message recorded in the log for this error
     pub internal_message: String,
 }
 
-/**
- * Body of an HTTP response for an `HttpError`.  This type can be used to
- * deserialize an HTTP response corresponding to an error in order to access the
- * error code, message, etc.
- */
-/*
- * TODO: does this need to be pub if it's going to be expressed in the OpenAPI
- * output?
- */
+/// Body of an HTTP response for an `HttpError`.  This type can be used to
+/// deserialize an HTTP response corresponding to an error in order to access the
+/// error code, message, etc.
+// TODO: does this need to be pub if it's going to be expressed in the OpenAPI
+// output?
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[schemars(rename = "Error")]
 #[schemars(description = "Error information from a response.")]
@@ -127,10 +115,8 @@ pub struct HttpErrorResponseBody {
 
 impl From<HyperError> for HttpError {
     fn from(error: HyperError) -> Self {
-        /*
-         * TODO-correctness dig deeper into the various cases to make sure this
-         * is a valid way to represent it.
-         */
+        // TODO-correctness dig deeper into the various cases to make sure this
+        // is a valid way to represent it.
         HttpError::for_bad_request(
             None,
             format!("error processing request: {}", error),
@@ -140,10 +126,8 @@ impl From<HyperError> for HttpError {
 
 impl From<http::Error> for HttpError {
     fn from(error: http::Error) -> Self {
-        /*
-         * TODO-correctness dig deeper into the various cases to make sure this
-         * is a valid way to represent it.
-         */
+        // TODO-correctness dig deeper into the various cases to make sure this
+        // is a valid way to represent it.
         HttpError::for_bad_request(
             None,
             format!("error processing request: {}", error),
@@ -152,12 +136,10 @@ impl From<http::Error> for HttpError {
 }
 
 impl HttpError {
-    /**
-     * Generates an `HttpError` for any 400-level client error with a custom
-     * `message` used for both the internal and external message.  The
-     * expectation here is that for most 400-level errors, there's no need for a
-     * separate internal message.
-     */
+    /// Generates an `HttpError` for any 400-level client error with a custom
+    /// `message` used for both the internal and external message.  The
+    /// expectation here is that for most 400-level errors, there's no need for a
+    /// separate internal message.
     pub fn for_client_error(
         error_code: Option<String>,
         status_code: http::StatusCode,
@@ -172,10 +154,8 @@ impl HttpError {
         }
     }
 
-    /**
-     * Generates an `HttpError` for a 500 "Internal Server Error" error with the
-     * given `internal_message` for the internal message.
-     */
+    /// Generates an `HttpError` for a 500 "Internal Server Error" error with the
+    /// given `internal_message` for the internal message.
     pub fn for_internal_error(internal_message: String) -> Self {
         let status_code = http::StatusCode::INTERNAL_SERVER_ERROR;
         HttpError {
@@ -189,10 +169,8 @@ impl HttpError {
         }
     }
 
-    /**
-     * Generates an `HttpError` for a 503 "Service Unavailable" error with the
-     * given `internal_message` for the internal message.
-     */
+    /// Generates an `HttpError` for a 503 "Service Unavailable" error with the
+    /// given `internal_message` for the internal message.
     pub fn for_unavail(
         error_code: Option<String>,
         internal_message: String,
@@ -209,11 +187,9 @@ impl HttpError {
         }
     }
 
-    /**
-     * Generates a 400 "Bad Request" error with the given `message` used for
-     * both the internal and external message.  This is a convenience wrapper
-     * around [`HttpError::for_client_error`].
-     */
+    /// Generates a 400 "Bad Request" error with the given `message` used for
+    /// both the internal and external message.  This is a convenience wrapper
+    /// around [`HttpError::for_client_error`].
     pub fn for_bad_request(
         error_code: Option<String>,
         message: String,
@@ -225,26 +201,22 @@ impl HttpError {
         )
     }
 
-    /**
-     * Generates an `HttpError` for the given HTTP `status_code` where the
-     * internal and external messages for the error come from the standard label
-     * for this status code (e.g., the message for status code 404 is "Not
-     * Found").
-     */
+    /// Generates an `HttpError` for the given HTTP `status_code` where the
+    /// internal and external messages for the error come from the standard label
+    /// for this status code (e.g., the message for status code 404 is "Not
+    /// Found").
     pub fn for_status(
         error_code: Option<String>,
         status_code: http::StatusCode,
     ) -> Self {
-        /* TODO-polish This should probably be our own message. */
+        // TODO-polish This should probably be our own message.
         let message = status_code.canonical_reason().unwrap().to_string();
         HttpError::for_client_error(error_code, status_code, message)
     }
 
-    /**
-     * Generates an `HttpError` for a 404 "Not Found" error with a custom
-     * internal message `internal_message`.  The external message will be "Not
-     * Found" (i.e., the standard label for status code 404).
-     */
+    /// Generates an `HttpError` for a 404 "Not Found" error with a custom
+    /// internal message `internal_message`.  The external message will be "Not
+    /// Found" (i.e., the standard label for status code 404).
     pub fn for_not_found(
         error_code: Option<String>,
         internal_message: String,
@@ -260,24 +232,20 @@ impl HttpError {
         }
     }
 
-    /**
-     * Generates an HTTP response for the given `HttpError`, using `request_id`
-     * for the response's request id.
-     */
+    /// Generates an HTTP response for the given `HttpError`, using `request_id`
+    /// for the response's request id.
     pub fn into_response(
         self,
         request_id: &str,
     ) -> hyper::Response<hyper::Body> {
-        /*
-         * TODO-hardening: consider handling the operational errors that the
-         * Serde serialization fails or the response construction fails.  In
-         * those cases, we should probably try to report this as a serious
-         * problem (e.g., to the log) and send back a 500-level response.  (Of
-         * course, that could fail in the same way, but it's less likely because
-         * there's only one possible set of input and we can test it.  We'll
-         * probably have to use unwrap() there and make sure we've tested that
-         * code at least once!)
-         */
+        // TODO-hardening: consider handling the operational errors that the
+        // Serde serialization fails or the response construction fails.  In
+        // those cases, we should probably try to report this as a serious
+        // problem (e.g., to the log) and send back a 500-level response.  (Of
+        // course, that could fail in the same way, but it's less likely because
+        // there's only one possible set of input and we can test it.  We'll
+        // probably have to use unwrap() there and make sure we've tested that
+        // code at least once!)
         hyper::Response::builder()
             .status(self.status_code)
             .header(

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -1,37 +1,35 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Interface for implementing HTTP endpoint handler functions.
- *
- * For information about supported endpoint function signatures, argument types,
- * extractors, and return types, see the top-level documentation for this crate.
- * As documented there, we support several different sets of function arguments
- * and return types.
- *
- * We allow for variation in the function arguments not so much for programmer
- * convenience (since parsing the query string or JSON body could be implemented
- * in a line or two of code each, with the right helper functions) but rather so
- * that the type signature of the handler function can be programmatically
- * analyzed to generate an OpenAPI snippet for this endpoint.  This approach of
- * treating the server implementation as the source of truth for the API
- * specification ensures that--at least in many important ways--the
- * implementation cannot diverge from the spec.
- *
- * Just like we want API input types to be represented in function arguments, we
- * want API response types to be represented in function return values so that
- * OpenAPI tooling can identify them at build time.  The more specific a type
- * returned by the handler function, the more can be validated at build-time,
- * and the more specific an OpenAPI schema can be generated from the source
- * alone.
- *
- * We go through considerable effort below to make this interface possible.
- * Both the interface (primarily) and the implementation (less so) are inspired
- * by Actix-Web.  The Actix implementation is significantly more general (and
- * commensurately complex).  It would be possible to implement richer facilities
- * here, like extractors for backend server state, headers, and so on; allowing
- * for server and request parameters to be omitted; and so on; but those other
- * facilities don't seem that valuable right now since they largely don't affect
- * OpenAPI document generation.
- */
+//! Interface for implementing HTTP endpoint handler functions.
+//!
+//! For information about supported endpoint function signatures, argument types,
+//! extractors, and return types, see the top-level documentation for this crate.
+//! As documented there, we support several different sets of function arguments
+//! and return types.
+//!
+//! We allow for variation in the function arguments not so much for programmer
+//! convenience (since parsing the query string or JSON body could be implemented
+//! in a line or two of code each, with the right helper functions) but rather so
+//! that the type signature of the handler function can be programmatically
+//! analyzed to generate an OpenAPI snippet for this endpoint.  This approach of
+//! treating the server implementation as the source of truth for the API
+//! specification ensures that--at least in many important ways--the
+//! implementation cannot diverge from the spec.
+//!
+//! Just like we want API input types to be represented in function arguments, we
+//! want API response types to be represented in function return values so that
+//! OpenAPI tooling can identify them at build time.  The more specific a type
+//! returned by the handler function, the more can be validated at build-time,
+//! and the more specific an OpenAPI schema can be generated from the source
+//! alone.
+//!
+//! We go through considerable effort below to make this interface possible.
+//! Both the interface (primarily) and the implementation (less so) are inspired
+//! by Actix-Web.  The Actix implementation is significantly more general (and
+//! commensurately complex).  It would be possible to implement richer facilities
+//! here, like extractors for backend server state, headers, and so on; allowing
+//! for server and request parameters to be omitted; and so on; but those other
+//! facilities don't seem that valuable right now since they largely don't affect
+//! OpenAPI document generation.
 
 use super::error::HttpError;
 use super::http_util::http_extract_path_params;
@@ -76,55 +74,45 @@ use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-/**
- * Type alias for the result returned by HTTP handler functions.
- */
+/// Type alias for the result returned by HTTP handler functions.
 pub type HttpHandlerResult = Result<Response<Body>, HttpError>;
 
-/**
- * Handle for various interfaces useful during request processing.
- */
-/*
- * TODO-cleanup What's the right way to package up "request"?  The only time we
- * need it to be mutable is when we're reading the body (e.g., as part of the
- * JSON extractor).  In order to support that, we wrap it in something that
- * supports interior mutability.  It also needs to be thread-safe, since we're
- * using async/await.  That brings us to Arc<Mutex<...>>, but it seems like
- * overkill since it will only really be used by one thread at a time (at all,
- * let alone mutably) and there will never be contention on the Mutex.
- */
+/// Handle for various interfaces useful during request processing.
+// TODO-cleanup What's the right way to package up "request"?  The only time we
+// need it to be mutable is when we're reading the body (e.g., as part of the
+// JSON extractor).  In order to support that, we wrap it in something that
+// supports interior mutability.  It also needs to be thread-safe, since we're
+// using async/await.  That brings us to Arc<Mutex<...>>, but it seems like
+// overkill since it will only really be used by one thread at a time (at all,
+// let alone mutably) and there will never be contention on the Mutex.
 #[derive(Debug)]
 pub struct RequestContext<Context: ServerContext> {
-    /** shared server state */
+    /// shared server state
     pub server: Arc<DropshotState<Context>>,
-    /** HTTP request details */
+    /// HTTP request details
     pub request: Arc<Mutex<Request<Body>>>,
-    /** HTTP request routing variables */
+    /// HTTP request routing variables
     pub path_variables: VariableSet,
-    /** expected request body mime type */
+    /// expected request body mime type
     pub body_content_type: ApiEndpointBodyContentType,
-    /** unique id assigned to this request */
+    /// unique id assigned to this request
     pub request_id: String,
-    /** logger for this specific request */
+    /// logger for this specific request
     pub log: Logger,
 }
 
 impl<Context: ServerContext> RequestContext<Context> {
-    /**
-     * Returns the server context state.
-     */
+    /// Returns the server context state.
     pub fn context(&self) -> &Context {
         &self.server.private
     }
 
-    /**
-     * Returns the appropriate count of items to return for a paginated request
-     *
-     * This first looks at any client-requested limit and clamps it based on the
-     * server-configured maximum page size.  If the client did not request any
-     * particular limit, this function returns the server-configured default
-     * page size.
-     */
+    /// Returns the appropriate count of items to return for a paginated request
+    ///
+    /// This first looks at any client-requested limit and clamps it based on the
+    /// server-configured maximum page size.  If the client did not request any
+    /// particular limit, this function returns the server-configured default
+    /// page size.
     pub fn page_limit<ScanParams, PageSelector>(
         &self,
         pag_params: &PaginationParams<ScanParams, PageSelector>,
@@ -137,28 +125,22 @@ impl<Context: ServerContext> RequestContext<Context> {
 
         Ok(pag_params
             .limit
-            /*
-             * Compare the client-provided limit to the configured max for the
-             * server and take the smaller one.
-             */
+            // Compare the client-provided limit to the configured max for the
+            // server and take the smaller one.
             .map(|limit| min(limit, server_config.page_max_nitems))
-            /*
-             * If no limit was provided by the client, use the configured
-             * default.
-             */
+            // If no limit was provided by the client, use the configured
+            // default.
             .unwrap_or(server_config.page_default_nitems))
     }
 }
 
-/**
- * Helper trait for extracting the underlying Context type from the
- * first argument to an endpoint. This trait exists to help the
- * endpoint macro parse this argument.
- *
- * The first argument to an endpoint handler must be of the form:
- * `Arc<RequestContext<T>>` where `T` is a caller-supplied
- * value that implements `ServerContext`.
- */
+/// Helper trait for extracting the underlying Context type from the
+/// first argument to an endpoint. This trait exists to help the
+/// endpoint macro parse this argument.
+///
+/// The first argument to an endpoint handler must be of the form:
+/// `Arc<RequestContext<T>>` where `T` is a caller-supplied
+/// value that implements `ServerContext`.
 pub trait RequestContextArgument {
     type Context;
 }
@@ -169,26 +151,22 @@ impl<T: 'static + ServerContext> RequestContextArgument
     type Context = T;
 }
 
-/**
- * `Extractor` defines an interface allowing a type to be constructed from a
- * `RequestContext`.  Unlike most traits, `Extractor` essentially defines only a
- * constructor function, not instance functions.
- *
- * The extractors that we provide (`Query`, `Path`, `TypedBody`, `UntypedBody`, and
- * `WebsocketUpgrade`) implement `Extractor` in order to construct themselves from
- * the request. For example, `Extractor` is implemented for `Query<Q>` with a
- * function that reads the query string from the request, parses it, and
- * constructs a `Query<Q>` with it.
- *
- * We also define implementations of `Extractor` for tuples of types that
- * themselves implement `Extractor`.  See the implementation of
- * `HttpRouteHandler` for more on why this needed.
- */
+/// `Extractor` defines an interface allowing a type to be constructed from a
+/// `RequestContext`.  Unlike most traits, `Extractor` essentially defines only a
+/// constructor function, not instance functions.
+///
+/// The extractors that we provide (`Query`, `Path`, `TypedBody`, `UntypedBody`, and
+/// `WebsocketUpgrade`) implement `Extractor` in order to construct themselves from
+/// the request. For example, `Extractor` is implemented for `Query<Q>` with a
+/// function that reads the query string from the request, parses it, and
+/// constructs a `Query<Q>` with it.
+///
+/// We also define implementations of `Extractor` for tuples of types that
+/// themselves implement `Extractor`.  See the implementation of
+/// `HttpRouteHandler` for more on why this needed.
 #[async_trait]
 pub trait Extractor: Send + Sync + Sized {
-    /**
-     * Construct an instance of this type from a `RequestContext`.
-     */
+    /// Construct an instance of this type from a `RequestContext`.
     async fn from_request<Context: ServerContext>(
         rqctx: Arc<RequestContext<Context>>,
     ) -> Result<Self, HttpError>;
@@ -198,19 +176,15 @@ pub trait Extractor: Send + Sync + Sized {
     ) -> ExtractorMetadata;
 }
 
-/**
- * Metadata associated with an extractor including parameters and whether or not
- * the associated endpoint is paginated.
- */
+/// Metadata associated with an extractor including parameters and whether or not
+/// the associated endpoint is paginated.
 pub struct ExtractorMetadata {
     pub extension_mode: ExtensionMode,
     pub parameters: Vec<ApiEndpointParameter>,
 }
 
-/**
- * `impl_derived_for_tuple!` defines implementations of `Extractor` for tuples
- * whose elements themselves implement `Extractor`.
- */
+/// `impl_derived_for_tuple!` defines implementations of `Extractor` for tuples
+/// whose elements themselves implement `Extractor`.
 macro_rules! impl_extractor_for_tuple {
     ($( $T:ident),*) => {
     #[async_trait]
@@ -248,23 +222,21 @@ impl_extractor_for_tuple!(T1);
 impl_extractor_for_tuple!(T1, T2);
 impl_extractor_for_tuple!(T1, T2, T3);
 
-/**
- * `HttpHandlerFunc` is a trait providing a single function, `handle_request()`,
- * which takes an HTTP request and produces an HTTP response (or
- * `HttpError`).
- *
- * As described above, handler functions can have a number of different
- * signatures.  They all consume a reference to the current request context.
- * They may also consume some number of extractor arguments.  The
- * `HttpHandlerFunc` trait is parametrized by the type `FuncParams`, which is
- * expected to be a tuple describing these extractor arguments.
- *
- * Below, we define implementations of `HttpHandlerFunc` for various function
- * types.  In this way, we can treat functions with different signatures as
- * different kinds of `HttpHandlerFunc`.  However, since the signature shows up
- * in the `FuncParams` type parameter, we'll need additional abstraction to
- * treat different handlers interchangeably.  See `RouteHandler` below.
- */
+/// `HttpHandlerFunc` is a trait providing a single function, `handle_request()`,
+/// which takes an HTTP request and produces an HTTP response (or
+/// `HttpError`).
+///
+/// As described above, handler functions can have a number of different
+/// signatures.  They all consume a reference to the current request context.
+/// They may also consume some number of extractor arguments.  The
+/// `HttpHandlerFunc` trait is parametrized by the type `FuncParams`, which is
+/// expected to be a tuple describing these extractor arguments.
+///
+/// Below, we define implementations of `HttpHandlerFunc` for various function
+/// types.  In this way, we can treat functions with different signatures as
+/// different kinds of `HttpHandlerFunc`.  However, since the signature shows up
+/// in the `FuncParams` type parameter, we'll need additional abstraction to
+/// treat different handlers interchangeably.  See `RouteHandler` below.
 #[async_trait]
 pub trait HttpHandlerFunc<Context, FuncParams, ResponseType>:
     Send + Sync + 'static
@@ -280,88 +252,84 @@ where
     ) -> HttpHandlerResult;
 }
 
-/**
- * Defines an implementation of the `HttpHandlerFunc` trait for functions
- * matching one of the supported signatures for HTTP endpoint handler functions.
- * We use a macro to do this because we need to provide different
- * implementations for functions that take 0 arguments, 1 argument, 2 arguments,
- * etc., but the implementations are almost identical.
- */
-/*
- * For background: as the module-level documentation explains, we want to
- * support API endpoint handler functions that vary in their signature so that
- * the signature can accurately reflect details about their expected input and
- * output instead of a generic `Request -> Response` description.  The
- * `HttpHandlerFunc` trait defines an interface for invoking one of these
- * functions.  This macro defines an implementation of `HttpHandlerFunc` that
- * says how to take any of these HTTP endpoint handler function and provide that
- * uniform interface for callers.  The implementation essentially does three
- * things:
- *
- * 1. Converts the uniform arguments of `handle_request()` into the appropriate
- *    arguments for the underlying function.  This is easier than it sounds at
- *    this point because we require that one of the arguments be a tuple whose
- *    types correspond to the argument types for the function, so we just need
- *    to unpack them from the tuple into function arguments.
- *
- * 2. Converts a call to the `handle_request()` method into a call to the
- *    underlying function.
- *
- * 3. Converts the return type of the underlying function into the uniform
- *    return type expected by callers of `handle_request()`.  This, too, is
- *    easier than it sounds because we require that the return value implement
- *    `HttpResponse`.
- *
- * As mentioned above, we're implementing the trait `HttpHandlerFunc` on _any_
- * type `FuncType` that matches the trait bounds below.  In particular, it must
- * take a request context argument and whatever other type parameters have been
- * passed to this macro.
- *
- * The function's return type deserves further explanation.  (Actually, these
- * functions all return a `Future`, but for convenience when we say "return
- * type" in the comments here we're referring to the output type of the returned
- * future.)  Again, as described above, we'd like to allow HTTP endpoint
- * functions to return a variety of different return types that are ultimately
- * converted into `Result<Response<Body>, HttpError>`.  To do that, the trait
- * bounds below say that the function must produce a `Result<ResponseType,
- * HttpError>` where `ResponseType` is a type that implements `HttpResponse`.
- * We provide a few implementations of the trait `HttpTypedResponse` that
- * includes a HTTP status code and structured output. In addition we allow for
- * functions to hand-craft a `Response<Body>`. For both we implement
- * `HttpResponse` (trivially in the latter case).
- *
- *      1. Handler function
- *            |
- *            | returns:
- *            v
- *      2. Result<ResponseType, HttpError>
- *            |
- *            | This may fail with an HttpError which we return immediately.
- *            | On success, this will be Ok(ResponseType) for some specific
- *            | ResponseType that implements HttpResponse.  We'll end up
- *            | invoking:
- *            v
- *      3. ResponseType::to_result()
- *            |
- *            | This is a type-specific conversion from `ResponseType` into
- *            | `Response<Body>` that's allowed to fail with an `HttpError`.
- *            v
- *      4. Result<Response<Body>, HttpError>
- *
- * Note that the handler function may fail due to an internal error *or* the
- * conversion to JSON may successively fail in the call to
- * `serde_json::to_string()`.
- *
- * The `HttpResponse` trait lets us handle both generic responses via
- * `Response<Body>` as well as more structured responses via structures
- * implementing `HttpResponse<Body = Type>`. The latter gives us a typed
- * structure as well as response code that we use to generate rich OpenAPI
- * content.
- *
- * Note: the macro parameters really ought to be `$i:literal` and `$T:ident`,
- * however that causes us to run afoul of issue dtolnay/async-trait#46. The
- * workaround is to make both parameters `tt` (token tree).
- */
+/// Defines an implementation of the `HttpHandlerFunc` trait for functions
+/// matching one of the supported signatures for HTTP endpoint handler functions.
+/// We use a macro to do this because we need to provide different
+/// implementations for functions that take 0 arguments, 1 argument, 2 arguments,
+/// etc., but the implementations are almost identical.
+// For background: as the module-level documentation explains, we want to
+// support API endpoint handler functions that vary in their signature so that
+// the signature can accurately reflect details about their expected input and
+// output instead of a generic `Request -> Response` description.  The
+// `HttpHandlerFunc` trait defines an interface for invoking one of these
+// functions.  This macro defines an implementation of `HttpHandlerFunc` that
+// says how to take any of these HTTP endpoint handler function and provide that
+// uniform interface for callers.  The implementation essentially does three
+// things:
+//
+// 1. Converts the uniform arguments of `handle_request()` into the appropriate
+//    arguments for the underlying function.  This is easier than it sounds at
+//    this point because we require that one of the arguments be a tuple whose
+//    types correspond to the argument types for the function, so we just need
+//    to unpack them from the tuple into function arguments.
+//
+// 2. Converts a call to the `handle_request()` method into a call to the
+//    underlying function.
+//
+// 3. Converts the return type of the underlying function into the uniform
+//    return type expected by callers of `handle_request()`.  This, too, is
+//    easier than it sounds because we require that the return value implement
+//    `HttpResponse`.
+//
+// As mentioned above, we're implementing the trait `HttpHandlerFunc` on _any_
+// type `FuncType` that matches the trait bounds below.  In particular, it must
+// take a request context argument and whatever other type parameters have been
+// passed to this macro.
+//
+// The function's return type deserves further explanation.  (Actually, these
+// functions all return a `Future`, but for convenience when we say "return
+// type" in the comments here we're referring to the output type of the returned
+// future.)  Again, as described above, we'd like to allow HTTP endpoint
+// functions to return a variety of different return types that are ultimately
+// converted into `Result<Response<Body>, HttpError>`.  To do that, the trait
+// bounds below say that the function must produce a `Result<ResponseType,
+// HttpError>` where `ResponseType` is a type that implements `HttpResponse`.
+// We provide a few implementations of the trait `HttpTypedResponse` that
+// includes a HTTP status code and structured output. In addition we allow for
+// functions to hand-craft a `Response<Body>`. For both we implement
+// `HttpResponse` (trivially in the latter case).
+//
+//      1. Handler function
+//            |
+//            | returns:
+//            v
+//      2. Result<ResponseType, HttpError>
+//            |
+//            | This may fail with an HttpError which we return immediately.
+//            | On success, this will be Ok(ResponseType) for some specific
+//            | ResponseType that implements HttpResponse.  We'll end up
+//            | invoking:
+//            v
+//      3. ResponseType::to_result()
+//            |
+//            | This is a type-specific conversion from `ResponseType` into
+//            | `Response<Body>` that's allowed to fail with an `HttpError`.
+//            v
+//      4. Result<Response<Body>, HttpError>
+//
+// Note that the handler function may fail due to an internal error *or* the
+// conversion to JSON may successively fail in the call to
+// `serde_json::to_string()`.
+//
+// The `HttpResponse` trait lets us handle both generic responses via
+// `Response<Body>` as well as more structured responses via structures
+// implementing `HttpResponse<Body = Type>`. The latter gives us a typed
+// structure as well as response code that we use to generate rich OpenAPI
+// content.
+//
+// Note: the macro parameters really ought to be `$i:literal` and `$T:ident`,
+// however that causes us to run afoul of issue dtolnay/async-trait#46. The
+// workaround is to make both parameters `tt` (token tree).
 macro_rules! impl_HttpHandlerFunc_for_func_with_params {
     ($(($i:tt, $T:tt)),*) => {
 
@@ -395,41 +363,33 @@ impl_HttpHandlerFunc_for_func_with_params!((0, T0));
 impl_HttpHandlerFunc_for_func_with_params!((0, T1), (1, T2));
 impl_HttpHandlerFunc_for_func_with_params!((0, T1), (1, T2), (2, T3));
 
-/**
- * `RouteHandler` abstracts an `HttpHandlerFunc<FuncParams, ResponseType>` in a
- * way that allows callers to invoke the handler without knowing the handler's
- * function signature.
- *
- * The "Route" in `RouteHandler` refers to the fact that this structure is used
- * to record that a specific handler has been attached to a specific HTTP route.
- */
+/// `RouteHandler` abstracts an `HttpHandlerFunc<FuncParams, ResponseType>` in a
+/// way that allows callers to invoke the handler without knowing the handler's
+/// function signature.
+///
+/// The "Route" in `RouteHandler` refers to the fact that this structure is used
+/// to record that a specific handler has been attached to a specific HTTP route.
 #[async_trait]
 pub trait RouteHandler<Context: ServerContext>: Debug + Send + Sync {
-    /**
-     * Returns a description of this handler.  This might be a function name,
-     * for example.  This is not guaranteed to be unique.
-     */
+    /// Returns a description of this handler.  This might be a function name,
+    /// for example.  This is not guaranteed to be unique.
     fn label(&self) -> &str;
 
-    /**
-     * Handle an incoming HTTP request.
-     */
+    /// Handle an incoming HTTP request.
     async fn handle_request(
         &self,
         rqctx: RequestContext<Context>,
     ) -> HttpHandlerResult;
 }
 
-/**
- * `HttpRouteHandler` is the only type that implements `RouteHandler`.  The
- * reason both exist is that we need `HttpRouteHandler::new()` to consume an
- * arbitrary kind of `HttpHandlerFunc<FuncParams>` and return an object that's
- * _not_ parametrized by `FuncParams`.  In fact, the resulting
- * `HttpRouteHandler` _is_ parametrized by `FuncParams`, but we returned it
- * as a `RouteHandler` that does not have those type parameters, allowing the
- * caller to ignore the differences between different handler function type
- * signatures.
- */
+/// `HttpRouteHandler` is the only type that implements `RouteHandler`.  The
+/// reason both exist is that we need `HttpRouteHandler::new()` to consume an
+/// arbitrary kind of `HttpHandlerFunc<FuncParams>` and return an object that's
+/// _not_ parametrized by `FuncParams`.  In fact, the resulting
+/// `HttpRouteHandler` _is_ parametrized by `FuncParams`, but we returned it
+/// as a `RouteHandler` that does not have those type parameters, allowing the
+/// caller to ignore the differences between different handler function type
+/// signatures.
 pub struct HttpRouteHandler<Context, HandlerType, FuncParams, ResponseType>
 where
     Context: ServerContext,
@@ -437,20 +397,18 @@ where
     FuncParams: Extractor,
     ResponseType: HttpResponse + Send + Sync + 'static,
 {
-    /** the actual HttpHandlerFunc used to implement this route */
+    /// the actual HttpHandlerFunc used to implement this route
     handler: HandlerType,
 
-    /** debugging label for the handler */
+    /// debugging label for the handler
     label: String,
 
-    /**
-     * In order to define `new()` below, we need a type parameter `HandlerType`
-     * that implements `HttpHandlerFunc<FuncParams>`, which means we also need a
-     * `FuncParams` type parameter.  However, this type parameter would be
-     * unconstrained, which makes Rust upset.  Use of PhantomData<FuncParams>
-     * here causes the compiler to behave as though this struct referred to a
-     * `FuncParams`, which allows us to use the type parameter below.
-     */
+    /// In order to define `new()` below, we need a type parameter `HandlerType`
+    /// that implements `HttpHandlerFunc<FuncParams>`, which means we also need a
+    /// `FuncParams` type parameter.  However, this type parameter would be
+    /// unconstrained, which makes Rust upset.  Use of PhantomData<FuncParams>
+    /// here causes the compiler to behave as though this struct referred to a
+    /// `FuncParams`, which allows us to use the type parameter below.
     phantom: PhantomData<(FuncParams, ResponseType, Context)>,
 }
 
@@ -484,24 +442,22 @@ where
         &self,
         rqctx_raw: RequestContext<Context>,
     ) -> HttpHandlerResult {
-        /*
-         * This is where the magic happens: in the code below, `funcparams` has
-         * type `FuncParams`, which is a tuple type describing the extractor
-         * arguments to the handler function.  This could be `()`, `(Query<Q>)`,
-         * `(TypedBody<J>)`, `(Query<Q>, TypedBody<J>)`, or any other
-         * combination of extractors we decide to support in the future.
-         * Whatever it is must implement `Extractor`, which means we can invoke
-         * `Extractor::from_request()` to construct the argument tuple,
-         * generally from information available in the `request` object.  We
-         * pass this down to the `HttpHandlerFunc`, for which there's a
-         * different implementation for each value of `FuncParams`.  The
-         * `HttpHandlerFunc` for each `FuncParams` just pulls the arguments out
-         * of the `funcparams` tuple and makes them actual function arguments
-         * for the actual handler function.  From this point down, all of this
-         * is resolved statically.makes them actual function arguments for the
-         * actual handler function.  From this point down, all of this is
-         * resolved statically.
-         */
+        // This is where the magic happens: in the code below, `funcparams` has
+        // type `FuncParams`, which is a tuple type describing the extractor
+        // arguments to the handler function.  This could be `()`, `(Query<Q>)`,
+        // `(TypedBody<J>)`, `(Query<Q>, TypedBody<J>)`, or any other
+        // combination of extractors we decide to support in the future.
+        // Whatever it is must implement `Extractor`, which means we can invoke
+        // `Extractor::from_request()` to construct the argument tuple,
+        // generally from information available in the `request` object.  We
+        // pass this down to the `HttpHandlerFunc`, for which there's a
+        // different implementation for each value of `FuncParams`.  The
+        // `HttpHandlerFunc` for each `FuncParams` just pulls the arguments out
+        // of the `funcparams` tuple and makes them actual function arguments
+        // for the actual handler function.  From this point down, all of this
+        // is resolved statically.makes them actual function arguments for the
+        // actual handler function.  From this point down, all of this is
+        // resolved statically.
         let rqctx = Arc::new(rqctx_raw);
         let funcparams = Extractor::from_request(Arc::clone(&rqctx)).await?;
         let future = self.handler.handle_request(rqctx, funcparams);
@@ -509,9 +465,7 @@ where
     }
 }
 
-/*
- * Public interfaces
- */
+// Public interfaces
 
 impl<Context, HandlerType, FuncParams, ResponseType>
     HttpRouteHandler<Context, HandlerType, FuncParams, ResponseType>
@@ -521,20 +475,16 @@ where
     FuncParams: Extractor + 'static,
     ResponseType: HttpResponse + Send + Sync + 'static,
 {
-    /**
-     * Given a function matching one of the supported API handler function
-     * signatures, return a RouteHandler that can be used to respond to HTTP
-     * requests using this function.
-     */
+    /// Given a function matching one of the supported API handler function
+    /// signatures, return a RouteHandler that can be used to respond to HTTP
+    /// requests using this function.
     pub fn new(handler: HandlerType) -> Box<dyn RouteHandler<Context>> {
         HttpRouteHandler::new_with_name(handler, "<unlabeled handler>")
     }
 
-    /**
-     * Given a function matching one of the supported API handler function
-     * signatures, return a RouteHandler that can be used to respond to HTTP
-     * requests using this function.
-     */
+    /// Given a function matching one of the supported API handler function
+    /// signatures, return a RouteHandler that can be used to respond to HTTP
+    /// requests using this function.
     pub fn new_with_name(
         handler: HandlerType,
         label: &str,
@@ -547,38 +497,28 @@ where
     }
 }
 
-/*
- * Extractors
- */
+// Extractors
 
-/*
- * Query: query string extractor
- */
+// Query: query string extractor
 
-/**
- * `Query<QueryType>` is an extractor used to deserialize an instance of
- * `QueryType` from an HTTP request's query string.  `QueryType` is any
- * structure of yours that implements `serde::Deserialize`.  See this module's
- * documentation for more information.
- */
+/// `Query<QueryType>` is an extractor used to deserialize an instance of
+/// `QueryType` from an HTTP request's query string.  `QueryType` is any
+/// structure of yours that implements `serde::Deserialize`.  See this module's
+/// documentation for more information.
 #[derive(Debug)]
 pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
     inner: QueryType,
 }
 
 impl<QueryType: DeserializeOwned + JsonSchema + Send + Sync> Query<QueryType> {
-    /*
-     * TODO drop this in favor of Deref?  + Display and Debug for convenience?
-     */
+    // TODO drop this in favor of Deref?  + Display and Debug for convenience?
     pub fn into_inner(self) -> QueryType {
         self.inner
     }
 }
 
-/**
- * Given an HTTP request, pull out the query string and attempt to deserialize
- * it as an instance of `QueryType`.
- */
+/// Given an HTTP request, pull out the query string and attempt to deserialize
+/// it as an instance of `QueryType`.
 fn http_request_load_query<QueryType>(
     request: &Request<Body>,
 ) -> Result<Query<QueryType>, HttpError>
@@ -586,9 +526,7 @@ where
     QueryType: DeserializeOwned + JsonSchema + Send + Sync,
 {
     let raw_query_string = request.uri().query().unwrap_or("");
-    /*
-     * TODO-correctness: are query strings defined to be urlencoded in this way?
-     */
+    // TODO-correctness: are query strings defined to be urlencoded in this way?
     match serde_urlencoded::from_str(raw_query_string) {
         Ok(q) => Ok(Query { inner: q }),
         Err(e) => Err(HttpError::for_bad_request(
@@ -598,14 +536,12 @@ where
     }
 }
 
-/*
- * The `Extractor` implementation for Query<QueryType> describes how to construct
- * an instance of `Query<QueryType>` from an HTTP request: namely, by parsing
- * the query string to an instance of `QueryType`.
- * TODO-cleanup We shouldn't have to use the "'static" bound on `QueryType`
- * here.  It seems like we ought to be able to use 'async_trait, but that
- * doesn't seem to be defined.
- */
+// The `Extractor` implementation for Query<QueryType> describes how to construct
+// an instance of `Query<QueryType>` from an HTTP request: namely, by parsing
+// the query string to an instance of `QueryType`.
+// TODO-cleanup We shouldn't have to use the "'static" bound on `QueryType`
+// here.  It seems like we ought to be able to use 'async_trait, but that
+// doesn't seem to be defined.
 #[async_trait]
 impl<QueryType> Extractor for Query<QueryType>
 where
@@ -625,35 +561,27 @@ where
     }
 }
 
-/*
- * Path: path parameter string extractor
- */
+// Path: path parameter string extractor
 
-/**
- * `Path<PathType>` is an extractor used to deserialize an instance of
- * `PathType` from an HTTP request's path parameters.  `PathType` is any
- * structure of yours that implements `serde::Deserialize`.  See this module's
- * documentation for more information.
- */
+/// `Path<PathType>` is an extractor used to deserialize an instance of
+/// `PathType` from an HTTP request's path parameters.  `PathType` is any
+/// structure of yours that implements `serde::Deserialize`.  See this module's
+/// documentation for more information.
 #[derive(Debug)]
 pub struct Path<PathType: JsonSchema + Send + Sync> {
     inner: PathType,
 }
 
 impl<PathType: JsonSchema + Send + Sync> Path<PathType> {
-    /*
-     * TODO drop this in favor of Deref?  + Display and Debug for convenience?
-     */
+    // TODO drop this in favor of Deref?  + Display and Debug for convenience?
     pub fn into_inner(self) -> PathType {
         self.inner
     }
 }
 
-/*
- * The `Extractor` implementation for Path<PathType> describes how to construct
- * an instance of `Path<QueryType>` from an HTTP request: namely, by extracting
- * parameters from the query string.
- */
+// The `Extractor` implementation for Path<PathType> describes how to construct
+// an instance of `Path<QueryType>` from an HTTP request: namely, by extracting
+// parameters from the query string.
 #[async_trait]
 impl<PathType> Extractor for Path<PathType>
 where
@@ -673,20 +601,16 @@ where
     }
 }
 
-/**
- * Convenience function to generate parameter metadata from types implementing
- * `JsonSchema` for use with `Query` and `Path` `Extractors`.
- */
+/// Convenience function to generate parameter metadata from types implementing
+/// `JsonSchema` for use with `Query` and `Path` `Extractors`.
 fn get_metadata<ParamType>(
     loc: &ApiEndpointParameterLocation,
 ) -> ExtractorMetadata
 where
     ParamType: JsonSchema,
 {
-    /*
-     * Generate the type for `ParamType` then pluck out each member of
-     * the structure to encode as an individual parameter.
-     */
+    // Generate the type for `ParamType` then pluck out each member of
+    // the structure to encode as an individual parameter.
     let mut generator = schemars::gen::SchemaGenerator::new(
         schemars::gen::SchemaSettings::openapi3(),
     );
@@ -711,9 +635,7 @@ where
         None => ExtensionMode::None,
     };
 
-    /*
-     * Convert our collection of struct members list of parameters.
-     */
+    // Convert our collection of struct members list of parameters.
     let parameters = schema2struct(&schema, &generator, true)
         .into_iter()
         .map(|struct_member| {
@@ -747,9 +669,7 @@ fn schema_extensions(
     }
 }
 
-/**
- * Used to visit all schemas and collect all dependencies.
- */
+/// Used to visit all schemas and collect all dependencies.
 struct ReferenceVisitor<'a> {
     generator: &'a schemars::gen::SchemaGenerator,
     dependencies: indexmap::IndexMap<String, schemars::schema::Schema>,
@@ -801,29 +721,25 @@ pub(crate) struct StructMember {
     pub required: bool,
 }
 
-/**
- * This helper function produces a list of the structure members for the
- * given schema. For each it returns:
- *   (name: &String, schema: &Schema, required: bool)
- *
- * If the input schema is not a flat structure the result will be a runtime
- * failure reflective of a programming error (likely an invalid type specified
- * in a handler function).
- *
- * This function is invoked recursively on subschemas.
- */
+/// This helper function produces a list of the structure members for the
+/// given schema. For each it returns:
+///   (name: &String, schema: &Schema, required: bool)
+///
+/// If the input schema is not a flat structure the result will be a runtime
+/// failure reflective of a programming error (likely an invalid type specified
+/// in a handler function).
+///
+/// This function is invoked recursively on subschemas.
 pub(crate) fn schema2struct(
     schema: &schemars::schema::Schema,
     generator: &schemars::gen::SchemaGenerator,
     required: bool,
 ) -> Vec<StructMember> {
-    /*
-     * We ignore schema.metadata, which includes things like doc comments, and
-     * schema.extensions. We call these out explicitly rather than eliding them
-     * as .. since we match all other fields in the structure.
-     */
+    // We ignore schema.metadata, which includes things like doc comments, and
+    // schema.extensions. We call these out explicitly rather than eliding them
+    // as .. since we match all other fields in the structure.
     match schema {
-        /* We expect references to be on their own. */
+        // We expect references to be on their own.
         schemars::schema::Schema::Object(schemars::schema::SchemaObject {
             metadata: _,
             instance_type: None,
@@ -843,7 +759,7 @@ pub(crate) fn schema2struct(
             required,
         ),
 
-        /* Match objects and subschemas. */
+        // Match objects and subschemas.
         schemars::schema::Schema::Object(schemars::schema::SchemaObject {
             metadata: _,
             instance_type: Some(schemars::schema::SingleOrVec::Single(_)),
@@ -860,10 +776,8 @@ pub(crate) fn schema2struct(
         }) => {
             let mut results = Vec::new();
 
-            /*
-             * If there's a top-level object, add its members to the list of
-             * parameters.
-             */
+            // If there's a top-level object, add its members to the list of
+            // parameters.
             if let Some(object) = object {
                 results.extend(object.properties.iter().map(
                     |(name, schema)| {
@@ -880,13 +794,11 @@ pub(crate) fn schema2struct(
                 ));
             }
 
-            /*
-             * We might see subschemas here in the case of flattened enums
-             * or flattened structures that have associated doc comments.
-             */
+            // We might see subschemas here in the case of flattened enums
+            // or flattened structures that have associated doc comments.
             if let Some(subschemas) = subschemas {
                 match subschemas.as_ref() {
-                    /* We expect any_of in the case of an enum. */
+                    // We expect any_of in the case of an enum.
                     schemars::schema::SubschemaValidation {
                         all_of: None,
                         any_of: Some(schemas),
@@ -896,16 +808,14 @@ pub(crate) fn schema2struct(
                         then_schema: None,
                         else_schema: None,
                     } => results.extend(schemas.iter().flat_map(|subschema| {
-                        /* Note that these will be tagged as optional. */
+                        // Note that these will be tagged as optional.
                         schema2struct(subschema, generator, false)
                     })),
 
-                    /*
-                     * With an all_of, there should be a single element. We
-                     * typically see this in the case where there is a doc
-                     * comment on a structure as OpenAPI 3.0.x doesn't have
-                     * a description field directly on schemas.
-                     */
+                    // With an all_of, there should be a single element. We
+                    // typically see this in the case where there is a doc
+                    // comment on a structure as OpenAPI 3.0.x doesn't have
+                    // a description field directly on schemas.
                     schemars::schema::SubschemaValidation {
                         all_of: Some(subschemas),
                         any_of: None,
@@ -920,7 +830,7 @@ pub(crate) fn schema2struct(
                         }),
                     ),
 
-                    /* We don't expect any other types of subschemas. */
+                    // We don't expect any other types of subschemas.
                     invalid => panic!("invalid subschema {:#?}", invalid),
                 }
             }
@@ -928,22 +838,18 @@ pub(crate) fn schema2struct(
             results
         }
 
-        /* The generated schema should be an object. */
+        // The generated schema should be an object.
         invalid => panic!("invalid type {:#?}", invalid),
     }
 }
 
-/*
- * TypedBody: body extractor for formats that can be deserialized to a specific
- * type.  Only JSON is currently supported.
- */
+// TypedBody: body extractor for formats that can be deserialized to a specific
+// type.  Only JSON is currently supported.
 
-/**
- * `TypedBody<BodyType>` is an extractor used to deserialize an instance of
- * `BodyType` from an HTTP request body.  `BodyType` is any structure of yours
- * that implements `serde::Deserialize`.  See this module's documentation for
- * more information.
- */
+/// `TypedBody<BodyType>` is an extractor used to deserialize an instance of
+/// `BodyType` from an HTTP request body.  `BodyType` is any structure of yours
+/// that implements `serde::Deserialize`.  See this module's documentation for
+/// more information.
 #[derive(Debug)]
 pub struct TypedBody<BodyType: JsonSchema + DeserializeOwned + Send + Sync> {
     inner: BodyType,
@@ -952,18 +858,14 @@ pub struct TypedBody<BodyType: JsonSchema + DeserializeOwned + Send + Sync> {
 impl<BodyType: JsonSchema + DeserializeOwned + Send + Sync>
     TypedBody<BodyType>
 {
-    /*
-     * TODO drop this in favor of Deref?  + Display and Debug for convenience?
-     */
+    // TODO drop this in favor of Deref?  + Display and Debug for convenience?
     pub fn into_inner(self) -> BodyType {
         self.inner
     }
 }
 
-/**
- * Given an HTTP request, attempt to read the body, parse it according
- * to the content type, and deserialize it to an instance of `BodyType`.
- */
+/// Given an HTTP request, attempt to read the body, parse it according
+/// to the content type, and deserialize it to an instance of `BodyType`.
 async fn http_request_load_body<Context: ServerContext, BodyType>(
     rqctx: Arc<RequestContext<Context>>,
 ) -> Result<TypedBody<BodyType>, HttpError>
@@ -1029,14 +931,12 @@ where
     Ok(TypedBody { inner: content })
 }
 
-/*
- * The `Extractor` implementation for TypedBody<BodyType> describes how to
- * construct an instance of `TypedBody<BodyType>` from an HTTP request: namely,
- * by reading the request body and parsing it as JSON into type `BodyType`.
- * TODO-cleanup We shouldn't have to use the "'static" bound on `BodyType` here.
- * It seems like we ought to be able to use 'async_trait, but that doesn't seem
- * to be defined.
- */
+// The `Extractor` implementation for TypedBody<BodyType> describes how to
+// construct an instance of `TypedBody<BodyType>` from an HTTP request: namely,
+// by reading the request body and parsing it as JSON into type `BodyType`.
+// TODO-cleanup We shouldn't have to use the "'static" bound on `BodyType` here.
+// It seems like we ought to be able to use 'async_trait, but that doesn't seem
+// to be defined.
 #[async_trait]
 impl<BodyType> Extractor for TypedBody<BodyType>
 where
@@ -1065,34 +965,24 @@ where
     }
 }
 
-/*
- * UntypedBody: body extractor for a plain array of bytes of a body.
- */
+// UntypedBody: body extractor for a plain array of bytes of a body.
 
-/**
- * `UntypedBody` is an extractor for reading in the contents of the HTTP request
- * body and making the raw bytes directly available to the consumer.
- */
+/// `UntypedBody` is an extractor for reading in the contents of the HTTP request
+/// body and making the raw bytes directly available to the consumer.
 #[derive(Debug)]
 pub struct UntypedBody {
     content: Bytes,
 }
 
 impl UntypedBody {
-    /**
-     * Returns a byte slice of the underlying body content.
-     */
-    /*
-     * TODO drop this in favor of Deref?  + Display and Debug for convenience?
-     */
+    /// Returns a byte slice of the underlying body content.
+    // TODO drop this in favor of Deref?  + Display and Debug for convenience?
     pub fn as_bytes(&self) -> &[u8] {
         &self.content
     }
 
-    /**
-     * Convenience wrapper to convert the body to a UTF-8 string slice,
-     * returning a 400-level error if the body is not valid UTF-8.
-     */
+    /// Convenience wrapper to convert the body to a UTF-8 string slice,
+    /// returning a 400-level error if the body is not valid UTF-8.
     pub fn as_str(&self) -> Result<&str, HttpError> {
         std::str::from_utf8(self.as_bytes()).map_err(|e| {
             HttpError::for_bad_request(
@@ -1143,35 +1033,25 @@ impl Extractor for UntypedBody {
     }
 }
 
-/*
- * Response Type Conversion
- *
- * See the discussion on macro `impl_HttpHandlerFunc_for_func_with_params` for a
- * great deal of context on this.
- */
+// Response Type Conversion
+//
+// See the discussion on macro `impl_HttpHandlerFunc_for_func_with_params` for a
+// great deal of context on this.
 
-/**
- * HttpResponse must produce a `Result<Response<Body>, HttpError>` and generate
- * the response metadata.  Typically one should use `Response<Body>` or an
- * implementation of `HttpTypedResponse`.
- */
+/// HttpResponse must produce a `Result<Response<Body>, HttpError>` and generate
+/// the response metadata.  Typically one should use `Response<Body>` or an
+/// implementation of `HttpTypedResponse`.
 pub trait HttpResponse {
-    /**
-     * Generate the response to the HTTP call.
-     */
+    /// Generate the response to the HTTP call.
     fn to_result(self) -> HttpHandlerResult;
 
-    /**
-     * Extract status code and structure metadata for the non-error response.
-     * Type information for errors is handled generically across all endpoints.
-     */
+    /// Extract status code and structure metadata for the non-error response.
+    /// Type information for errors is handled generically across all endpoints.
     fn response_metadata() -> ApiEndpointResponse;
 }
 
-/**
- * `Response<Body>` is used for free-form responses. The implementation of
- * `to_result()` is trivial, and we don't have any typed metadata to return.
- */
+/// `Response<Body>` is used for free-form responses. The implementation of
+/// `to_result()` is trivial, and we don't have any typed metadata to return.
 impl HttpResponse for Response<Body> {
     fn to_result(self) -> HttpHandlerResult {
         Ok(self)
@@ -1191,21 +1071,17 @@ impl From<Body> for FreeformBody {
     }
 }
 
-/**
- * An "empty" type used to represent responses that have no associated data
- * payload. This isn't intended for general use, but must be pub since it's
- * used as the Body type for certain responses.
- */
+/// An "empty" type used to represent responses that have no associated data
+/// payload. This isn't intended for general use, but must be pub since it's
+/// used as the Body type for certain responses.
 #[doc(hidden)]
 pub struct Empty;
 
-/*
- * Specific Response Types
- *
- * The `HttpTypedResponse` trait and the concrete types below are provided so
- * that handler functions can return types that indicate at compile time the
- * kind of HTTP response body they produce.
- */
+// Specific Response Types
+//
+// The `HttpTypedResponse` trait and the concrete types below are provided so
+// that handler functions can return types that indicate at compile time the
+// kind of HTTP response body they produce.
 
 /// Adapter trait that allows both concrete types that implement [JsonSchema]
 /// and the [FreeformBody] type to add their content to a response builder
@@ -1277,11 +1153,9 @@ where
     }
 }
 
-/**
- * The `HttpCodedResponse` trait is used for all of the specific response types
- * that we provide. We use it in particular to encode the success status code
- * and the type information of the return value.
- */
+/// The `HttpCodedResponse` trait is used for all of the specific response types
+/// that we provide. We use it in particular to encode the success status code
+/// and the type information of the return value.
 pub trait HttpCodedResponse:
     Into<HttpHandlerResult> + Send + Sync + 'static
 {
@@ -1289,20 +1163,16 @@ pub trait HttpCodedResponse:
     const STATUS_CODE: StatusCode;
     const DESCRIPTION: &'static str;
 
-    /**
-     * Convenience method to produce a response based on the input
-     * `body_object` (whose specific type is defined by the implementing type)
-     * and the STATUS_CODE specified by the implementing type. This is a default
-     * trait method to allow callers to avoid redundant type specification.
-     */
+    /// Convenience method to produce a response based on the input
+    /// `body_object` (whose specific type is defined by the implementing type)
+    /// and the STATUS_CODE specified by the implementing type. This is a default
+    /// trait method to allow callers to avoid redundant type specification.
     fn for_object(body: Self::Body) -> HttpHandlerResult {
         body.to_response(Response::builder().status(Self::STATUS_CODE))
     }
 }
 
-/**
- * Provide results and metadata generation for all implementing types.
- */
+/// Provide results and metadata generation for all implementing types.
 impl<T> HttpResponse for T
 where
     T: HttpCodedResponse,
@@ -1326,16 +1196,12 @@ fn make_subschema_for<T: JsonSchema>(
     gen.subschema_for::<T>()
 }
 
-/**
- * `HttpResponseCreated<T: Serialize>` wraps an object of any serializable type.
- * It denotes an HTTP 201 "Created" response whose body is generated by
- * serializing the object.
- */
-/*
- * TODO-cleanup should ApiObject move into this submodule?  It'd be nice if we
- * could restrict this to an ApiObject::View (by having T: ApiObject and the
- * field having type T::View).
- */
+/// `HttpResponseCreated<T: Serialize>` wraps an object of any serializable type.
+/// It denotes an HTTP 201 "Created" response whose body is generated by
+/// serializing the object.
+// TODO-cleanup should ApiObject move into this submodule?  It'd be nice if we
+// could restrict this to an ApiObject::View (by having T: ApiObject and the
+// field having type T::View).
 pub struct HttpResponseCreated<T: HttpResponseContent + Send + Sync + 'static>(
     pub T,
 );
@@ -1350,16 +1216,14 @@ impl<T: HttpResponseContent + Send + Sync + 'static>
     From<HttpResponseCreated<T>> for HttpHandlerResult
 {
     fn from(response: HttpResponseCreated<T>) -> HttpHandlerResult {
-        /* TODO-correctness (or polish?): add Location header */
+        // TODO-correctness (or polish?): add Location header
         HttpResponseCreated::for_object(response.0)
     }
 }
 
-/**
- * `HttpResponseAccepted<T: Serialize>` wraps an object of any
- * serializable type.  It denotes an HTTP 202 "Accepted" response whose body is
- * generated by serializing the object.
- */
+/// `HttpResponseAccepted<T: Serialize>` wraps an object of any
+/// serializable type.  It denotes an HTTP 202 "Accepted" response whose body is
+/// generated by serializing the object.
 pub struct HttpResponseAccepted<T: HttpResponseContent + Send + Sync + 'static>(
     pub T,
 );
@@ -1378,11 +1242,9 @@ impl<T: HttpResponseContent + Send + Sync + 'static>
     }
 }
 
-/**
- * `HttpResponseOk<T: Serialize>` wraps an object of any serializable type.  It
- * denotes an HTTP 200 "OK" response whose body is generated by serializing the
- * object.
- */
+/// `HttpResponseOk<T: Serialize>` wraps an object of any serializable type.  It
+/// denotes an HTTP 200 "OK" response whose body is generated by serializing the
+/// object.
 pub struct HttpResponseOk<T: HttpResponseContent + Send + Sync + 'static>(
     pub T,
 );
@@ -1401,10 +1263,8 @@ impl<T: HttpResponseContent + Send + Sync + 'static> From<HttpResponseOk<T>>
     }
 }
 
-/**
- * `HttpResponseDeleted` represents an HTTP 204 "No Content" response, intended
- * for use when an API operation has successfully deleted an object.
- */
+/// `HttpResponseDeleted` represents an HTTP 204 "No Content" response, intended
+/// for use when an API operation has successfully deleted an object.
 pub struct HttpResponseDeleted();
 
 impl HttpCodedResponse for HttpResponseDeleted {
@@ -1418,11 +1278,9 @@ impl From<HttpResponseDeleted> for HttpHandlerResult {
     }
 }
 
-/**
- * `HttpResponseUpdatedNoContent` represents an HTTP 204 "No Content" response,
- * intended for use when an API operation has successfully updated an object and
- * has nothing to return.
- */
+/// `HttpResponseUpdatedNoContent` represents an HTTP 204 "No Content" response,
+/// intended for use when an API operation has successfully updated an object and
+/// has nothing to return.
 pub struct HttpResponseUpdatedNoContent();
 
 impl HttpCodedResponse for HttpResponseUpdatedNoContent {
@@ -1436,45 +1294,41 @@ impl From<HttpResponseUpdatedNoContent> for HttpHandlerResult {
     }
 }
 
-/** Describes headers associated with a 300-level response. */
+/// Describes headers associated with a 300-level response.
 #[derive(JsonSchema, Serialize)]
 #[doc(hidden)]
 pub struct RedirectHeaders {
-    /** HTTP "Location" header */
-    /*
-     * What type should we use to represent header values?
-     *
-     * It's tempting to use `http::HeaderValue` here.  But in HTTP, header
-     * values can contain bytes that aren't valid Rust strings.  See
-     * `http::header::HeaderValue`.  We could propagate this nonsense all the
-     * way to the OpenAPI spec, encoding the Location header as, say,
-     * base64-encoded bytes.  This sounds really annoying to consumers.  It's
-     * also a fair bit more work to implement.  We'd need to create a separate
-     * type for this field so that we can impl `Serialize` and `JsonSchema` on
-     * it, and we'd need to also impl serialization of byte sequences in
-     * `MapSerializer`.  Ugh.
-     *
-     * We just use `String`.  This might contain values that aren't valid in
-     * HTTP response headers.  But we can at least validate that at runtime, and
-     * it sure is easier to implement!
-     */
+    /// HTTP "Location" header
+    // What type should we use to represent header values?
+    //
+    // It's tempting to use `http::HeaderValue` here.  But in HTTP, header
+    // values can contain bytes that aren't valid Rust strings.  See
+    // `http::header::HeaderValue`.  We could propagate this nonsense all the
+    // way to the OpenAPI spec, encoding the Location header as, say,
+    // base64-encoded bytes.  This sounds really annoying to consumers.  It's
+    // also a fair bit more work to implement.  We'd need to create a separate
+    // type for this field so that we can impl `Serialize` and `JsonSchema` on
+    // it, and we'd need to also impl serialization of byte sequences in
+    // `MapSerializer`.  Ugh.
+    //
+    // We just use `String`.  This might contain values that aren't valid in
+    // HTTP response headers.  But we can at least validate that at runtime, and
+    // it sure is easier to implement!
     location: String,
 }
 
-/** See `http_response_found()` */
+/// See `http_response_found()`
 pub type HttpResponseFound =
     HttpResponseHeaders<HttpResponseFoundStatus, RedirectHeaders>;
 
-/**
- * `http_response_found` returns an HTTP 302 "Found" response with no response
- * body.
- *
- * The sole argument will become the value of the `Location` header.  This is
- * where you want to redirect the client to.
- *
- * Per MDN and RFC 9110 S15.4.3, you might want to use 307 ("Temporary
- * Redirect") or 303 ("See Other") instead.
- */
+/// `http_response_found` returns an HTTP 302 "Found" response with no response
+/// body.
+///
+/// The sole argument will become the value of the `Location` header.  This is
+/// where you want to redirect the client to.
+///
+/// Per MDN and RFC 9110 S15.4.3, you might want to use 307 ("Temporary
+/// Redirect") or 303 ("See Other") instead.
 pub fn http_response_found(
     location: String,
 ) -> Result<HttpResponseFound, HttpError> {
@@ -1496,11 +1350,9 @@ fn http_redirect_error(
     ))
 }
 
-/**
- * This internal type impls HttpCodedResponse.  Consumers should use
- * `HttpResponseFound` instead, which includes metadata about the `Location`
- * header.
- */
+/// This internal type impls HttpCodedResponse.  Consumers should use
+/// `HttpResponseFound` instead, which includes metadata about the `Location`
+/// header.
 #[doc(hidden)]
 pub struct HttpResponseFoundStatus;
 impl HttpCodedResponse for HttpResponseFoundStatus {
@@ -1514,22 +1366,20 @@ impl From<HttpResponseFoundStatus> for HttpHandlerResult {
     }
 }
 
-/** See `http_response_see_other()` */
+/// See `http_response_see_other()`
 pub type HttpResponseSeeOther =
     HttpResponseHeaders<HttpResponseSeeOtherStatus, RedirectHeaders>;
 
-/**
- * `http_response_see_other` returns an HTTP 303 "See Other" response with no
- * response body.
- *
- * The sole argument will become the value of the `Location` header.  This is
- * where you want to redirect the client to.
- *
- * Use this (as opposed to 307 "Temporary Redirect") when you want the client to
- * follow up with a GET, rather than whatever method they used to make the
- * current request.  This is intended to be used after a PUT or POST to show a
- * confirmation page or the like.
- */
+/// `http_response_see_other` returns an HTTP 303 "See Other" response with no
+/// response body.
+///
+/// The sole argument will become the value of the `Location` header.  This is
+/// where you want to redirect the client to.
+///
+/// Use this (as opposed to 307 "Temporary Redirect") when you want the client to
+/// follow up with a GET, rather than whatever method they used to make the
+/// current request.  This is intended to be used after a PUT or POST to show a
+/// confirmation page or the like.
 pub fn http_response_see_other(
     location: String,
 ) -> Result<HttpResponseSeeOther, HttpError> {
@@ -1541,11 +1391,9 @@ pub fn http_response_see_other(
     ))
 }
 
-/**
- * This internal type impls HttpCodedResponse.  Consumers should use
- * `HttpResponseSeeOther` instead, which includes metadata about the `Location`
- * header.
- */
+/// This internal type impls HttpCodedResponse.  Consumers should use
+/// `HttpResponseSeeOther` instead, which includes metadata about the `Location`
+/// header.
 #[doc(hidden)]
 pub struct HttpResponseSeeOtherStatus;
 impl HttpCodedResponse for HttpResponseSeeOtherStatus {
@@ -1559,20 +1407,18 @@ impl From<HttpResponseSeeOtherStatus> for HttpHandlerResult {
     }
 }
 
-/** See `http_response_temporary_redirect()` */
+/// See `http_response_temporary_redirect()`
 pub type HttpResponseTemporaryRedirect =
     HttpResponseHeaders<HttpResponseTemporaryRedirectStatus, RedirectHeaders>;
 
-/**
- * `http_response_temporary_redirect` represents an HTTP 307 "Temporary
- * Redirect" response with no response body.
- *
- * The sole argument will become the value of the `Location` header.  This is
- * where you want to redirect the client to.
- *
- * Use this (as opposed to 303 "See Other") when you want the client to use the
- * same request method and body when it makes the follow-up request.
- */
+/// `http_response_temporary_redirect` represents an HTTP 307 "Temporary
+/// Redirect" response with no response body.
+///
+/// The sole argument will become the value of the `Location` header.  This is
+/// where you want to redirect the client to.
+///
+/// Use this (as opposed to 303 "See Other") when you want the client to use the
+/// same request method and body when it makes the follow-up request.
 pub fn http_response_temporary_redirect(
     location: String,
 ) -> Result<HttpResponseTemporaryRedirect, HttpError> {
@@ -1584,11 +1430,9 @@ pub fn http_response_temporary_redirect(
     ))
 }
 
-/**
- * This internal type impls HttpCodedResponse.  Consumers should use
- * `HttpResponseTemporaryRedirect` instead, which includes metadata about the
- * `Location` header.
- */
+/// This internal type impls HttpCodedResponse.  Consumers should use
+/// `HttpResponseTemporaryRedirect` instead, which includes metadata about the
+/// `Location` header.
 #[doc(hidden)]
 pub struct HttpResponseTemporaryRedirectStatus;
 impl HttpCodedResponse for HttpResponseTemporaryRedirectStatus {
@@ -1605,16 +1449,14 @@ impl From<HttpResponseTemporaryRedirectStatus> for HttpHandlerResult {
 #[derive(Serialize, JsonSchema)]
 pub struct NoHeaders {}
 
-/**
- * `HttpResponseHeaders` is a wrapper for responses that include both
- * structured and unstructured headers. The first type parameter is a
- * `HttpTypedResponse` that provides the structure of the response body.
- * The second type parameter is an optional struct that enumerates named
- * headers that are included in the response. In addition to those (optional)
- * named headers, consumers may add additional headers via the `headers_mut`
- * interface. Unnamed headers override named headers in the case of naming
- * conflicts.
- */
+/// `HttpResponseHeaders` is a wrapper for responses that include both
+/// structured and unstructured headers. The first type parameter is a
+/// `HttpTypedResponse` that provides the structure of the response body.
+/// The second type parameter is an optional struct that enumerates named
+/// headers that are included in the response. In addition to those (optional)
+/// named headers, consumers may add additional headers via the `headers_mut`
+/// interface. Unnamed headers override named headers in the case of naming
+/// conflicts.
 pub struct HttpResponseHeaders<
     T: HttpCodedResponse,
     H: JsonSchema + Serialize + Send + Sync + 'static = NoHeaders,
@@ -1657,9 +1499,9 @@ impl<
     fn to_result(self) -> HttpHandlerResult {
         let HttpResponseHeaders { body, structured_headers, other_headers } =
             self;
-        /* Compute the body. */
+        // Compute the body.
         let mut result = body.into()?;
-        /* Add in both the structured and other headers. */
+        // Add in both the structured and other headers.
         let headers = result.headers_mut();
         let header_map = to_map(&structured_headers).map_err(|e| {
             HttpError::for_internal_error(format!(
@@ -1715,11 +1557,9 @@ impl<
 fn schema_extract_description(
     schema: &schemars::schema::Schema,
 ) -> (Option<String>, schemars::schema::Schema) {
-    /*
-     * Because the OpenAPI v3.0.x Schema cannot include a description with
-     * a reference, we may see a schema with a description and an `all_of`
-     * with a single subschema. In this case, we flatten the trivial subschema.
-     */
+    // Because the OpenAPI v3.0.x Schema cannot include a description with
+    // a reference, we may see a schema with a description and an `all_of`
+    // with a single subschema. In this case, we flatten the trivial subschema.
     if let schemars::schema::Schema::Object(schemars::schema::SchemaObject {
         metadata,
         instance_type: None,
@@ -1822,10 +1662,8 @@ mod test {
     ) {
         assert_eq!(actual.extension_mode, extension_mode);
 
-        /*
-         * This is order-dependent. We might not really care if the order
-         * changes, but it will be interesting to understand why if it does.
-         */
+        // This is order-dependent. We might not really care if the order
+        // changes, but it will be interesting to understand why if it does.
         actual.parameters.iter().zip(parameters.iter()).for_each(
             |(param, (name, required))| {
                 if let ApiEndpointParameter {

--- a/dropshot/src/http_util.rs
+++ b/dropshot/src/http_util.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * General-purpose HTTP-related facilities
- */
+//! General-purpose HTTP-related facilities
 
 use bytes::BufMut;
 use bytes::Bytes;
@@ -12,22 +10,20 @@ use super::error::HttpError;
 use crate::from_map::from_map;
 use crate::router::VariableSet;
 
-/** header name for conveying request ids ("x-request-id") */
+/// header name for conveying request ids ("x-request-id")
 pub const HEADER_REQUEST_ID: &str = "x-request-id";
-/** MIME type for raw bytes */
+/// MIME type for raw bytes
 pub const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
-/** MIME type for plain JSON data */
+/// MIME type for plain JSON data
 pub const CONTENT_TYPE_JSON: &str = "application/json";
-/** MIME type for newline-delimited JSON data */
+/// MIME type for newline-delimited JSON data
 pub const CONTENT_TYPE_NDJSON: &str = "application/x-ndjson";
-/** MIME type for form/urlencoded data */
+/// MIME type for form/urlencoded data
 pub const CONTENT_TYPE_URL_ENCODED: &str = "application/x-www-form-urlencoded";
 
-/**
- * Reads the rest of the body from the request up to the given number of bytes.
- * If the body fits within the specified cap, a buffer is returned with all the
- * bytes read.  If not, an error is returned.
- */
+/// Reads the rest of the body from the request up to the given number of bytes.
+/// If the body fits within the specified cap, a buffer is returned with all the
+/// bytes read.  If not, an error is returned.
 pub async fn http_read_body<T>(
     body: &mut T,
     cap: usize,
@@ -35,18 +31,16 @@ pub async fn http_read_body<T>(
 where
     T: HttpBody<Data = Bytes, Error = hyper::Error> + std::marker::Unpin,
 {
-    /*
-     * This looks a lot like the implementation of hyper::body::to_bytes(), but
-     * applies the requested cap.  We've skipped the optimization for the
-     * 1-buffer case for now, as it seems likely this implementation will change
-     * anyway.
-     * TODO should this use some Stream interface instead?
-     * TODO why does this look so different in type signature (Data=Bytes,
-     * std::marker::Unpin, &mut T)
-     * TODO Error type shouldn't have to be hyper Error -- Into<ApiError> should
-     * work too?
-     * TODO do we need to use saturating_add() here?
-     */
+    // This looks a lot like the implementation of hyper::body::to_bytes(), but
+    // applies the requested cap.  We've skipped the optimization for the
+    // 1-buffer case for now, as it seems likely this implementation will change
+    // anyway.
+    // TODO should this use some Stream interface instead?
+    // TODO why does this look so different in type signature (Data=Bytes,
+    // std::marker::Unpin, &mut T)
+    // TODO Error type shouldn't have to be hyper Error -- Into<ApiError> should
+    // work too?
+    // TODO do we need to use saturating_add() here?
     let mut parts = std::vec::Vec::new();
     let mut nbytesread: usize = 0;
     while let Some(maybebuf) = body.data().await {
@@ -66,95 +60,81 @@ where
         parts.put(buf);
     }
 
-    /*
-     * Read the trailers as well, even though we're not going to do anything
-     * with them.
-     */
+    // Read the trailers as well, even though we're not going to do anything
+    // with them.
     body.trailers().await?;
-    /*
-     * TODO-correctness why does the is_end_stream() assertion fail and the next
-     * one panic?
-     */
+    // TODO-correctness why does the is_end_stream() assertion fail and the next
+    // one panic?
     // assert!(body.is_end_stream());
     // assert!(body.data().await.is_none());
     // assert!(body.trailers().await?.is_none());
     Ok(parts.into())
 }
 
-/**
- * Reads the rest of the body from the request, dropping all the bytes.  This is
- * useful after encountering error conditions.
- */
+/// Reads the rest of the body from the request, dropping all the bytes.  This is
+/// useful after encountering error conditions.
 pub async fn http_dump_body<T>(body: &mut T) -> Result<usize, T::Error>
 where
     T: HttpBody<Data = Bytes> + std::marker::Unpin,
 {
-    /*
-     * TODO should this use some Stream interface instead?
-     * TODO-hardening: does this actually cap the amount of data that will be
-     * read?  What if the underlying implementation chooses to wait for a much
-     * larger number of bytes?
-     * TODO better understand pin_mut!()
-     * TODO do we need to use saturating_add() here?
-     */
+    // TODO should this use some Stream interface instead?
+    // TODO-hardening: does this actually cap the amount of data that will be
+    // read?  What if the underlying implementation chooses to wait for a much
+    // larger number of bytes?
+    // TODO better understand pin_mut!()
+    // TODO do we need to use saturating_add() here?
     let mut nbytesread: usize = 0;
     while let Some(maybebuf) = body.data().await {
         let buf = maybebuf?;
         nbytesread += buf.len();
     }
 
-    /*
-     * TODO-correctness why does the is_end_stream() assertion fail?
-     */
+    // TODO-correctness why does the is_end_stream() assertion fail?
     // assert!(body.is_end_stream());
     Ok(nbytesread)
 }
 
-/**
- * Given a set of variables (most immediately from a RequestContext, likely
- * generated by the HttpRouter when routing an incoming request), extract them
- * into an instance of type T.  This is a convenience function that reports an
- * appropriate error when the extraction fails.
- *
- * Note that if this function fails, either there was a type error (e.g., a path
- * parameter was supposed to be a UUID, but wasn't), in which case we should
- * report a 400-level error; or the caller attempted to extract a parameter
- * (using a field in T) that wasn't populated in `path_params`.  This latter
- * case is a programmer error -- this invocation can never work with this type
- * for this HTTP handler.  Ideally, we'd catch this at build time, but we don't
- * currently do that.  However, we _do_ currently catch this at server startup
- * time, so this case should be impossible.
- *
- * TODO-cleanup: It would be better to fail to build when the struct's
- * parameters don't match up precisely with the path parameters
- * TODO-cleanup It would also be nice to know if the struct could not possibly
- * be correctly constructed from path parameters because the struct contains
- * values that could not be represented in path parameters (e.g., nested
- * structs).  One approach to doing this would be to skip serde altogether here
- * for `T` and instead define our own trait.  We could define a "derive" macro
- * that would do something similar to serde, but only allows field values that
- * implement FromStr.  Then we'd at least know at build time that the consumer
- * gave us a type that could conceivably be represented by the path parameters.
- * TODO-testing: Add automated tests.
- */
+/// Given a set of variables (most immediately from a RequestContext, likely
+/// generated by the HttpRouter when routing an incoming request), extract them
+/// into an instance of type T.  This is a convenience function that reports an
+/// appropriate error when the extraction fails.
+///
+/// Note that if this function fails, either there was a type error (e.g., a path
+/// parameter was supposed to be a UUID, but wasn't), in which case we should
+/// report a 400-level error; or the caller attempted to extract a parameter
+/// (using a field in T) that wasn't populated in `path_params`.  This latter
+/// case is a programmer error -- this invocation can never work with this type
+/// for this HTTP handler.  Ideally, we'd catch this at build time, but we don't
+/// currently do that.  However, we _do_ currently catch this at server startup
+/// time, so this case should be impossible.
+///
+/// TODO-cleanup: It would be better to fail to build when the struct's
+/// parameters don't match up precisely with the path parameters
+/// TODO-cleanup It would also be nice to know if the struct could not possibly
+/// be correctly constructed from path parameters because the struct contains
+/// values that could not be represented in path parameters (e.g., nested
+/// structs).  One approach to doing this would be to skip serde altogether here
+/// for `T` and instead define our own trait.  We could define a "derive" macro
+/// that would do something similar to serde, but only allows field values that
+/// implement FromStr.  Then we'd at least know at build time that the consumer
+/// gave us a type that could conceivably be represented by the path parameters.
+/// TODO-testing: Add automated tests.
 pub fn http_extract_path_params<T: DeserializeOwned>(
     path_params: &VariableSet,
 ) -> Result<T, HttpError> {
     from_map(path_params).map_err(|message| {
-        /*
-         * TODO-correctness We'd like to assert that the error here is a bad
-         * type, not a missing field.  If it's a missing field, then we somehow
-         * allowed somebody to register a handler function for a path where the
-         * handler function's path parameters are inconsistent with the actual
-         * path registered.  Unfortunately, we don't have a way to
-         * programmatically distinguish these values at this point.  In fact,
-         * even with our own deserializer, we'd also have to build our
-         * own serde::de::Error impl in order to distinguish this particular
-         * case.  For now, we resort to parsing the error message.
-         * TODO-correctness The error message produced in the type-error case
-         * (that end users will see) does not indicate which path parameter was
-         * invalid.  That's pretty bad for end users.
-         */
+        // TODO-correctness We'd like to assert that the error here is a bad
+        // type, not a missing field.  If it's a missing field, then we somehow
+        // allowed somebody to register a handler function for a path where the
+        // handler function's path parameters are inconsistent with the actual
+        // path registered.  Unfortunately, we don't have a way to
+        // programmatically distinguish these values at this point.  In fact,
+        // even with our own deserializer, we'd also have to build our
+        // own serde::de::Error impl in order to distinguish this particular
+        // case.  For now, we resort to parsing the error message.
+        // TODO-correctness The error message produced in the type-error case
+        // (that end users will see) does not indicate which path parameter was
+        // invalid.  That's pretty bad for end users.
         assert!(!message.starts_with("missing field: "));
         HttpError::for_bad_request(
             None,

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -1,554 +1,547 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Dropshot is a general-purpose crate for exposing REST APIs from a Rust
- * program.  Planned highlights include:
- *
- * * Suitability for production use on a largely untrusted network.
- *   Dropshot-based systems should be high-performing, reliable, debuggable, and
- *   secure against basic denial of service attacks (intentional or otherwise).
- *
- * * First-class OpenAPI support, in the form of precise OpenAPI specs generated
- *   directly from code.  This works because the functions that serve HTTP
- *   resources consume arguments and return values of specific types from which
- *   a schema can be statically generated.
- *
- * * Ease of integrating into a diverse team.  An important use case for
- *   Dropshot consumers is to have a team of engineers where individuals might
- *   add a few endpoints at a time to a complex server, and it should be
- *   relatively easy to do this.  Part of this means an emphasis on the
- *   principle of least surprise: like Rust itself, we may choose abstractions
- *   that require more time to learn up front in order to make it harder to
- *   accidentally build systems that will not perform, will crash in corner
- *   cases, etc.
- *
- * By "REST API", we primarily mean an API built atop existing HTTP primitives,
- * organized into hierarchical resources, and providing consistent, idempotent
- * mechanisms to create, update, list, and delete those resources.  "REST" can
- * mean a range of things depending on who you talk to, and some people are
- * dogmatic about what is or isn't RESTy.  We find such dogma not only
- * unhelpful, but poorly defined.  (Consider such a simple case as trying to
- * update a resource in a REST API.  Popular APIs sometimes use `PUT`, `PATCH`,
- * or `POST` for the verb; and JSON Merge Patch or JSON Patch as the format.
- * (sometimes without even knowing it!).  There's hardly a clear standard, yet
- * this is a really basic operation for any REST API.)
- *
- * For a discussion of alternative crates considered, see Oxide RFD 10.
- *
- * We hope Dropshot will be fairly general-purpose, but it's primarily intended
- * to address the needs of the Oxide control plane.
- *
- *
- * ## Usage
- *
- * The bare minimum might look like this:
- *
- * ```no_run
- * use dropshot::ApiDescription;
- * use dropshot::ConfigDropshot;
- * use dropshot::ConfigLogging;
- * use dropshot::ConfigLoggingLevel;
- * use dropshot::HttpServerStarter;
- * use std::sync::Arc;
- *
- * #[tokio::main]
- * async fn main() -> Result<(), String> {
- *     // Set up a logger.
- *     let log =
- *         ConfigLogging::StderrTerminal {
- *             level: ConfigLoggingLevel::Info,
- *         }
- *         .to_logger("minimal-example")
- *         .map_err(|e| e.to_string())?;
- *
- *     // Describe the API.
- *     let api = ApiDescription::new();
- *     // Register API functions -- see detailed example or ApiDescription docs.
- *
- *     // Start the server.
- *     let server =
- *         HttpServerStarter::new(
- *             &ConfigDropshot {
- *                 bind_address: "127.0.0.1:0".parse().unwrap(),
- *                 request_body_max_bytes: 1024,
- *                 tls: None,
- *             },
- *             api,
- *             Arc::new(()),
- *             &log,
- *         )
- *         .map_err(|error| format!("failed to start server: {}", error))?
- *         .start();
- *
- *     server.await
- * }
- * ```
- *
- * This server returns a 404 for all resources because no API functions were
- * registered.  See `examples/basic.rs` for a simple, documented example that
- * provides a few resources using shared state.
- *
- * For a given `ApiDescription`, you can also print out an OpenAPI spec
- * describing the API.  See [`ApiDescription::openapi`].
- *
- *
- * ## API Handler Functions
- *
- * HTTP talks about **resources**.  For a REST API, we often talk about
- * **endpoints** or **operations**, which are identified by a combination of the
- * HTTP method and the URI path.
- *
- * Example endpoints for a resource called a "project" might include:
- *
- * * `GET /projects` (list projects)
- * * `POST /projects` (one way to create a project)
- * * `GET /projects/my_project` (fetch one project)
- * * `PUT /projects/my_project` (update (or possibly create) a project)
- * * `DELETE /projects/my_project` (delete a project)
- *
- * With Dropshot, an incoming request for a given API endpoint is handled by a
- * particular Rust function.  That function is called an **entrypoint**, an
- * **endpoint handler**, or a **handler function**.  When you set up a Dropshot
- * server, you configure the set of available API endpoints and which functions
- * will handle each one by setting up an [`ApiDescription`].
- *
- * Typically, you define an endpoint with a handler function by using the
- * [`endpoint`] macro. Here's an example of a single endpoint that lists
- * a hardcoded project:
- *
- * ```
- * use dropshot::endpoint;
- * use dropshot::ApiDescription;
- * use dropshot::HttpError;
- * use dropshot::HttpResponseOk;
- * use dropshot::RequestContext;
- * use http::Method;
- * use schemars::JsonSchema;
- * use serde::Serialize;
- * use std::sync::Arc;
- *
- * /** Represents a project in our API */
- * #[derive(Serialize, JsonSchema)]
- * struct Project {
- *     /** name of the project */
- *     name: String,
- * }
- *
- * /** Fetch a project. */
- * #[endpoint {
- *     method = GET,
- *     path = "/projects/project1",
- * }]
- * async fn myapi_projects_get_project(
- *     rqctx: Arc<RequestContext<()>>,
- * ) -> Result<HttpResponseOk<Project>, HttpError>
- * {
- *    let project = Project { name: String::from("project1") };
- *    Ok(HttpResponseOk(project))
- * }
- *
- * fn main() {
- *     let mut api = ApiDescription::new();
- *
- *     /*
- *      * Register our endpoint and its handler function.  The "endpoint" macro
- *      * specifies the HTTP method and URI path that identify the endpoint,
- *      * allowing this metadata to live right alongside the handler function.
- *      */
- *     api.register(myapi_projects_get_project).unwrap();
- *
- *     /* ... (use `api` to set up an `HttpServer` ) */
- * }
- *
- * ```
- *
- * There's quite a lot going on here:
- *
- * * The `endpoint` macro specifies the HTTP method and URI path.  When we
- *   invoke `ApiDescription::register()`, this information is used to register
- *   the endpoint that will be handled by our function.
- * * The signature of our function indicates that on success, it returns a
- *   `HttpResponseOk<Project>`.  This means that the function will
- *   return an HTTP 200 status code ("OK") with an object of type `Project`.
- * * The function itself has a Rustdoc comment that will be used to document
- *   this _endpoint_ in the OpenAPI schema.
- *
- * From this information, Dropshot can generate an OpenAPI specification for
- * this API that describes the endpoint (which OpenAPI calls an "operation"),
- * its documentation, the possible responses that it can return, and the schema
- * for each type of response (which can also include documentation).  This is
- * largely known statically, though generated at runtime.
- *
- *
- * ### `#[endpoint { ... }]` attribute parameters
- *
- * The `endpoint` attribute accepts parameters the affect the operation of
- * the endpoint as well as metadata that appears in the OpenAPI description
- * of it.
- *
- * ```ignore
- * #[endpoint {
- *     // Required fields
- *     method = { DELETE | GET | PATCH | POST | PUT },
- *     path = "/path/name/with/{named}/{variables}",
- *
- *     // Optional fields
- *     tags = [ "all", "your", "OpenAPI", "tags" ],
- * }]
- * ```
- *
- * This is where you specify the HTTP method and path (including path variables)
- * for the API endpoint. These are used as part of endpoint registration and
- * appear in the OpenAPI spec output.
- *
- * The tags field is used to categorize API endpoints and only impacts the
- * OpenAPI spec output.
- *
- *
- * ### Function parameters
- *
- * In general, a handler function looks like this:
- *
- * ```ignore
- * async fn f(
- *      rqctx: Arc<RequestContext<Context>>,
- *      [query_params: Query<Q>,]
- *      [path_params: Path<P>,]
- *      [body_param: TypedBody<J>,]
- *      [body_param: UntypedBody<J>,]
- * ) -> Result<HttpResponse*, HttpError>
- * ```
- *
- * Other than the RequestContext, parameters may appear in any order.
- *
- * The `Context` type is caller-provided context which is provided when
- * the server is created.
- *
- * The types `Query`, `Path`, `TypedBody`, and `UntypedBody` are called
- * **Extractors** because they cause information to be pulled out of the request
- * and made available to the handler function.
- *
- * * [`Query`]`<Q>` extracts parameters from a query string, deserializing them
- *   into an instance of type `Q`. `Q` must implement `serde::Deserialize` and
- *   `schemars::JsonSchema`.
- * * [`Path`]`<P>` extracts parameters from HTTP path, deserializing them into
- *   an instance of type `P`. `P` must implement `serde::Deserialize` and
- *   `schemars::JsonSchema`.
- * * [`TypedBody`]`<J>` extracts content from the request body by parsing the
- *   body as JSON (or form/url-encoded) and deserializing it into an instance
- *   of type `J`. `J` must implement `serde::Deserialize` and `schemars::JsonSchema`.
- * * [`UntypedBody`] extracts the raw bytes of the request body.
- *
- * If the handler takes a `Query<Q>`, `Path<P>`, `TypedBody<J>`, or
- * `UntypedBody`, and the corresponding extraction cannot be completed, the
- * request fails with status code 400 and an error message reflecting a
- * validation error.
- *
- * As with any serde-deserializable type, you can make fields optional by having
- * the corresponding property of the type be an `Option`.  Here's an example of
- * an endpoint that takes two arguments via query parameters: "limit", a
- * required u32, and "marker", an optional string:
- *
- * ```
- * use http::StatusCode;
- * use dropshot::HttpError;
- * use dropshot::TypedBody;
- * use dropshot::Query;
- * use dropshot::RequestContext;
- * use hyper::Body;
- * use hyper::Response;
- * use schemars::JsonSchema;
- * use serde::Deserialize;
- * use std::sync::Arc;
- *
- * #[derive(Deserialize, JsonSchema)]
- * struct MyQueryArgs {
- *     limit: u32,
- *     marker: Option<String>
- * }
- *
- * struct MyContext {}
- *
- * async fn myapi_projects_get(
- *     rqctx: Arc<RequestContext<MyContext>>,
- *     query: Query<MyQueryArgs>)
- *     -> Result<Response<Body>, HttpError>
- * {
- *     let query_args = query.into_inner();
- *     let context: &MyContext = rqctx.context();
- *     let limit: u32 = query_args.limit;
- *     let marker: Option<String> = query_args.marker;
- *     Ok(Response::builder()
- *         .status(StatusCode::OK)
- *         .body(format!("limit = {}, marker = {:?}\n", limit, marker).into())?)
- * }
- * ```
- *
- * ### Endpoint function return types
- *
- * Endpoint handler functions are async, so they always return a `Future`.  When
- * we say "return type" below, we use that as shorthand for the output of the
- * future.
- *
- * An endpoint function must return a type that implements `HttpResponse`.
- * Typically this should be a type that implements `HttpTypedResponse` (either
- * one of the Dropshot-provided ones or one of your own creation).
- *
- * The more specific a type returned by the handler function, the more can be
- * validated at build-time, and the more specific an OpenAPI schema can be
- * generated from the source code.  For example, a POST to an endpoint
- * "/projects" might return `Result<HttpResponseCreated<Project>, HttpError>`.
- * As you might expect, on success, this turns into an HTTP 201 "Created"
- * response whose body is constructed by serializing the `Project`.  In this
- * example, OpenAPI tooling can identify at build time that this function
- * produces a 201 "Created" response on success with a body whose schema matches
- * `Project` (which we already said implements `Serialize`), and there would be
- * no way to violate this contract at runtime.
- *
- * These are the implementations of `HttpTypedResponse` with their associated
- * HTTP response code
- * on the HTTP method:
- *
- * | Return Type | HTTP status code |
- * | ----------- | ---------------- |
- * | [`HttpResponseOk`] | 200 |
- * | [`HttpResponseCreated`] | 201 |
- * | [`HttpResponseAccepted`] | 202 |
- * | [`HttpResponseDeleted`] | 204 |
- * | [`HttpResponseUpdatedNoContent`] | 204 |
- *
- * In situations where the response schema is not fixed, the endpoint should
- * return `Response<Body>`, which also implements `HttpResponse`. Note that
- * the OpenAPI spec will not include any status code or type information in
- * this case.
- *
- * ## What about generic handlers that run on all requests?
- *
- * There's no mechanism in Dropshot for this.  Instead, it's recommended that
- * users commonize code using regular Rust functions and calling them.  See the
- * design notes in the README for more on this.
- *
- *
- * ## Support for paginated resources
- *
- * "Pagination" here refers to the interface pattern where HTTP resources (or
- * API endpoints) that provide a list of the items in a collection return a
- * relatively small maximum number of items per request, often called a "page"
- * of results.  Each page includes some metadata that the client can use to make
- * another request for the next page of results.  The client can repeat this
- * until they've gotten all the results.  Limiting the number of results
- * returned per request helps bound the resource utilization and time required
- * for any request, which in turn facilities horizontal scalability, high
- * availability, and protection against some denial of service attacks
- * (intentional or otherwise).  For more background, see the comments in
- * dropshot/src/pagination.rs.
- *
- * Pagination support in Dropshot implements this common pattern:
- *
- * * This server exposes an **API endpoint** that returns the **items**
- *   contained within a **collection**.
- * * The client is not allowed to list the entire collection in one request.
- *   Instead, they list the collection using a sequence of requests to the one
- *   endpoint.  We call this sequence of requests a **scan** of the collection,
- *   and we sometimes say that the client **pages through** the collection.
- * * The initial request in the scan may specify the **scan parameters**, which
- *   typically specify how the results are to be sorted (i.e., by which
- *   field(s) and whether the sort is ascending or descending), any filters to
- *   apply, etc.
- * * Each request returns a **page** of results at a time, along with a **page
- *   token** that's provided with the next request as a query parameter.
- * * The scan parameters cannot change between requests that are part of the
- *   same scan.
- * * With all requests: there's a default limit (e.g., 100 items returned at a
- *   time).  Clients can request a higher limit using a query parameter (e.g.,
- *   `limit=1000`).  This limit is capped by a hard limit on the server.  If the
- *   client asks for more than the hard limit, the server can use the hard limit
- *   or reject the request.
- *
- * As an example, imagine that we have an API endpoint called `"/animals"`.  Each
- * item returned is an `Animal` object that might look like this:
- *
- * ```json
- * {
- *     "name": "aardvark",
- *     "class": "mammal",
- *     "max_weight": "80", /* kilograms, typical */
- * }
- * ```
- *
- * There are at least 1.5 million known species of animal -- too many to return
- * in one API call!  Our API supports paginating them by `"name"`, which we'll
- * say is a unique field in our data set.
- *
- * The first request to the API fetches `"/animals"` (with no querystring
- * parameters) and returns:
- *
- * ```json
- * {
- *     "page_token": "abc123...",
- *     "items": [
- *         {
- *             "name": "aardvark",
- *             "class": "mammal",
- *             "max_weight": "80",
- *         },
- *         ...
- *         {
- *             "name": "badger",
- *             "class": "mammal",
- *             "max_weight": "12",
- *         }
- *     ]
- * }
- * ```
- *
- * The subsequent request to the API fetches `"/animals?page_token=abc123..."`.
- * The page token `"abc123..."` is an opaque token to the client, but typically
- * encodes the scan parameters and the value of the last item seen
- * (`"name=badger"`).  The client knows it has completed the scan when it
- * receives a response with no `page_token` in it.
- *
- * Our API endpoint can also support scanning in reverse order.  In this case,
- * when the client makes the first request, it should fetch
- * `"/animals?sort=name-descending"`.  Now the first result might be `"zebra"`.
- * Again, the page token must include the scan parameters so that in subsequent
- * requests, the API endpoint knows that we're scanning backwards, not forwards,
- * from the value we were given.  It's not allowed to change directions or sort
- * order in the middle of a scan.  (You can always start a new scan, but you
- * can't pick up from where you were in the previous scan.)
- *
- * It's also possible to support sorting by multiple fields.  For example, we
- * could support `sort=class-name`, which we could define to mean that we'll
- * sort the results first by the animal's class, then by name.  Thus we'd get
- * all the amphibians in sorted order, then all the mammals, then all the
- * reptiles.  The main requirement is that the combination of fields used for
- * pagination must be unique.  We cannot paginate by the animal's class alone.
- * (To see why: there are over 6,000 mammals.  If the page size is, say, 1000,
- * then the page_token would say `"mammal"`, but there's not enough information
- * there to see where we are within the list of mammals.  It doesn't matter
- * whether there are 2 mammals or 6,000 because clients can limit the page size
- * to just one item if they want and that ought to work.)
- *
- *
- * ### Dropshot interfaces for pagination
- *
- * We can think of pagination in two parts: the input (handling the pagination
- * query parameters) and the output (emitting a page of results, including the
- * page token).
- *
- * For input, a paginated API endpoint's handler function should accept a
- * [`Query`]`<`[`PaginationParams`]`<ScanParams, PageSelector>>`, where
- * `ScanParams` is a consumer-defined type specifying the parameters of the scan
- * (typically including the sort fields, sort order, and filter options) and
- * `PageSelector` is a consumer-defined type describing the page token.  The
- * PageSelector will be serialized to JSON and base64-encoded to construct the
- * page token.  This will be automatically parsed on the way back in.
- *
- * For output, a paginated API endpoint's handler function can return
- * `Result<`[`HttpResponseOk`]<[`ResultsPage`]`<T>, HttpError>` where `T:
- * Serialize` is the item listed by the endpoint.  You can also use your own
- * structure that contains a [`ResultsPage`] (possibly using
- * `#[serde(flatten)]`), if that's the behavior you want.
- *
- * There are several complete, documented examples in the "examples" directory.
- *
- *
- * ### Advanced usage notes
- *
- * It's possible to accept additional query parameters besides the pagination
- * parameters by having your API endpoint handler function take two different
- * arguments using `Query`, like this:
- *
- * ```
- * use dropshot::HttpError;
- * use dropshot::HttpResponseOk;
- * use dropshot::PaginationParams;
- * use dropshot::Query;
- * use dropshot::RequestContext;
- * use dropshot::ResultsPage;
- * use dropshot::endpoint;
- * use schemars::JsonSchema;
- * use serde::Deserialize;
- * use std::sync::Arc;
- * # use serde::Serialize;
- * # #[derive(Debug, Deserialize, JsonSchema)]
- * # enum MyScanParams { A };
- * # #[derive(Debug, Deserialize, JsonSchema, Serialize)]
- * # enum MyPageSelector { A(String) };
- * #[derive(Deserialize, JsonSchema)]
- * struct MyExtraQueryParams {
- *     do_extra_stuff: bool,
- * }
- *
- * #[endpoint {
- *     method = GET,
- *     path = "/list_stuff"
- * }]
- * async fn my_list_api(
- *     rqctx: Arc<RequestContext<()>>,
- *     pag_params: Query<PaginationParams<MyScanParams, MyPageSelector>>,
- *     extra_params: Query<MyExtraQueryParams>,
- * ) -> Result<HttpResponseOk<ResultsPage<String>>, HttpError>
- * {
- *  # unimplemented!();
- *  /* ... */
- * }
- * ```
- *
- * You might expect that instead of doing this, you could define your own
- * structure that includes a `PaginationParams` using `#[serde(flatten)]`, and
- * this ought to work, but it currently doesn't due to serde_urlencoded#33,
- * which is really serde#1183.
- *
- * ### DTrace probes
- *
- * Dropshot optionally exposes two DTrace probes, `request_start` and
- * `request_finish`. These provide detailed information about each request,
- * such as their ID, the local and remote IPs, and the response information.
- * See the [`RequestInfo`] and [`ResponseInfo`] types for a complete listing
- * of what's available.
- *
- * These probes are implemented via the [`usdt`] crate. They require a nightly
- * toolchain if built on MacOS (which requires the unstable `asm_sym` feature).
- * Otherwise a stable compiler >= v1.59 is required in order to present the
- * necessary features.  Given these constraints, usdt functionality is behind
- * the feature flag `"usdt-probes"`.
- *
- * > *Important:* The probes are internally registered with the DTrace kernel
- * module, making them visible via `dtrace(1M)`. This is done when an `HttpServer`
- * object is created, but it's possible that registration fails. The result of
- * registration is stored in the server after creation, and can be accessed with
- * the [`HttpServer::probe_registration()`] method. This allows callers to decide
- * how to handle failures, but ensures that probes are always enabled if possible.
- *
- * Once in place, the probes can be seen via DTrace. For example, running:
- *
- * ```text
- * $ cargo +nightly run --example basic --features usdt-probes
- * ```
- *
- * And making several requests to it with `curl`, we can see the DTrace
- * probes with an invocation like:
- *
- * ```text
- * ## dtrace -Zq -n 'dropshot*:::request-* { printf("%s\n", copyinstr(arg0)); }'
- * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","method":"GET","path":"/counter","query":null}}
- * {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","status_code":200,"message":""}}
- * {"ok":{"id":"9050e30a-1ce3-4d6f-be1c-69a11c618800","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:41101","method":"PUT","path":"/counter","query":null}}
- * {"ok":{"id":"9050e30a-1ce3-4d6f-be1c-69a11c618800","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:41101","status_code":400,"message":"do not like the number 10"}}
- * {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","method":"PUT","path":"/counter","query":null}}
- * {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","status_code":204,"message":""}}
- * ```
- */
+//! Dropshot is a general-purpose crate for exposing REST APIs from a Rust
+//! program.  Planned highlights include:
+//!
+//! * Suitability for production use on a largely untrusted network.
+//!   Dropshot-based systems should be high-performing, reliable, debuggable, and
+//!   secure against basic denial of service attacks (intentional or otherwise).
+//!
+//! * First-class OpenAPI support, in the form of precise OpenAPI specs generated
+//!   directly from code.  This works because the functions that serve HTTP
+//!   resources consume arguments and return values of specific types from which
+//!   a schema can be statically generated.
+//!
+//! * Ease of integrating into a diverse team.  An important use case for
+//!   Dropshot consumers is to have a team of engineers where individuals might
+//!   add a few endpoints at a time to a complex server, and it should be
+//!   relatively easy to do this.  Part of this means an emphasis on the
+//!   principle of least surprise: like Rust itself, we may choose abstractions
+//!   that require more time to learn up front in order to make it harder to
+//!   accidentally build systems that will not perform, will crash in corner
+//!   cases, etc.
+//!
+//! By "REST API", we primarily mean an API built atop existing HTTP primitives,
+//! organized into hierarchical resources, and providing consistent, idempotent
+//! mechanisms to create, update, list, and delete those resources.  "REST" can
+//! mean a range of things depending on who you talk to, and some people are
+//! dogmatic about what is or isn't RESTy.  We find such dogma not only
+//! unhelpful, but poorly defined.  (Consider such a simple case as trying to
+//! update a resource in a REST API.  Popular APIs sometimes use `PUT`, `PATCH`,
+//! or `POST` for the verb; and JSON Merge Patch or JSON Patch as the format.
+//! (sometimes without even knowing it!).  There's hardly a clear standard, yet
+//! this is a really basic operation for any REST API.)
+//!
+//! For a discussion of alternative crates considered, see Oxide RFD 10.
+//!
+//! We hope Dropshot will be fairly general-purpose, but it's primarily intended
+//! to address the needs of the Oxide control plane.
+//!
+//!
+//! ## Usage
+//!
+//! The bare minimum might look like this:
+//!
+//! ```no_run
+//! use dropshot::ApiDescription;
+//! use dropshot::ConfigDropshot;
+//! use dropshot::ConfigLogging;
+//! use dropshot::ConfigLoggingLevel;
+//! use dropshot::HttpServerStarter;
+//! use std::sync::Arc;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), String> {
+//!     // Set up a logger.
+//!     let log =
+//!         ConfigLogging::StderrTerminal {
+//!             level: ConfigLoggingLevel::Info,
+//!         }
+//!         .to_logger("minimal-example")
+//!         .map_err(|e| e.to_string())?;
+//!
+//!     // Describe the API.
+//!     let api = ApiDescription::new();
+//!     // Register API functions -- see detailed example or ApiDescription docs.
+//!
+//!     // Start the server.
+//!     let server =
+//!         HttpServerStarter::new(
+//!             &ConfigDropshot {
+//!                 bind_address: "127.0.0.1:0".parse().unwrap(),
+//!                 request_body_max_bytes: 1024,
+//!                 tls: None,
+//!             },
+//!             api,
+//!             Arc::new(()),
+//!             &log,
+//!         )
+//!         .map_err(|error| format!("failed to start server: {}", error))?
+//!         .start();
+//!
+//!     server.await
+//! }
+//! ```
+//!
+//! This server returns a 404 for all resources because no API functions were
+//! registered.  See `examples/basic.rs` for a simple, documented example that
+//! provides a few resources using shared state.
+//!
+//! For a given `ApiDescription`, you can also print out an OpenAPI spec
+//! describing the API.  See [`ApiDescription::openapi`].
+//!
+//!
+//! ## API Handler Functions
+//!
+//! HTTP talks about **resources**.  For a REST API, we often talk about
+//! **endpoints** or **operations**, which are identified by a combination of the
+//! HTTP method and the URI path.
+//!
+//! Example endpoints for a resource called a "project" might include:
+//!
+//! * `GET /projects` (list projects)
+//! * `POST /projects` (one way to create a project)
+//! * `GET /projects/my_project` (fetch one project)
+//! * `PUT /projects/my_project` (update (or possibly create) a project)
+//! * `DELETE /projects/my_project` (delete a project)
+//!
+//! With Dropshot, an incoming request for a given API endpoint is handled by a
+//! particular Rust function.  That function is called an **entrypoint**, an
+//! **endpoint handler**, or a **handler function**.  When you set up a Dropshot
+//! server, you configure the set of available API endpoints and which functions
+//! will handle each one by setting up an [`ApiDescription`].
+//!
+//! Typically, you define an endpoint with a handler function by using the
+//! [`endpoint`] macro. Here's an example of a single endpoint that lists
+//! a hardcoded project:
+//!
+//! ```
+//! use dropshot::endpoint;
+//! use dropshot::ApiDescription;
+//! use dropshot::HttpError;
+//! use dropshot::HttpResponseOk;
+//! use dropshot::RequestContext;
+//! use http::Method;
+//! use schemars::JsonSchema;
+//! use serde::Serialize;
+//! use std::sync::Arc;
+//!
+//! /** Represents a project in our API */
+//! #[derive(Serialize, JsonSchema)]
+//! struct Project {
+//!     /** name of the project */
+//!     name: String,
+//! }
+//!
+//! /** Fetch a project. */
+//! #[endpoint {
+//!     method = GET,
+//!     path = "/projects/project1",
+//! }]
+//! async fn myapi_projects_get_project(
+//!     rqctx: Arc<RequestContext<()>>,
+//! ) -> Result<HttpResponseOk<Project>, HttpError>
+//! {
+//!    let project = Project { name: String::from("project1") };
+//!    Ok(HttpResponseOk(project))
+//! }
+//!
+//! fn main() {
+//!     let mut api = ApiDescription::new();
+//!
+//!     /*
+//!      * Register our endpoint and its handler function.  The "endpoint" macro
+//!      * specifies the HTTP method and URI path that identify the endpoint,
+//!      * allowing this metadata to live right alongside the handler function.
+//!      */
+//!     api.register(myapi_projects_get_project).unwrap();
+//!
+//!     /* ... (use `api` to set up an `HttpServer` ) */
+//! }
+//! ```
+//!
+//! There's quite a lot going on here:
+//!
+//! * The `endpoint` macro specifies the HTTP method and URI path.  When we
+//!   invoke `ApiDescription::register()`, this information is used to register
+//!   the endpoint that will be handled by our function.
+//! * The signature of our function indicates that on success, it returns a
+//!   `HttpResponseOk<Project>`.  This means that the function will
+//!   return an HTTP 200 status code ("OK") with an object of type `Project`.
+//! * The function itself has a Rustdoc comment that will be used to document
+//!   this _endpoint_ in the OpenAPI schema.
+//!
+//! From this information, Dropshot can generate an OpenAPI specification for
+//! this API that describes the endpoint (which OpenAPI calls an "operation"),
+//! its documentation, the possible responses that it can return, and the schema
+//! for each type of response (which can also include documentation).  This is
+//! largely known statically, though generated at runtime.
+//!
+//!
+//! ### `#[endpoint { ... }]` attribute parameters
+//!
+//! The `endpoint` attribute accepts parameters the affect the operation of
+//! the endpoint as well as metadata that appears in the OpenAPI description
+//! of it.
+//!
+//! ```ignore
+//! #[endpoint {
+//!     // Required fields
+//!     method = { DELETE | GET | PATCH | POST | PUT },
+//!     path = "/path/name/with/{named}/{variables}",
+//!
+//!     // Optional fields
+//!     tags = [ "all", "your", "OpenAPI", "tags" ],
+//! }]
+//! ```
+//!
+//! This is where you specify the HTTP method and path (including path variables)
+//! for the API endpoint. These are used as part of endpoint registration and
+//! appear in the OpenAPI spec output.
+//!
+//! The tags field is used to categorize API endpoints and only impacts the
+//! OpenAPI spec output.
+//!
+//!
+//! ### Function parameters
+//!
+//! In general, a handler function looks like this:
+//!
+//! ```ignore
+//! async fn f(
+//!      rqctx: Arc<RequestContext<Context>>,
+//!      [query_params: Query<Q>,]
+//!      [path_params: Path<P>,]
+//!      [body_param: TypedBody<J>,]
+//!      [body_param: UntypedBody<J>,]
+//! ) -> Result<HttpResponse*, HttpError>
+//! ```
+//!
+//! Other than the RequestContext, parameters may appear in any order.
+//!
+//! The `Context` type is caller-provided context which is provided when
+//! the server is created.
+//!
+//! The types `Query`, `Path`, `TypedBody`, and `UntypedBody` are called
+//! **Extractors** because they cause information to be pulled out of the request
+//! and made available to the handler function.
+//!
+//! * [`Query`]`<Q>` extracts parameters from a query string, deserializing them
+//!   into an instance of type `Q`. `Q` must implement `serde::Deserialize` and
+//!   `schemars::JsonSchema`.
+//! * [`Path`]`<P>` extracts parameters from HTTP path, deserializing them into
+//!   an instance of type `P`. `P` must implement `serde::Deserialize` and
+//!   `schemars::JsonSchema`.
+//! * [`TypedBody`]`<J>` extracts content from the request body by parsing the
+//!   body as JSON (or form/url-encoded) and deserializing it into an instance
+//!   of type `J`. `J` must implement `serde::Deserialize` and `schemars::JsonSchema`.
+//! * [`UntypedBody`] extracts the raw bytes of the request body.
+//!
+//! If the handler takes a `Query<Q>`, `Path<P>`, `TypedBody<J>`, or
+//! `UntypedBody`, and the corresponding extraction cannot be completed, the
+//! request fails with status code 400 and an error message reflecting a
+//! validation error.
+//!
+//! As with any serde-deserializable type, you can make fields optional by having
+//! the corresponding property of the type be an `Option`.  Here's an example of
+//! an endpoint that takes two arguments via query parameters: "limit", a
+//! required u32, and "marker", an optional string:
+//!
+//! ```
+//! use http::StatusCode;
+//! use dropshot::HttpError;
+//! use dropshot::TypedBody;
+//! use dropshot::Query;
+//! use dropshot::RequestContext;
+//! use hyper::Body;
+//! use hyper::Response;
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//! use std::sync::Arc;
+//!
+//! #[derive(Deserialize, JsonSchema)]
+//! struct MyQueryArgs {
+//!     limit: u32,
+//!     marker: Option<String>
+//! }
+//!
+//! struct MyContext {}
+//!
+//! async fn myapi_projects_get(
+//!     rqctx: Arc<RequestContext<MyContext>>,
+//!     query: Query<MyQueryArgs>)
+//!     -> Result<Response<Body>, HttpError>
+//! {
+//!     let query_args = query.into_inner();
+//!     let context: &MyContext = rqctx.context();
+//!     let limit: u32 = query_args.limit;
+//!     let marker: Option<String> = query_args.marker;
+//!     Ok(Response::builder()
+//!         .status(StatusCode::OK)
+//!         .body(format!("limit = {}, marker = {:?}\n", limit, marker).into())?)
+//! }
+//! ```
+//!
+//! ### Endpoint function return types
+//!
+//! Endpoint handler functions are async, so they always return a `Future`.  When
+//! we say "return type" below, we use that as shorthand for the output of the
+//! future.
+//!
+//! An endpoint function must return a type that implements `HttpResponse`.
+//! Typically this should be a type that implements `HttpTypedResponse` (either
+//! one of the Dropshot-provided ones or one of your own creation).
+//!
+//! The more specific a type returned by the handler function, the more can be
+//! validated at build-time, and the more specific an OpenAPI schema can be
+//! generated from the source code.  For example, a POST to an endpoint
+//! "/projects" might return `Result<HttpResponseCreated<Project>, HttpError>`.
+//! As you might expect, on success, this turns into an HTTP 201 "Created"
+//! response whose body is constructed by serializing the `Project`.  In this
+//! example, OpenAPI tooling can identify at build time that this function
+//! produces a 201 "Created" response on success with a body whose schema matches
+//! `Project` (which we already said implements `Serialize`), and there would be
+//! no way to violate this contract at runtime.
+//!
+//! These are the implementations of `HttpTypedResponse` with their associated
+//! HTTP response code
+//! on the HTTP method:
+//!
+//! | Return Type | HTTP status code |
+//! | ----------- | ---------------- |
+//! | [`HttpResponseOk`] | 200 |
+//! | [`HttpResponseCreated`] | 201 |
+//! | [`HttpResponseAccepted`] | 202 |
+//! | [`HttpResponseDeleted`] | 204 |
+//! | [`HttpResponseUpdatedNoContent`] | 204 |
+//!
+//! In situations where the response schema is not fixed, the endpoint should
+//! return `Response<Body>`, which also implements `HttpResponse`. Note that
+//! the OpenAPI spec will not include any status code or type information in
+//! this case.
+//!
+//! ## What about generic handlers that run on all requests?
+//!
+//! There's no mechanism in Dropshot for this.  Instead, it's recommended that
+//! users commonize code using regular Rust functions and calling them.  See the
+//! design notes in the README for more on this.
+//!
+//!
+//! ## Support for paginated resources
+//!
+//! "Pagination" here refers to the interface pattern where HTTP resources (or
+//! API endpoints) that provide a list of the items in a collection return a
+//! relatively small maximum number of items per request, often called a "page"
+//! of results.  Each page includes some metadata that the client can use to make
+//! another request for the next page of results.  The client can repeat this
+//! until they've gotten all the results.  Limiting the number of results
+//! returned per request helps bound the resource utilization and time required
+//! for any request, which in turn facilities horizontal scalability, high
+//! availability, and protection against some denial of service attacks
+//! (intentional or otherwise).  For more background, see the comments in
+//! dropshot/src/pagination.rs.
+//!
+//! Pagination support in Dropshot implements this common pattern:
+//!
+//! * This server exposes an **API endpoint** that returns the **items**
+//!   contained within a **collection**.
+//! * The client is not allowed to list the entire collection in one request.
+//!   Instead, they list the collection using a sequence of requests to the one
+//!   endpoint.  We call this sequence of requests a **scan** of the collection,
+//!   and we sometimes say that the client **pages through** the collection.
+//! * The initial request in the scan may specify the **scan parameters**, which
+//!   typically specify how the results are to be sorted (i.e., by which
+//!   field(s) and whether the sort is ascending or descending), any filters to
+//!   apply, etc.
+//! * Each request returns a **page** of results at a time, along with a **page
+//!   token** that's provided with the next request as a query parameter.
+//! * The scan parameters cannot change between requests that are part of the
+//!   same scan.
+//! * With all requests: there's a default limit (e.g., 100 items returned at a
+//!   time).  Clients can request a higher limit using a query parameter (e.g.,
+//!   `limit=1000`).  This limit is capped by a hard limit on the server.  If the
+//!   client asks for more than the hard limit, the server can use the hard limit
+//!   or reject the request.
+//!
+//! As an example, imagine that we have an API endpoint called `"/animals"`.  Each
+//! item returned is an `Animal` object that might look like this:
+//!
+//! ```json
+//! {
+//!     "name": "aardvark",
+//!     "class": "mammal",
+//!     "max_weight": "80", /* kilograms, typical */
+//! }
+//! ```
+//!
+//! There are at least 1.5 million known species of animal -- too many to return
+//! in one API call!  Our API supports paginating them by `"name"`, which we'll
+//! say is a unique field in our data set.
+//!
+//! The first request to the API fetches `"/animals"` (with no querystring
+//! parameters) and returns:
+//!
+//! ```json
+//! {
+//!     "page_token": "abc123...",
+//!     "items": [
+//!         {
+//!             "name": "aardvark",
+//!             "class": "mammal",
+//!             "max_weight": "80",
+//!         },
+//!         ...
+//!         {
+//!             "name": "badger",
+//!             "class": "mammal",
+//!             "max_weight": "12",
+//!         }
+//!     ]
+//! }
+//! ```
+//!
+//! The subsequent request to the API fetches `"/animals?page_token=abc123..."`.
+//! The page token `"abc123..."` is an opaque token to the client, but typically
+//! encodes the scan parameters and the value of the last item seen
+//! (`"name=badger"`).  The client knows it has completed the scan when it
+//! receives a response with no `page_token` in it.
+//!
+//! Our API endpoint can also support scanning in reverse order.  In this case,
+//! when the client makes the first request, it should fetch
+//! `"/animals?sort=name-descending"`.  Now the first result might be `"zebra"`.
+//! Again, the page token must include the scan parameters so that in subsequent
+//! requests, the API endpoint knows that we're scanning backwards, not forwards,
+//! from the value we were given.  It's not allowed to change directions or sort
+//! order in the middle of a scan.  (You can always start a new scan, but you
+//! can't pick up from where you were in the previous scan.)
+//!
+//! It's also possible to support sorting by multiple fields.  For example, we
+//! could support `sort=class-name`, which we could define to mean that we'll
+//! sort the results first by the animal's class, then by name.  Thus we'd get
+//! all the amphibians in sorted order, then all the mammals, then all the
+//! reptiles.  The main requirement is that the combination of fields used for
+//! pagination must be unique.  We cannot paginate by the animal's class alone.
+//! (To see why: there are over 6,000 mammals.  If the page size is, say, 1000,
+//! then the page_token would say `"mammal"`, but there's not enough information
+//! there to see where we are within the list of mammals.  It doesn't matter
+//! whether there are 2 mammals or 6,000 because clients can limit the page size
+//! to just one item if they want and that ought to work.)
+//!
+//!
+//! ### Dropshot interfaces for pagination
+//!
+//! We can think of pagination in two parts: the input (handling the pagination
+//! query parameters) and the output (emitting a page of results, including the
+//! page token).
+//!
+//! For input, a paginated API endpoint's handler function should accept a
+//! [`Query`]`<`[`PaginationParams`]`<ScanParams, PageSelector>>`, where
+//! `ScanParams` is a consumer-defined type specifying the parameters of the scan
+//! (typically including the sort fields, sort order, and filter options) and
+//! `PageSelector` is a consumer-defined type describing the page token.  The
+//! PageSelector will be serialized to JSON and base64-encoded to construct the
+//! page token.  This will be automatically parsed on the way back in.
+//!
+//! For output, a paginated API endpoint's handler function can return
+//! `Result<`[`HttpResponseOk`]<[`ResultsPage`]`<T>, HttpError>` where `T:
+//! Serialize` is the item listed by the endpoint.  You can also use your own
+//! structure that contains a [`ResultsPage`] (possibly using
+//! `#[serde(flatten)]`), if that's the behavior you want.
+//!
+//! There are several complete, documented examples in the "examples" directory.
+//!
+//!
+//! ### Advanced usage notes
+//!
+//! It's possible to accept additional query parameters besides the pagination
+//! parameters by having your API endpoint handler function take two different
+//! arguments using `Query`, like this:
+//!
+//! ```
+//! use dropshot::HttpError;
+//! use dropshot::HttpResponseOk;
+//! use dropshot::PaginationParams;
+//! use dropshot::Query;
+//! use dropshot::RequestContext;
+//! use dropshot::ResultsPage;
+//! use dropshot::endpoint;
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//! use std::sync::Arc;
+//! # use serde::Serialize;
+//! # #[derive(Debug, Deserialize, JsonSchema)]
+//! # enum MyScanParams { A };
+//! # #[derive(Debug, Deserialize, JsonSchema, Serialize)]
+//! # enum MyPageSelector { A(String) };
+//! #[derive(Deserialize, JsonSchema)]
+//! struct MyExtraQueryParams {
+//!     do_extra_stuff: bool,
+//! }
+//!
+//! #[endpoint {
+//!     method = GET,
+//!     path = "/list_stuff"
+//! }]
+//! async fn my_list_api(
+//!     rqctx: Arc<RequestContext<()>>,
+//!     pag_params: Query<PaginationParams<MyScanParams, MyPageSelector>>,
+//!     extra_params: Query<MyExtraQueryParams>,
+//! ) -> Result<HttpResponseOk<ResultsPage<String>>, HttpError>
+//! {
+//!  # unimplemented!();
+//!  /* ... */
+//! }
+//! ```
+//!
+//! You might expect that instead of doing this, you could define your own
+//! structure that includes a `PaginationParams` using `#[serde(flatten)]`, and
+//! this ought to work, but it currently doesn't due to serde_urlencoded#33,
+//! which is really serde#1183.
+//!
+//! ### DTrace probes
+//!
+//! Dropshot optionally exposes two DTrace probes, `request_start` and
+//! `request_finish`. These provide detailed information about each request,
+//! such as their ID, the local and remote IPs, and the response information.
+//! See the [`RequestInfo`] and [`ResponseInfo`] types for a complete listing
+//! of what's available.
+//!
+//! These probes are implemented via the [`usdt`] crate. They require a nightly
+//! toolchain if built on MacOS (which requires the unstable `asm_sym` feature).
+//! Otherwise a stable compiler >= v1.59 is required in order to present the
+//! necessary features.  Given these constraints, usdt functionality is behind
+//! the feature flag `"usdt-probes"`.
+//!
+//! > *Important:* The probes are internally registered with the DTrace kernel
+//! module, making them visible via `dtrace(1M)`. This is done when an `HttpServer`
+//! object is created, but it's possible that registration fails. The result of
+//! registration is stored in the server after creation, and can be accessed with
+//! the [`HttpServer::probe_registration()`] method. This allows callers to decide
+//! how to handle failures, but ensures that probes are always enabled if possible.
+//!
+//! Once in place, the probes can be seen via DTrace. For example, running:
+//!
+//! ```text
+//! $ cargo +nightly run --example basic --features usdt-probes
+//! ```
+//!
+//! And making several requests to it with `curl`, we can see the DTrace
+//! probes with an invocation like:
+//!
+//! ```text
+//! ## dtrace -Zq -n 'dropshot*:::request-* { printf("%s\n", copyinstr(arg0)); }'
+//! {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","method":"GET","path":"/counter","query":null}}
+//! {"ok":{"id":"b793c62e-60e4-45c5-9274-198a04d9abb1","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:34286","status_code":200,"message":""}}
+//! {"ok":{"id":"9050e30a-1ce3-4d6f-be1c-69a11c618800","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:41101","method":"PUT","path":"/counter","query":null}}
+//! {"ok":{"id":"9050e30a-1ce3-4d6f-be1c-69a11c618800","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:41101","status_code":400,"message":"do not like the number 10"}}
+//! {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","method":"PUT","path":"/counter","query":null}}
+//! {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","status_code":204,"message":""}}
+//! ```
 
-/*
- * Clippy's style advice is definitely valuable, but not worth the trouble for
- * automated enforcement.
- */
+// Clippy's style advice is definitely valuable, but not worth the trouble for
+// automated enforcement.
 #![allow(clippy::style)]
-/*
- * The `usdt` crate requires nightly, enabled if our consumer is enabling
- * DTrace probes.
- */
+// The `usdt` crate requires nightly, enabled if our consumer is enabling
+// DTrace probes.
 #![cfg_attr(all(feature = "usdt-probes", not(usdt_stable_asm)), feature(asm))]
 #![cfg_attr(
     all(
@@ -678,9 +671,7 @@ pub use websocket::WebsocketConnectionRaw;
 pub use websocket::WebsocketEndpointResult;
 pub use websocket::WebsocketUpgrade;
 
-/*
- * Users of the `endpoint` macro need the following macros:
- */
+// Users of the `endpoint` macro need the following macros:
 pub use handler::RequestContextArgument;
 pub use http::Method;
 

--- a/dropshot/src/to_map.rs
+++ b/dropshot/src/to_map.rs
@@ -7,9 +7,7 @@ use serde::{
     Serialize, Serializer,
 };
 
-/**
- * Serialize an instance of T into a `BTreeMap<String, String>`.
- */
+/// Serialize an instance of T into a `BTreeMap<String, String>`.
 pub(crate) fn to_map<T>(input: &T) -> Result<BTreeMap<String, String>, MapError>
 where
     T: Serialize,
@@ -174,9 +172,7 @@ impl<'de, 'a, Input> Serializer for &'a mut MapSerializer<'de, Input> {
     }
 }
 
-/**
- * Used to serialize structs for `MapSerializer`.
- */
+/// Used to serialize structs for `MapSerializer`.
 struct MapSerializeStruct {
     output: BTreeMap<String, String>,
 }
@@ -204,11 +200,9 @@ impl SerializeStruct for MapSerializeStruct {
     }
 }
 
-/**
- * A trivial `Serializer` used to extract a `String`. One could imagine
- * extending this to convert other scalars into strings, but for now we'll just
- * work with strings.
- */
+/// A trivial `Serializer` used to extract a `String`. One could imagine
+/// extending this to convert other scalars into strings, but for now we'll just
+/// work with strings.
 struct StringSerializer;
 impl<'a> Serializer for &'a mut StringSerializer {
     type Ok = String;

--- a/dropshot/src/type_util.rs
+++ b/dropshot/src/type_util.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 
-/*!
- * Utility functions for working with JsonSchema types.
- */
+//! Utility functions for working with JsonSchema types.
 
 use std::collections::HashSet;
 
@@ -11,10 +9,8 @@ use schemars::schema::{
     InstanceType, Schema, SchemaObject, SingleOrVec, SubschemaValidation,
 };
 
-/**
- * Returns true iff the input schema is a boolean, floating-point number,
- * string or integer.
- */
+/// Returns true iff the input schema is a boolean, floating-point number,
+/// string or integer.
 pub fn type_is_scalar(
     name: &String,
     schema: &Schema,
@@ -31,9 +27,7 @@ pub fn type_is_scalar(
     })
 }
 
-/**
- * Returns true iff the input schema is a string.
- */
+/// Returns true iff the input schema is a string.
 pub fn type_is_string(
     name: &String,
     schema: &Schema,
@@ -44,24 +38,20 @@ pub fn type_is_string(
     })
 }
 
-/**
- * Helper function for scalar types.
- */
+/// Helper function for scalar types.
 fn type_is_scalar_common(
     name: &String,
     schema: &Schema,
     dependencies: &IndexMap<String, Schema>,
     type_check: fn(&InstanceType) -> bool,
 ) -> Result<(), String> {
-    /* Make sure we're examining a type and not a reference */
+    // Make sure we're examining a type and not a reference
     let schema = type_resolve(schema, dependencies);
 
     match schema {
-        /*
-         * Types that have no subschemas, are not arrays, are not objects, are
-         * not references, and whose instance type matches the limited set of
-         * scalar types.
-         */
+        // Types that have no subschemas, are not arrays, are not objects, are
+        // not references, and whose instance type matches the limited set of
+        // scalar types.
         Schema::Object(SchemaObject {
             instance_type: Some(SingleOrVec::Single(instance_type)),
             subschemas: None,
@@ -71,9 +61,7 @@ fn type_is_scalar_common(
             ..
         }) if type_check(instance_type.as_ref()) => Ok(()),
 
-        /*
-         * Handle subschemas.
-         */
+        // Handle subschemas.
         Schema::Object(SchemaObject {
             instance_type: None,
             format: None,
@@ -100,12 +88,10 @@ fn type_is_scalar_common(
     }
 }
 
-/**
- * Determine if a collection of subschemas are scalar (and meet the criteria of
- * the `type_check` parameter). For `allOf` and `anyOf` subschemas, we proceed
- * only if there is a lone subschema which we check recursively. For `oneOf`
- * subschemas, we check that each subschema is scalar.
- */
+/// Determine if a collection of subschemas are scalar (and meet the criteria of
+/// the `type_check` parameter). For `allOf` and `anyOf` subschemas, we proceed
+/// only if there is a lone subschema which we check recursively. For `oneOf`
+/// subschemas, we check that each subschema is scalar.
 fn type_is_scalar_subschemas(
     name: &String,
     subschemas: &SubschemaValidation,
@@ -160,7 +146,7 @@ pub fn type_is_string_enum(
     schema: &Schema,
     dependencies: &IndexMap<String, Schema>,
 ) -> Result<(), String> {
-    /* Make sure we're examining a type and not a reference */
+    // Make sure we're examining a type and not a reference
     let schema = type_resolve(schema, dependencies);
 
     match schema {
@@ -302,7 +288,7 @@ mod tests {
 
         #[derive(JsonSchema)]
         struct ThingHolder {
-            /** This is my thing */
+            /// This is my thing
             thing: Things,
         }
 

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -189,20 +189,20 @@ impl WebsocketUpgrade {
     /// ```
     /// #[dropshot::endpoint { method = GET, path = "/my/ws/endpoint/{id}" }]
     /// async fn my_ws_endpoint(
-    /// rqctx: std::sync::Arc<dropshot::RequestContext<()>>,
-    /// websock: dropshot::WebsocketUpgrade,
-    /// id: dropshot::Path<String>,
+    ///     rqctx: std::sync::Arc<dropshot::RequestContext<()>>,
+    ///     websock: dropshot::WebsocketUpgrade,
+    ///     id: dropshot::Path<String>,
     /// ) -> dropshot::WebsocketEndpointResult {
-    /// let logger = rqctx.log.new(slog::o!());
-    /// websock.handle(move |upgraded| async move {
-    /// slog::info!(logger, "Entered handler for ID {}", id.into_inner());
-    /// use futures::stream::StreamExt;
-    /// let mut ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(
-    /// upgraded.into_inner(), tokio_tungstenite::tungstenite::protocol::Role::Server, None
-    /// ).await;
-    /// slog::info!(logger, "Received from websocket: {:?}", ws_stream.next().await);
-    /// Ok(())
-    /// })
+    ///     let logger = rqctx.log.new(slog::o!());
+    ///     websock.handle(move |upgraded| async move {
+    ///         slog::info!(logger, "Entered handler for ID {}", id.into_inner());
+    ///         use futures::stream::StreamExt;
+    ///         let mut ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(
+    ///             upgraded.into_inner(), tokio_tungstenite::tungstenite::protocol::Role::Server, None
+    ///         ).await;
+    ///         slog::info!(logger, "Received from websocket: {:?}", ws_stream.next().await);
+    ///         Ok(())
+    ///     })
     /// }
     /// ```
     ///

--- a/dropshot/tests/common/mod.rs
+++ b/dropshot/tests/common/mod.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Common facilities for automated testing.
- */
+//! Common facilities for automated testing.
 
 use dropshot::test_util::LogContext;
 use dropshot::test_util::TestContext;
@@ -18,15 +16,13 @@ pub fn test_setup(
     test_name: &str,
     api: ApiDescription<usize>,
 ) -> TestContext<usize> {
-    /*
-     * The IP address to which we bind can be any local IP, but we use
-     * 127.0.0.1 because we know it's present, it shouldn't expose this server
-     * on any external network, and we don't have to go looking for some other
-     * local IP (likely in a platform-specific way).  We specify port 0 to
-     * request any available port.  This is important because we may run
-     * multiple concurrent tests, so any fixed port could result in spurious
-     * failures due to port conflicts.
-     */
+    // The IP address to which we bind can be any local IP, but we use
+    // 127.0.0.1 because we know it's present, it shouldn't expose this server
+    // on any external network, and we don't have to go looking for some other
+    // local IP (likely in a platform-specific way).  We specify port 0 to
+    // request any available port.  This is important because we may run
+    // multiple concurrent tests, so any fixed port could result in spurious
+    // failures due to port conflicts.
     let config_dropshot: ConfigDropshot = Default::default();
 
     let logctx = create_log_context(test_name);

--- a/dropshot/tests/test_config.rs
+++ b/dropshot/tests/test_config.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Tests for configuration file.
- */
+//! Tests for configuration file.
 
 use dropshot::test_util::read_config;
 use dropshot::{ConfigDropshot, ConfigTls};
@@ -14,9 +12,7 @@ use tempfile::NamedTempFile;
 pub mod common;
 use common::create_log_context;
 
-/*
- * Bad values for "bind_address"
- */
+// Bad values for "bind_address"
 
 #[test]
 fn test_config_bad_bind_address_port_too_small() {
@@ -54,9 +50,7 @@ fn test_config_bad_bind_address_garbage() {
         .starts_with("invalid socket address syntax for key `bind_address`"));
 }
 
-/*
- * Bad values for "request_body_max_bytes"
- */
+// Bad values for "request_body_max_bytes"
 
 #[test]
 fn test_config_bad_request_body_max_bytes_negative() {
@@ -80,9 +74,7 @@ fn test_config_bad_request_body_max_bytes_too_large() {
     assert!(error.starts_with(""));
 }
 
-/*
- * Bad values for "key_file"
- */
+// Bad values for "key_file"
 
 #[test]
 fn test_config_bad_key_file_garbage() {
@@ -95,9 +87,7 @@ fn test_config_bad_key_file_garbage() {
     assert!(error.starts_with("invalid type: integer"));
 }
 
-/*
- * Bad values for "cert_file"
- */
+// Bad values for "cert_file"
 
 #[test]
 fn test_config_bad_cert_file_garbage() {
@@ -110,9 +100,7 @@ fn test_config_bad_cert_file_garbage() {
     assert!(error.starts_with("invalid type: integer"));
 }
 
-/*
- * Bad values for "tls"
- */
+// Bad values for "tls"
 
 #[test]
 fn test_config_bad_tls_garbage() {
@@ -186,41 +174,33 @@ where
 {
     let client = test_config.make_client();
 
-    /*
-     * Make sure there is not currently a server running on our expected
-     * port so that when we subsequently create a server and run it we know
-     * we're getting the one we configured.
-     */
+    // Make sure there is not currently a server running on our expected
+    // port so that when we subsequently create a server and run it we know
+    // we're getting the one we configured.
     let error = client.get(test_config.make_uri(bind_port)).await.unwrap_err();
     assert!(error.is_connect());
 
-    /*
-     * Now start a server with our configuration and make the request again.
-     * This should succeed in terms of making the request.  (The request
-     * itself might fail with a 400-level or 500-level response code -- we
-     * don't want to depend on too much from the ApiServer here -- but we
-     * should have successfully made the request.)
-     */
+    // Now start a server with our configuration and make the request again.
+    // This should succeed in terms of making the request.  (The request
+    // itself might fail with a 400-level or 500-level response code -- we
+    // don't want to depend on too much from the ApiServer here -- but we
+    // should have successfully made the request.)
     let server = test_config.make_server(bind_port);
     client.get(test_config.make_uri(bind_port)).await.unwrap();
     server.close().await.unwrap();
 
-    /*
-     * Make another request to make sure it fails now that we've shut down
-     * the server.  We need a new client to make sure our client-side connection
-     * starts from a clean slate.  (Otherwise, a race during shutdown could
-     * cause us to successfully send a request packet, only to have the TCP
-     * stack return with ECONNRESET, which gets in the way of what we're trying
-     * to test here.)
-     */
+    // Make another request to make sure it fails now that we've shut down
+    // the server.  We need a new client to make sure our client-side connection
+    // starts from a clean slate.  (Otherwise, a race during shutdown could
+    // cause us to successfully send a request packet, only to have the TCP
+    // stack return with ECONNRESET, which gets in the way of what we're trying
+    // to test here.)
     let client = test_config.make_client();
     let error = client.get(test_config.make_uri(bind_port)).await.unwrap_err();
     assert!(error.is_connect());
 
-    /*
-     * Start a server on another TCP port and make sure we can reach that
-     * one (and NOT the one we just shut down).
-     */
+    // Start a server on another TCP port and make sure we can reach that
+    // one (and NOT the one we just shut down).
     let server = test_config.make_server(bind_port + 1);
     client.get(test_config.make_uri(bind_port + 1)).await.unwrap();
     let error = client.get(test_config.make_uri(bind_port)).await.unwrap_err();
@@ -336,7 +316,7 @@ async fn test_config_bind_address_https() {
     let (cert_file, key_file) = common::tls_key_to_file(&certs, &key);
     let test_config = ConfigBindServerHttps { log, certs, cert_file, key_file };
 
-    /* This must be different than the bind_port used in the http test. */
+    // This must be different than the bind_port used in the http test.
     let bind_port = 12217;
     test_config_bind_server::<_, ConfigBindServerHttps>(test_config, bind_port)
         .await;
@@ -409,7 +389,7 @@ async fn test_config_bind_address_https_buffer() {
     let test_config =
         ConfigBindServerHttps { log, certs, serialized_certs, serialized_key };
 
-    /* This must be different than the bind_port used in the http test. */
+    // This must be different than the bind_port used in the http test.
     let bind_port = 12219;
     test_config_bind_server::<_, ConfigBindServerHttps>(test_config, bind_port)
         .await;

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -1,19 +1,17 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Test cases for the "demo" handlers.  These handlers exercise various
- * supported configurations of the HTTP handler interface.  We exercise them
- * here to make sure that even if these aren't used at a given point, they still
- * work.
- *
- * Note that the purpose is mainly to exercise the various possible function
- * signatures that can be used to implement handler functions.  We don't need to
- * exercises very many cases (or error cases) of each one because the handlers
- * themselves are not important, but we need to exercise enough to validate that
- * the generic JSON and query parsing handles error cases.
- *
- * TODO-hardening: add test cases that exceed limits (e.g., query string length,
- * JSON body length)
- */
+//! Test cases for the "demo" handlers.  These handlers exercise various
+//! supported configurations of the HTTP handler interface.  We exercise them
+//! here to make sure that even if these aren't used at a given point, they still
+//! work.
+//!
+//! Note that the purpose is mainly to exercise the various possible function
+//! signatures that can be used to implement handler functions.  We don't need to
+//! exercises very many cases (or error cases) of each one because the handlers
+//! themselves are not important, but we need to exercise enough to validate that
+//! the generic JSON and query parsing handles error cases.
+//!
+//! TODO-hardening: add test cases that exceed limits (e.g., query string length,
+//! JSON body length)
 
 use dropshot::channel;
 use dropshot::endpoint;
@@ -80,10 +78,8 @@ fn demo_api() -> ApiDescription<usize> {
     api.register(demo_handler_307_temporary_redirect).unwrap();
     api.register(demo_handler_websocket).unwrap();
 
-    /*
-     * We don't need to exhaustively test these cases, as they're tested by unit
-     * tests.
-     */
+    // We don't need to exhaustively test these cases, as they're tested by unit
+    // tests.
     let error = api.register(demo_handler_path_param_impossible).unwrap_err();
     assert_eq!(
         error,
@@ -94,10 +90,8 @@ fn demo_api() -> ApiDescription<usize> {
     api
 }
 
-/*
- * The "demo1" handler consumes neither query nor JSON body parameters.  Here we
- * test that such handlers work.  There are no error cases for us to induce.
- */
+// The "demo1" handler consumes neither query nor JSON body parameters.  Here we
+// test that such handlers work.  There are no error cases for us to induce.
 #[tokio::test]
 async fn test_demo1() {
     let api = demo_api();
@@ -121,19 +115,17 @@ async fn test_demo1() {
     testctx.teardown().await;
 }
 
-/*
- * The "demo2query" handler consumes only query arguments.  Here we make sure
- * such handlers work and also exercise various error cases associated with bad
- * query string parsing.
- * TODO-hardening there are a lot more to check here, particularly around
- * encoded values.
- */
+// The "demo2query" handler consumes only query arguments.  Here we make sure
+// such handlers work and also exercise various error cases associated with bad
+// query string parsing.
+// TODO-hardening there are a lot more to check here, particularly around
+// encoded values.
 #[tokio::test]
 async fn test_demo2query() {
     let api = demo_api();
     let testctx = common::test_setup("demo2query", api);
 
-    /* Test case: optional field missing */
+    // Test case: optional field missing
     let mut response = testctx
         .client_testctx
         .make_request(
@@ -148,7 +140,7 @@ async fn test_demo2query() {
     assert_eq!(json.test1, "foo");
     assert_eq!(json.test2, None);
 
-    /* Test case: both fields specified */
+    // Test case: both fields specified
     let mut response = testctx
         .client_testctx
         .make_request(
@@ -163,7 +155,7 @@ async fn test_demo2query() {
     assert_eq!(json.test1, "foo");
     assert_eq!(json.test2, Some(10));
 
-    /* Test case: required field missing */
+    // Test case: required field missing
     let error = testctx
         .client_testctx
         .make_request(
@@ -179,7 +171,7 @@ async fn test_demo2query() {
         "unable to parse query string: missing field `test1`"
     );
 
-    /* Test case: typed field has bad value */
+    // Test case: typed field has bad value
     let error = testctx
         .client_testctx
         .make_request(
@@ -195,7 +187,7 @@ async fn test_demo2query() {
         "unable to parse query string: invalid digit found in string"
     );
 
-    /* Test case: duplicated field name */
+    // Test case: duplicated field name
     let error = testctx
         .client_testctx
         .make_request(
@@ -214,17 +206,15 @@ async fn test_demo2query() {
     testctx.teardown().await;
 }
 
-/*
- * The "demo2json" handler consumes only a JSON object.  Here we make sure such
- * handlers work and also exercise various error cases associated with bad JSON
- * handling.
- */
+// The "demo2json" handler consumes only a JSON object.  Here we make sure such
+// handlers work and also exercise various error cases associated with bad JSON
+// handling.
 #[tokio::test]
 async fn test_demo2json() {
     let api = demo_api();
     let testctx = common::test_setup("demo2json", api);
 
-    /* Test case: optional field */
+    // Test case: optional field
     let input = DemoJsonBody { test1: "bar".to_string(), test2: None };
     let mut response = testctx
         .client_testctx
@@ -240,7 +230,7 @@ async fn test_demo2json() {
     assert_eq!(json.test1, "bar");
     assert_eq!(json.test2, None);
 
-    /* Test case: both fields populated */
+    // Test case: both fields populated
     let input = DemoJsonBody { test1: "bar".to_string(), test2: Some(15) };
     let mut response = testctx
         .client_testctx
@@ -256,7 +246,7 @@ async fn test_demo2json() {
     assert_eq!(json.test1, "bar");
     assert_eq!(json.test2, Some(15));
 
-    /* Test case: no input specified */
+    // Test case: no input specified
     let error = testctx
         .client_testctx
         .make_request(
@@ -269,7 +259,7 @@ async fn test_demo2json() {
         .expect_err("expected failure");
     assert!(error.message.starts_with("unable to parse JSON body"));
 
-    /* Test case: invalid JSON */
+    // Test case: invalid JSON
     let error = testctx
         .client_testctx
         .make_request_with_body(
@@ -282,7 +272,7 @@ async fn test_demo2json() {
         .expect_err("expected failure");
     assert!(error.message.starts_with("unable to parse JSON body"));
 
-    /* Test case: bad type */
+    // Test case: bad type
     let json_bad_type = "{ \"test1\": \"oops\", \"test2\": \"oops\" }";
     let error = testctx
         .client_testctx
@@ -301,16 +291,14 @@ async fn test_demo2json() {
     testctx.teardown().await;
 }
 
-/*
- * Handlers may also accept form/URL-encoded bodies. Here we test such
- * bodies with both valid and invalid encodings.
- */
+// Handlers may also accept form/URL-encoded bodies. Here we test such
+// bodies with both valid and invalid encodings.
 #[tokio::test]
 async fn test_demo2urlencoded() {
     let api = demo_api();
     let testctx = common::test_setup("demo2urlencoded", api);
 
-    /* Test case: optional field */
+    // Test case: optional field
     let input = DemoJsonBody { test1: "bar".to_string(), test2: None };
     let mut response = testctx
         .client_testctx
@@ -326,7 +314,7 @@ async fn test_demo2urlencoded() {
     assert_eq!(json.test1, "bar");
     assert_eq!(json.test2, None);
 
-    /* Test case: both fields populated */
+    // Test case: both fields populated
     let input = DemoJsonBody { test1: "baz".to_string(), test2: Some(20) };
     let mut response = testctx
         .client_testctx
@@ -342,7 +330,7 @@ async fn test_demo2urlencoded() {
     assert_eq!(json.test1, "baz");
     assert_eq!(json.test2, Some(20));
 
-    /* Error case: wrong content type for endpoint */
+    // Error case: wrong content type for endpoint
     let input = DemoJsonBody { test1: "qux".to_string(), test2: Some(30) };
     let error = testctx
         .client_testctx
@@ -359,7 +347,7 @@ async fn test_demo2urlencoded() {
          got \"application/json\""
     ));
 
-    /* Error case: invalid encoding */
+    // Error case: invalid encoding
     let error = testctx
         .client_testctx
         .make_request_with_body_url_encoded(
@@ -372,7 +360,7 @@ async fn test_demo2urlencoded() {
         .expect_err("expected failure");
     assert!(error.message.starts_with("unable to parse URL-encoded body"));
 
-    /* Error case: bad type */
+    // Error case: bad type
     let error = testctx
         .client_testctx
         .make_request_with_body_url_encoded(
@@ -388,18 +376,16 @@ async fn test_demo2urlencoded() {
     ));
 }
 
-/*
- * The "demo3" handler takes both query arguments and a JSON body.  This test
- * makes sure that both sets of parameters are received by the handler function
- * and at least one error case from each of those sources is exercised.  We
- * don't need exhaustively re-test the query and JSON error handling paths.
- */
+// The "demo3" handler takes both query arguments and a JSON body.  This test
+// makes sure that both sets of parameters are received by the handler function
+// and at least one error case from each of those sources is exercised.  We
+// don't need exhaustively re-test the query and JSON error handling paths.
 #[tokio::test]
 async fn test_demo3json() {
     let api = demo_api();
     let testctx = common::test_setup("demo3json", api);
 
-    /* Test case: everything filled in. */
+    // Test case: everything filled in.
     let json_input = DemoJsonBody { test1: "bart".to_string(), test2: Some(0) };
 
     let mut response = testctx
@@ -418,7 +404,7 @@ async fn test_demo3json() {
     assert_eq!(json.query.test1, "martin");
     assert_eq!(json.query.test2.unwrap(), 2);
 
-    /* Test case: error parsing query */
+    // Test case: error parsing query
     let json_input = DemoJsonBody { test1: "bart".to_string(), test2: Some(0) };
     let error = testctx
         .client_testctx
@@ -435,7 +421,7 @@ async fn test_demo3json() {
         "unable to parse query string: missing field `test1`"
     );
 
-    /* Test case: error parsing body */
+    // Test case: error parsing body
     let error = testctx
         .client_testctx
         .make_request_with_body(
@@ -451,26 +437,22 @@ async fn test_demo3json() {
     testctx.teardown().await;
 }
 
-/*
- * The "demo_path_param_string" handler takes just a single string path
- * parameter.
- */
+// The "demo_path_param_string" handler takes just a single string path
+// parameter.
 #[tokio::test]
 async fn test_demo_path_param_string() {
     let api = demo_api();
     let testctx = common::test_setup("demo_path_param_string", api);
 
-    /*
-     * Simple error cases.  All of these should produce 404 "Not Found" errors.
-     */
+    // Simple error cases.  All of these should produce 404 "Not Found" errors.
     let bad_paths = vec![
-        /* missing path parameter (won't match route) */
+        // missing path parameter (won't match route)
         "/testing/demo_path_string",
-        /* missing path parameter (won't match route) */
+        // missing path parameter (won't match route)
         "/testing/demo_path_string/",
-        /* missing path parameter (won't match route) */
+        // missing path parameter (won't match route)
         "/testing/demo_path_string//",
-        /* extra path segment (won't match route) */
+        // extra path segment (won't match route)
         "/testing/demo_path_string/okay/then",
     ];
 
@@ -488,9 +470,7 @@ async fn test_demo_path_param_string() {
         assert_eq!(error.message, "Not Found");
     }
 
-    /*
-     * Success cases (use the path parameter).
-     */
+    // Success cases (use the path parameter).
     let okay_paths = vec![
         ("/testing/demo_path_string/okay", "okay"),
         ("/testing/demo_path_string/okay/", "okay"),
@@ -526,18 +506,14 @@ async fn test_demo_path_param_string() {
     testctx.teardown().await;
 }
 
-/*
- * The "demo_path_param_uuid" handler takes just a single uuid path parameter.
- */
+// The "demo_path_param_uuid" handler takes just a single uuid path parameter.
 #[tokio::test]
 async fn test_demo_path_param_uuid() {
     let api = demo_api();
     let testctx = common::test_setup("demo_path_param_uuid", api);
 
-    /*
-     * Error case: not a valid uuid.  The other error cases are the same as for
-     * the string-valued path parameter and they're tested above.
-     */
+    // Error case: not a valid uuid.  The other error cases are the same as for
+    // the string-valued path parameter and they're tested above.
     let error = testctx
         .client_testctx
         .make_request_with_body(
@@ -550,9 +526,7 @@ async fn test_demo_path_param_uuid() {
         .unwrap_err();
     assert!(error.message.starts_with("bad parameter in URL path:"));
 
-    /*
-     * Success case (use the Uuid)
-     */
+    // Success case (use the Uuid)
     let uuid_str = "e7de8ccc-8938-43fa-8404-a040a0836ee4";
     let valid_path = format!("/testing/demo_path_uuid/{}", uuid_str);
     let mut response = testctx
@@ -571,18 +545,14 @@ async fn test_demo_path_param_uuid() {
     testctx.teardown().await;
 }
 
-/*
- * The "demo_path_param_u32" handler takes just a single u32 path parameter.
- */
+// The "demo_path_param_u32" handler takes just a single u32 path parameter.
 #[tokio::test]
 async fn test_demo_path_param_u32() {
     let api = demo_api();
     let testctx = common::test_setup("demo_path_param_u32", api);
 
-    /*
-     * Error case: not a valid u32.  Other error cases are the same as for the
-     * string-valued path parameter and they're tested above.
-     */
+    // Error case: not a valid u32.  Other error cases are the same as for the
+    // string-valued path parameter and they're tested above.
     let error = testctx
         .client_testctx
         .make_request_with_body(
@@ -595,9 +565,7 @@ async fn test_demo_path_param_u32() {
         .unwrap_err();
     assert!(error.message.starts_with("bad parameter in URL path:"));
 
-    /*
-     * Success case (use the number)
-     */
+    // Success case (use the number)
     let u32_str = "37";
     let valid_path = format!("/testing/demo_path_u32/{}", u32_str);
     let mut response = testctx
@@ -616,16 +584,14 @@ async fn test_demo_path_param_u32() {
     testctx.teardown().await;
 }
 
-/*
- * Test `UntypedBody`.
- */
+// Test `UntypedBody`.
 #[tokio::test]
 async fn test_untyped_body() {
     let api = demo_api();
     let testctx = common::test_setup("test_untyped_body", api);
     let client = &testctx.client_testctx;
 
-    /* Error case: body too large. */
+    // Error case: body too large.
     let big_body = vec![0u8; 1025];
     let error = client
         .make_request_with_body(
@@ -641,7 +607,7 @@ async fn test_untyped_body() {
         "request body exceeded maximum size of 1024 bytes"
     );
 
-    /* Error case: invalid UTF-8, when parsing as a UTF-8 string. */
+    // Error case: invalid UTF-8, when parsing as a UTF-8 string.
     let bad_body = vec![0x80u8; 1];
     let error = client
         .make_request_with_body(
@@ -658,7 +624,7 @@ async fn test_untyped_body() {
          bytes from index 0"
     );
 
-    /* Success case: invalid UTF-8, when not parsing. */
+    // Success case: invalid UTF-8, when not parsing.
     let mut response = client
         .make_request_with_body(
             Method::PUT,
@@ -672,7 +638,7 @@ async fn test_untyped_body() {
     assert_eq!(json.nbytes, 1);
     assert_eq!(json.as_utf8, None);
 
-    /* Success case: empty body */
+    // Success case: empty body
     let mut response = client
         .make_request_with_body(
             Method::PUT,
@@ -686,7 +652,7 @@ async fn test_untyped_body() {
     assert_eq!(json.nbytes, 0);
     assert_eq!(json.as_utf8, Some(String::from("")));
 
-    /* Success case: non-empty content */
+    // Success case: non-empty content
     let body: Vec<u8> = Vec::from(&b"t\xce\xbcv"[..]);
     let mut response = client
         .make_request_with_body(
@@ -704,9 +670,7 @@ async fn test_untyped_body() {
     testctx.teardown().await;
 }
 
-/*
- * Test delete request
- */
+// Test delete request
 #[tokio::test]
 async fn test_delete_request() {
     let api = demo_api();
@@ -718,9 +682,7 @@ async fn test_delete_request() {
     testctx.teardown().await;
 }
 
-/*
- * Test response headers
- */
+// Test response headers
 #[tokio::test]
 async fn test_header_request() {
     let api = demo_api();
@@ -753,9 +715,7 @@ async fn test_header_request() {
     assert_eq!(headers, vec!["hi", "howdy"]);
 }
 
-/*
- * Test 302 "Found" response with an invalid header value
- */
+// Test 302 "Found" response with an invalid header value
 #[tokio::test]
 async fn test_302_bogus() {
     let api = demo_api();
@@ -771,9 +731,7 @@ async fn test_302_bogus() {
     assert_eq!(error.message, "Internal Server Error");
 }
 
-/*
- * Test 302 "Found" response
- */
+// Test 302 "Found" response
 #[tokio::test]
 async fn test_302_found() {
     let api = demo_api();
@@ -798,9 +756,7 @@ async fn test_302_found() {
     assert_eq!(read_string(&mut response).await, "");
 }
 
-/*
- * Test 303 "See Other" response
- */
+// Test 303 "See Other" response
 #[tokio::test]
 async fn test_303_see_other() {
     let api = demo_api();
@@ -825,9 +781,7 @@ async fn test_303_see_other() {
     assert_eq!(read_string(&mut response).await, "");
 }
 
-/*
- * Test 307 "Temporary Redirect" response
- */
+// Test 307 "Temporary Redirect" response
 #[tokio::test]
 async fn test_307_temporary_redirect() {
     let api = demo_api();
@@ -852,10 +806,8 @@ async fn test_307_temporary_redirect() {
     assert_eq!(read_string(&mut response).await, "");
 }
 
-/*
- * The "test_demo_websocket" handler upgrades to a websocket and exchanges
- * greetings with the client.
- */
+// The "test_demo_websocket" handler upgrades to a websocket and exchanges
+// greetings with the client.
 #[tokio::test]
 async fn test_demo_websocket() {
     let api = demo_api();
@@ -874,9 +826,7 @@ async fn test_demo_websocket() {
     testctx.teardown().await;
 }
 
-/*
- * Demo handler functions
- */
+// Demo handler functions
 
 type RequestCtx = Arc<RequestContext<usize>>;
 

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -43,12 +43,10 @@ struct QueryArgs {
     path = "/test/woman",
     tags = ["it"],
 }]
-/**
- * C-style comment
- *
- * This is a multi-
- * line comment.
- */
+/// C-style comment
+///
+/// This is a multi-
+/// line comment.
 async fn handler2(
     _rqctx: Arc<RequestContext<()>>,
     _query: Query<QueryArgs>,
@@ -172,10 +170,8 @@ async fn handler7(
     unimplemented!();
 }
 
-/*
- * Test that we do not generate duplicate type definitions when the same type is
- * returned by two different handler functions.
- */
+// Test that we do not generate duplicate type definitions when the same type is
+// returned by two different handler functions.
 
 /// Best non-duplicated type
 #[derive(JsonSchema, Serialize)]
@@ -213,10 +209,8 @@ async fn handler9(
     unimplemented!();
 }
 
-/*
- * Similarly, test that we do not generate duplicate type definitions when the
- * same type is accepted as a typed body to two different handler functions.
- */
+// Similarly, test that we do not generate duplicate type definitions when the
+// same type is accepted as a typed body to two different handler functions.
 
 #[derive(Deserialize, JsonSchema)]
 struct NeverDuplicatedBodyTopLevel {
@@ -253,10 +247,8 @@ async fn handler11(
     unimplemented!();
 }
 
-/*
- * Finally, test that we do not generate duplicate type definitions when the
- * same type is used in two different places.
- */
+// Finally, test that we do not generate duplicate type definitions when the
+// same type is used in two different places.
 
 #[derive(Deserialize, JsonSchema, Serialize)]
 #[allow(dead_code)]

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Oxide Computer Company
-/*!
- * Test cases for API handler functions that use pagination.
- */
+//! Test cases for API handler functions that use pagination.
 
 use chrono::DateTime;
 use chrono::Utc;
@@ -56,14 +54,10 @@ extern crate lazy_static;
 
 pub mod common;
 
-/*
- * Common helpers
- */
+// Common helpers
 
-/**
- * Given a test context and URL path, assert that a GET request to that path
- * (with an empty body) produces a 400 response with the given error message.
- */
+/// Given a test context and URL path, assert that a GET request to that path
+/// (with an empty body) produces a 400 response with the given error message.
 async fn assert_error(
     client: &ClientTestContext,
     path: &str,
@@ -76,10 +70,8 @@ async fn assert_error(
     assert_eq!(error.error_code, None);
 }
 
-/**
- * Given an array of integers, check that they're sequential starting at
- * "offset".
- */
+/// Given an array of integers, check that they're sequential starting at
+/// "offset".
 fn assert_sequence_from(items: &Vec<u16>, offset: u16, count: u16) {
     let nchecked = AtomicU16::new(0);
     items.iter().enumerate().for_each(|(i, c)| {
@@ -90,13 +82,11 @@ fn assert_sequence_from(items: &Vec<u16>, offset: u16, count: u16) {
     assert_eq!(count as usize, items.len());
 }
 
-/**
- * Iterate the paginated collection using several different "limit" values to
- * validate that it always produces the same collection (no dups or missing
- * records around page breaks).
- * TODO This should move into test_util so that consumers can use it to test
- * their own APIs.
- */
+/// Iterate the paginated collection using several different "limit" values to
+/// validate that it always produces the same collection (no dups or missing
+/// records around page breaks).
+/// TODO This should move into test_util so that consumers can use it to test
+/// their own APIs.
 async fn assert_collection_iter<T>(
     client: &ClientTestContext,
     path: &str,
@@ -105,7 +95,7 @@ async fn assert_collection_iter<T>(
 where
     T: Clone + Debug + Eq + DeserializeOwned,
 {
-    /* Use a modest small number for our initial limit. */
+    // Use a modest small number for our initial limit.
     let (itemsby100, npagesby100) =
         iter_collection::<T>(&client, path, initial_params, 100).await;
     let expected_npages = itemsby100.len() / 100
@@ -113,30 +103,24 @@ where
         + (if itemsby100.len() % 100 != 0 { 1 } else { 0 });
     assert_eq!(expected_npages, npagesby100);
 
-    /*
-     * Assert that there are between 100 and 10000 items.  It's not really a
-     * problem for there to be a number outside this range.  However, our goal
-     * here is to independently exercise a modest limit (small but larger than
-     * 1) and also to check it against a max-limit request that's expected to
-     * have all the results, and we can't do that easily unless this condition
-     * holds.  We could skip these checks if it's useful to have tests that work
-     * that way, but for now we assert this so that we find out if we're somehow
-     * not testing what we expect.
-     */
+    // Assert that there are between 100 and 10000 items.  It's not really a
+    // problem for there to be a number outside this range.  However, our goal
+    // here is to independently exercise a modest limit (small but larger than
+    // 1) and also to check it against a max-limit request that's expected to
+    // have all the results, and we can't do that easily unless this condition
+    // holds.  We could skip these checks if it's useful to have tests that work
+    // that way, but for now we assert this so that we find out if we're somehow
+    // not testing what we expect.
     assert!(itemsby100.len() > 100);
     assert!(itemsby100.len() <= 10000);
 
-    /*
-     * Use a max limit to fetch everything at once to make sure it's the same.
-     */
+    // Use a max limit to fetch everything at once to make sure it's the same.
     let (itemsbymax, npagesbymax) =
         iter_collection::<T>(&client, path, initial_params, 10000).await;
     assert_eq!(2, npagesbymax);
     assert_eq!(itemsby100, itemsbymax);
 
-    /*
-     * Iterate by one to make sure that edge case works, too.
-     */
+    // Iterate by one to make sure that edge case works, too.
     let (itemsby1, npagesby1) =
         iter_collection::<T>(&client, path, initial_params, 1).await;
     assert_eq!(itemsby100.len() + 1, npagesby1);
@@ -145,11 +129,9 @@ where
     itemsbymax
 }
 
-/**
- * Page selector for a set of "u16" values
- *
- * This is used for several resources below.
- */
+/// Page selector for a set of "u16" values
+///
+/// This is used for several resources below.
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 struct IntegersPageSelector {
     last_seen: u16,
@@ -159,10 +141,8 @@ fn page_selector_for(n: &u16, _p: &EmptyScanParams) -> IntegersPageSelector {
     IntegersPageSelector { last_seen: *n }
 }
 
-/**
- * Define an API with a couple of different endpoints that allow us to exercise
- * various functionality.
- */
+/// Define an API with a couple of different endpoints that allow us to exercise
+/// various functionality.
 fn paginate_api() -> ApiDescription<usize> {
     let mut api = ApiDescription::new();
     api.register(api_integers).unwrap();
@@ -183,14 +163,10 @@ fn range_u16(start: u16, limit: u16) -> Vec<u16> {
     }
 }
 
-/*
- * Basic tests
- */
+// Basic tests
 
-/**
- * "/intapi": a collection of positive values of "u16" (excepting u16::MAX).
- * The marker is simply the last number seen.
- */
+/// "/intapi": a collection of positive values of "u16" (excepting u16::MAX).
+/// The marker is simply the last number seen.
 #[endpoint {
     method = GET,
     path = "/intapi",
@@ -266,26 +242,20 @@ async fn test_paginate_basic() {
     let testctx = common::test_setup("basic", api);
     let client = &testctx.client_testctx;
 
-    /*
-     * "First page" test cases
-     */
+    // "First page" test cases
 
-    /*
-     * Test the default value of "limit".  This test will have to be updated if
-     * we change the default count of items, but it's important to check that
-     * the default actually works and is reasonable.
-     */
+    // Test the default value of "limit".  This test will have to be updated if
+    // we change the default count of items, but it's important to check that
+    // the default actually works and is reasonable.
     let expected_default = 100;
     let page = objects_list_page::<u16>(&client, "/intapi").await;
     assert_sequence_from(&page.items, 1, expected_default);
     assert!(page.next_page.is_some());
 
-    /*
-     * Test the maximum value of "limit" by providing a value much higher than
-     * we support and observing it get clamped.  As with the previous test, this
-     * will have to be updated if we change the maximum count, but it's worth it
-     * to test this case.
-     */
+    // Test the maximum value of "limit" by providing a value much higher than
+    // we support and observing it get clamped.  As with the previous test, this
+    // will have to be updated if we change the maximum count, but it's worth it
+    // to test this case.
     let expected_max = 10000;
     let page = objects_list_page::<u16>(
         &client,
@@ -294,10 +264,8 @@ async fn test_paginate_basic() {
     .await;
     assert_sequence_from(&page.items, 1, expected_max);
 
-    /*
-     * Limits in between the default and the max should also work.  This
-     * exercises the `page_limit()` function.
-     */
+    // Limits in between the default and the max should also work.  This
+    // exercises the `page_limit()` function.
     let count = 2 * expected_default;
     assert!(count > expected_default);
     assert!(count < expected_max);
@@ -306,13 +274,9 @@ async fn test_paginate_basic() {
             .await;
     assert_sequence_from(&page.items, 1, count);
 
-    /*
-     * "Next page" test cases
-     */
+    // "Next page" test cases
 
-    /*
-     * Run the same few limit tests as above.
-     */
+    // Run the same few limit tests as above.
     let next_page_start = page.items.last().unwrap() + 1;
     let next_page_token = page.next_page.unwrap();
 
@@ -344,9 +308,7 @@ async fn test_paginate_basic() {
     assert_sequence_from(&page.items, next_page_start, count);
     assert!(page.next_page.is_some());
 
-    /*
-     * Loop through the entire collection.
-     */
+    // Loop through the entire collection.
     let mut next_item = 1u16;
     let mut page = objects_list_page::<u16>(
         &client,
@@ -383,14 +345,10 @@ async fn test_paginate_basic() {
     testctx.teardown().await;
 }
 
-/*
- * Tests for an empty collection
- */
+// Tests for an empty collection
 
-/**
- * "/empty": an empty collection of u16s, useful for testing the case where the
- * first request in a scan returns no results.
- */
+/// "/empty": an empty collection of u16s, useful for testing the case where the
+/// first request in a scan returns no results.
 #[endpoint {
     method = GET,
     path = "/empty",
@@ -406,11 +364,9 @@ async fn api_empty(
     )?))
 }
 
-/*
- * Tests various cases related to an empty collection, particularly making sure
- * that basic parsing of query parameters still does what we expect and that we
- * get a valid results page with no objects.
- */
+// Tests various cases related to an empty collection, particularly making sure
+// that basic parsing of query parameters still does what we expect and that we
+// get a valid results page with no objects.
 #[tokio::test]
 async fn test_paginate_empty() {
     let api = paginate_api();
@@ -444,15 +400,11 @@ async fn test_paginate_empty() {
     testctx.teardown().await;
 }
 
-/*
- * Test extra query parameters and response properties
- */
+// Test extra query parameters and response properties
 
-/**
- * "/ints_extra": also a paginated collection of "u16" values.  This
- * API exercises consuming additional query parameters ("debug") and sending a
- * more complex response type.
- */
+/// "/ints_extra": also a paginated collection of "u16" values.  This
+/// API exercises consuming additional query parameters ("debug") and sending a
+/// more complex response type.
 
 #[endpoint {
     method = GET,
@@ -483,13 +435,13 @@ async fn api_with_extra_params(
     }))
 }
 
-/* TODO-coverage check generated OpenAPI spec */
+// TODO-coverage check generated OpenAPI spec
 #[derive(Deserialize, JsonSchema)]
 struct ExtraQueryParams {
     debug: Option<bool>,
 }
 
-/* TODO-coverage check generated OpenAPI spec */
+// TODO-coverage check generated OpenAPI spec
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 struct ExtraResultsPage {
     debug_was_set: bool,
@@ -504,7 +456,7 @@ async fn test_paginate_extra_params() {
     let testctx = common::test_setup("extra_params", api);
     let client = &testctx.client_testctx;
 
-    /* Test that the extra query parameter is optional. */
+    // Test that the extra query parameter is optional.
     let page =
         object_get::<ExtraResultsPage>(&client, "/ints_extra?limit=5").await;
     assert!(!page.debug_was_set);
@@ -512,7 +464,7 @@ async fn test_paginate_extra_params() {
     assert_eq!(page.page.items, vec![1, 2, 3, 4, 5]);
     let token = page.page.next_page.unwrap();
 
-    /* Provide a value for the extra query parameter in the FirstPage case. */
+    // Provide a value for the extra query parameter in the FirstPage case.
     let page = object_get::<ExtraResultsPage>(
         &client,
         "/ints_extra?limit=5&debug=true",
@@ -523,7 +475,7 @@ async fn test_paginate_extra_params() {
     assert_eq!(page.page.items, vec![1, 2, 3, 4, 5]);
     assert!(page.page.next_page.is_some());
 
-    /* Provide a value for the extra query parameter in the NextPage case. */
+    // Provide a value for the extra query parameter in the NextPage case.
     let page = object_get::<ExtraResultsPage>(
         &client,
         &format!("/ints_extra?page_token={}&debug=false&limit=7", token),
@@ -537,18 +489,14 @@ async fn test_paginate_extra_params() {
     testctx.teardown().await;
 }
 
-/*
- * Test an endpoint that requires scan parameters.
- */
+// Test an endpoint that requires scan parameters.
 
 #[derive(Deserialize, JsonSchema)]
 struct ReqScanParams {
     doit: bool,
 }
 
-/**
- * "/required": similar to "/intapi", but with a required start parameter
- */
+/// "/required": similar to "/intapi", but with a required start parameter
 #[endpoint {
     method = GET,
     path = "/required",
@@ -587,7 +535,7 @@ async fn test_paginate_with_required_params() {
     let testctx = common::test_setup("required_params", api);
     let client = &testctx.client_testctx;
 
-    /* Test that the extra query parameter is optional... */
+    // Test that the extra query parameter is optional...
     let error = client
         .make_request_error(
             Method::GET,
@@ -595,13 +543,11 @@ async fn test_paginate_with_required_params() {
             StatusCode::BAD_REQUEST,
         )
         .await;
-    /*
-     * TODO-polish the message here is pretty poor.  See comments in the
-     * automated tests in src/pagination.rs.
-     */
+    // TODO-polish the message here is pretty poor.  See comments in the
+    // automated tests in src/pagination.rs.
     assert!(error.message.starts_with("unable to parse query string"));
 
-    /* ... and that it's getting passed through to the handler function */
+    // ... and that it's getting passed through to the handler function
     let error = client
         .make_request_error(
             Method::GET,
@@ -618,11 +564,9 @@ async fn test_paginate_with_required_params() {
     testctx.teardown().await;
 }
 
-/*
- * Test an endpoint with scan options that returns custom structures.  Our
- * endpoint will return a list of words, with the marker being the last word
- * seen.
- */
+// Test an endpoint with scan options that returns custom structures.  Our
+// endpoint will return a list of words, with the marker being the last word
+// seen.
 
 lazy_static! {
     static ref WORD_LIST: BTreeSet<String> = make_word_list();
@@ -633,10 +577,8 @@ fn make_word_list() -> BTreeSet<String> {
     word_list.lines().map(|s| s.to_string()).collect()
 }
 
-/*
- * The use of a structure here is kind of pointless except to exercise the case
- * of endpoints that return a custom structure.
- */
+// The use of a structure here is kind of pointless except to exercise the case
+// of endpoints that return a custom structure.
 #[derive(Debug, Deserialize, Clone, Eq, JsonSchema, PartialEq, Serialize)]
 struct DictionaryWord {
     word: String,
@@ -710,19 +652,17 @@ async fn api_dictionary(
     )?))
 }
 
-/*
- * These tests exercise the behavior of a paginated API with filtering and
- * multiple sort options.  In some ways, these just test our test API.  But it's
- * an important validation that it's possible to build such an API that works
- * the way we expect it to.
- */
+// These tests exercise the behavior of a paginated API with filtering and
+// multiple sort options.  In some ways, these just test our test API.  But it's
+// an important validation that it's possible to build such an API that works
+// the way we expect it to.
 #[tokio::test]
 async fn test_paginate_dictionary() {
     let api = paginate_api();
     let testctx = common::test_setup("dictionary", api);
     let client = &testctx.client_testctx;
 
-    /* simple case */
+    // simple case
     let page =
         objects_list_page::<DictionaryWord>(&client, "/dictionary?limit=3")
             .await;
@@ -739,7 +679,7 @@ async fn test_paginate_dictionary() {
         page.items.iter().map(|dw| dw.word.as_str()).collect::<Vec<&str>>();
     assert_eq!(found_words, vec!["AAAS", "ABA", "AC",]);
 
-    /* Reverse the order. */
+    // Reverse the order.
     let page = objects_list_page::<DictionaryWord>(
         &client,
         "/dictionary?limit=3&order=descending",
@@ -749,7 +689,7 @@ async fn test_paginate_dictionary() {
         page.items.iter().map(|dw| dw.word.as_str()).collect::<Vec<&str>>();
     assert_eq!(found_words, vec!["zygote", "zucchini", "zounds",]);
     let token = page.next_page.unwrap();
-    /* Critically, we don't have to pass order=descending again. */
+    // Critically, we don't have to pass order=descending again.
     let page = objects_list_page::<DictionaryWord>(
         &client,
         &format!("/dictionary?limit=3&page_token={}", token),
@@ -759,7 +699,7 @@ async fn test_paginate_dictionary() {
         page.items.iter().map(|dw| dw.word.as_str()).collect::<Vec<&str>>();
     assert_eq!(found_words, vec!["zooplankton", "zoom", "zoology",]);
 
-    /* Apply a filter. */
+    // Apply a filter.
     let page = objects_list_page::<DictionaryWord>(
         &client,
         "/dictionary?limit=3&min_length=12",
@@ -784,10 +724,8 @@ async fn test_paginate_dictionary() {
         vec!["Bhagavadgita", "Brontosaurus", "Cantabrigian",]
     );
 
-    /*
-     * Let's page through the filtered collection one item at a time.  This is
-     * an edge case that only works if the marker is implemented correctly.
-     */
+    // Let's page through the filtered collection one item at a time.  This is
+    // an edge case that only works if the marker is implemented correctly.
     let (sortedby1, npagesby1) = iter_collection::<DictionaryWord>(
         &client,
         "/dictionary",
@@ -800,10 +738,8 @@ async fn test_paginate_dictionary() {
     assert_eq!(sortedby1[0].word, "Addressograph");
     assert_eq!(sortedby1[sortedby1.len() - 1].word, "wholehearted");
 
-    /*
-     * Page through it again one at a time, but in reverse order to make sure
-     * the marker works correctly in that direction as well.
-     */
+    // Page through it again one at a time, but in reverse order to make sure
+    // the marker works correctly in that direction as well.
     let (rsortedby1, rnpagesby1) = iter_collection::<DictionaryWord>(
         &client,
         "/dictionary",
@@ -821,10 +757,8 @@ async fn test_paginate_dictionary() {
             .collect::<Vec<DictionaryWord>>()
     );
 
-    /*
-     * Fetch the whole thing in one go to make sure we didn't hit any edge cases
-     * around the markers.
-     */
+    // Fetch the whole thing in one go to make sure we didn't hit any edge cases
+    // around the markers.
     let (sortedbybig, npagesbybig) = iter_collection::<DictionaryWord>(
         &client,
         "/dictionary",
@@ -833,11 +767,9 @@ async fn test_paginate_dictionary() {
     )
     .await;
     assert_eq!(sortedby1, sortedbybig);
-    /*
-     * There's currently an extra request as part of any scan because Dropshot
-     * doesn't know not to put the marker in the response unless it sees an
-     * empty response.
-     */
+    // There's currently an extra request as part of any scan because Dropshot
+    // doesn't know not to put the marker in the response unless it sees an
+    // empty response.
     assert_eq!(npagesbybig, 2);
 
     testctx.teardown().await;
@@ -861,13 +793,11 @@ impl Drop for ExampleContext {
     }
 }
 
-/**
- * For one of the example programs that starts a Dropshot server on localhost
- * using a TCP port provided as a command-line argument, this function starts
- * the requested example on the requested TCP port and attempts to wait for the
- * Dropshot server to become available.  It returns a handle to the child
- * process and a ClientTestContext for making requests against that server.
- */
+/// For one of the example programs that starts a Dropshot server on localhost
+/// using a TCP port provided as a command-line argument, this function starts
+/// the requested example on the requested TCP port and attempts to wait for the
+/// Dropshot server to become available.  It returns a handle to the child
+/// process and a ClientTestContext for making requests against that server.
 async fn start_example(path: &str, port: u16) -> ExampleContext {
     let logctx = LogContext::new(
         path,
@@ -889,22 +819,18 @@ async fn start_example(path: &str, port: u16) -> ExampleContext {
         my_path
     };
 
-    /*
-     * We redirect stderr to /dev/null to avoid spamming the user's terminal.
-     * It would be better to put this in some log file that we manage similarly
-     * to a LogContext so that it would be available for debugging when wanted
-     * but removed upon successful completion of the test.
-     */
+    // We redirect stderr to /dev/null to avoid spamming the user's terminal.
+    // It would be better to put this in some log file that we manage similarly
+    // to a LogContext so that it would be available for debugging when wanted
+    // but removed upon successful completion of the test.
     let config = Exec::cmd(cmd_path).arg(port.to_string()).stderr(NullFile);
     let cmdline = config.to_cmdline_lossy();
     info!(&log, "starting child process"; "cmdline" => &cmdline);
     let child = config.popen().unwrap();
 
-    /*
-     * Wait up to 10 seconds for the actual HTTP server to start up.  We'll
-     * continue trying to make requests against it until they fail for an
-     * HTTP-level error.
-     */
+    // Wait up to 10 seconds for the actual HTTP server to start up.  We'll
+    // continue trying to make requests against it until they fail for an
+    // HTTP-level error.
     let start = Instant::now();
     let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let client = ClientTestContext::new(server_addr, logctx.log.new(o!()));
@@ -943,16 +869,12 @@ struct ExampleProject {
     name: String,
 }
 
-/**
- * Tests the "pagination-basic" example, which just lists 999 projects.
- */
+/// Tests the "pagination-basic" example, which just lists 999 projects.
 #[tokio::test]
 async fn test_example_basic() {
-    /*
-     * We specify a port on which to run the example servers.  It would be
-     * better to let them pick a port on startup (as they will do if we don't
-     * provide an argument) and use that.
-     */
+    // We specify a port on which to run the example servers.  It would be
+    // better to let them pick a port on startup (as they will do if we don't
+    // provide an argument) and use that.
     let mut exctx = start_example("pagination-basic", 12230).await;
     let client = &exctx.client;
 
@@ -972,15 +894,13 @@ struct ExampleProjectMtime {
     mtime: DateTime<Utc>,
 }
 
-/**
- * Tests the "pagination-multiple-sorts" example.
- */
+/// Tests the "pagination-multiple-sorts" example.
 #[tokio::test]
 async fn test_example_multiple_sorts() {
     let mut exctx = start_example("pagination-multiple-sorts", 12231).await;
     let client = &exctx.client;
 
-    /* default sort */
+    // default sort
     let byname =
         assert_collection_iter::<ExampleProjectMtime>(&client, "/projects", "")
             .await;
@@ -988,7 +908,7 @@ async fn test_example_multiple_sorts() {
     assert_eq!(byname[0].name, "project001");
     assert_eq!(byname[byname.len() - 1].name, "project999");
 
-    /* ascending sort by name */
+    // ascending sort by name
     let byname_asc = assert_collection_iter::<ExampleProjectMtime>(
         &client,
         "/projects",
@@ -997,7 +917,7 @@ async fn test_example_multiple_sorts() {
     .await;
     assert_eq!(byname, byname_asc);
 
-    /* descending sort by name */
+    // descending sort by name
     let byname_desc = assert_collection_iter::<ExampleProjectMtime>(
         &client,
         "/projects",
@@ -1013,7 +933,7 @@ async fn test_example_multiple_sorts() {
             .collect::<Vec<ExampleProjectMtime>>()
     );
 
-    /* ascending sort by mtime */
+    // ascending sort by mtime
     let bymtime_asc = assert_collection_iter::<ExampleProjectMtime>(
         &client,
         "/projects",
@@ -1029,7 +949,7 @@ async fn test_example_multiple_sorts() {
         );
     });
 
-    /* descending sort by mtime */
+    // descending sort by mtime
     let bymtime_desc = assert_collection_iter::<ExampleProjectMtime>(
         &client,
         "/projects",
@@ -1057,9 +977,7 @@ struct ExampleObject {
     name: String,
 }
 
-/**
- * Tests the "pagination-multiple-resources" example.
- */
+/// Tests the "pagination-multiple-resources" example.
 #[tokio::test]
 async fn test_example_multiple_resources() {
     let mut exctx = start_example("pagination-multiple-resources", 12232).await;
@@ -1067,7 +985,7 @@ async fn test_example_multiple_resources() {
 
     let resources = ["/projects", "/disks", "/instances"];
     for resource in &resources[..] {
-        /* Scan parameters are not necessary. */
+        // Scan parameters are not necessary.
         let no_args =
             objects_list_page::<ExampleObject>(&client, "/projects?limit=3")
                 .await;

--- a/dropshot/tests/test_tls.rs
+++ b/dropshot/tests/test_tls.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 Oxide Computer Company
-/*!
- * Test cases for TLS support. This validates various behaviors of our TLS mode,
- * including certificate loading and supported modes.
- */
+//! Test cases for TLS support. This validates various behaviors of our TLS mode,
+//! including certificate loading and supported modes.
 
 use dropshot::{ConfigDropshot, ConfigTls, HttpResponseOk, HttpServerStarter};
 use slog::{o, Logger};
@@ -337,12 +335,10 @@ pub struct TlsCheckArgs {
     tls: bool,
 }
 
-/*
- * The same handler is used for both an HTTP and HTTPS server.
- * Make sure that we can distinguish between the two.
- * The intended version is determined by a query parameter
- * that varies between both tests.
- */
+// The same handler is used for both an HTTP and HTTPS server.
+// Make sure that we can distinguish between the two.
+// The intended version is determined by a query parameter
+// that varies between both tests.
 #[dropshot::endpoint {
     method = GET,
     path = "/",

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -4,10 +4,8 @@
 //! attributes are used both to define an HTTP API and to generate an OpenAPI
 //! Spec (OAS) v3 document that describes the API.
 
-/*
- * Clippy's style advice is definitely valuable, but not worth the trouble for
- * automated enforcement.
- */
+// Clippy's style advice is definitely valuable, but not worth the trouble for
+// automated enforcement.
 #![allow(clippy::style)]
 
 use quote::format_ident;
@@ -1524,11 +1522,9 @@ mod tests {
 
     #[test]
     fn test_extract_summary_description() {
-        /**
-         * Javadoc summary
-         * Maybe there's another name for these...
-         * ... but Java is the first place I saw these types of comments.
-         */
+        /// Javadoc summary
+        /// Maybe there's another name for these...
+        /// ... but Java is the first place I saw these types of comments.
         #[derive(Schema)]
         struct JavadocComments;
         assert_eq!(
@@ -1543,11 +1539,9 @@ mod tests {
             )
         );
 
-        /**
-         * Javadoc summary
-         *
-         * Skip that blank.
-         */
+        /// Javadoc summary
+        ///
+        /// Skip that blank.
         #[derive(Schema)]
         struct JavadocCommentsWithABlank;
         assert_eq!(
@@ -1558,7 +1552,7 @@ mod tests {
             )
         );
 
-        /** Terse Javadoc summary */
+        /// Terse Javadoc summary
         #[derive(Schema)]
         struct JavadocCommentsTerse;
         assert_eq!(
@@ -1604,9 +1598,7 @@ mod tests {
             (Some("Just a Rustdoc summary".to_string()), None)
         );
 
-        /**
-         * Just a Javadoc summary
-         */
+        /// Just a Javadoc summary
         #[derive(Schema)]
         struct JustTheJavadocSummary;
         assert_eq!(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,7 @@
 max_width = 80
 use_small_heuristics = "max"
 edition = "2018"
+
+# Temp unstable features
+unstable_features = true
+normalize_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,7 +4,3 @@
 max_width = 80
 use_small_heuristics = "max"
 edition = "2018"
-
-# Temp unstable features
-unstable_features = true
-normalize_comments = true


### PR DESCRIPTION
This is modeled after oxidecomputer/omicron#770.  Paraphrasing from there what applies here as well.

---

Dropshot currently has a mix of commenting styles -- both block style (C style, /* ... */) and line style (// ...). It seems like this has been a distraction for folks, and the line style is more popular.  After the success of oxidecomputer/omicron#770 I used rustfmt's `normalize_comments` option to switch everything to line style.  I don't think we should enforce this with rustfmt because that requires an unstable option, which we know from experience is painful.  I don't expect this to be a big problem because I think line style tends to be the more common expectation.

When this lands, it may be annoying to merge with outstanding work.  I'm happy to help with that.  Based on last time, when this commit lands on "main", I think the right strategy is to sync up other PRs by:

1. First merge with the parent commit of this commit on "main".
2. Make sure you have no uncommitted local changes.
3. Copy this to `rustfmt-new.toml`:

```
# ---------------------------------------------------------------------------
# Stable features that we customize locally
# ---------------------------------------------------------------------------
max_width = 80
use_small_heuristics = "max"
edition = "2021"

# Temp unstable features
unstable_features = true
normalize_comments = true
```
4. Run `cargo +nightly fmt -- --config-path=rustfmt-new.toml`
5. Run `git commit -am 'premerge with style update'`
6. Merge with this commit on main.  This should pretty straightforward. If you have conflicts, they should be because you've changed comment lines. I think you pretty much want to take your version at this point (since step 3 will already have changed your comments to line-style).