### PR TITLE
CI clippy run is incomplete

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Report Clippy version
         run: cargo clippy -- --version
       - name: Run Clippy Lints
-        run: cargo clippy -- -D warnings
+        # Clippy's style nits are useful, but not worth keeping in CI.  This
+        # override belongs in src/lib.rs, but that doesn't reliably work due to
+        # rust-lang/rust-clippy#6610.
+        run: cargo clippy --all-targets -- --deny warnings --allow clippy::style
 
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ suite runs cleanly and should remain clean.
 
 You can format the code using `cargo fmt`.  CI checks that code is correctly formatted.
 
-https://github.com/rust-lang/rust-clippy[Clippy] is used to check for common code issues.  (We disable the style checks.)  You can run it with `cargo clippy`.  CI will run clippy as well.
+https://github.com/rust-lang/rust-clippy[Clippy] is used to check for common code issues.  (We disable the style checks.)  You can run it with `cargo clippy --all-targets -- --deny warnings --allow clippy::style`.  CI will run clippy as well.
 
 For maintainers (e.g., publishing new releases and managing dependabot), see link:./MAINTAINERS.adoc[MAINTAINERS.adoc].
 

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -821,7 +821,7 @@ mod test {
         let t1: DateTime<Utc> =
             DateTime::parse_from_rfc3339(T1_STR).unwrap().into();
         BunyanLogRecord {
-            time: t1.into(),
+            time: t1,
             name: "n1".to_string(),
             hostname: "h1".to_string(),
             pid: 1,
@@ -837,7 +837,7 @@ mod test {
             DateTime::parse_from_rfc3339(T1_STR).unwrap().into();
         let r1 = make_dummy_record();
         let r2 = BunyanLogRecord {
-            time: t1.into(),
+            time: t1,
             name: "n1".to_string(),
             hostname: "h2".to_string(),
             pid: 1,
@@ -1017,7 +1017,7 @@ mod test {
             DateTime::parse_from_rfc3339(T2_STR).unwrap().into();
         let v0: Vec<BunyanLogRecord> = vec![];
         let v1: Vec<BunyanLogRecord> = vec![BunyanLogRecord {
-            time: t1.into(),
+            time: t1,
             name: "dummy_name".to_string(),
             hostname: "dummy_hostname".to_string(),
             pid: 123,
@@ -1026,7 +1026,7 @@ mod test {
         }];
         let v2: Vec<BunyanLogRecord> = vec![
             BunyanLogRecord {
-                time: t1.into(),
+                time: t1,
                 name: "dummy_name".to_string(),
                 hostname: "dummy_hostname".to_string(),
                 pid: 123,
@@ -1034,7 +1034,7 @@ mod test {
                 v: 0,
             },
             BunyanLogRecord {
-                time: t2.into(),
+                time: t2,
                 name: "dummy_name".to_string(),
                 hostname: "dummy_hostname".to_string(),
                 pid: 123,
@@ -1078,7 +1078,7 @@ mod test {
         let t2: DateTime<Utc> =
             DateTime::parse_from_rfc3339(T2_STR).unwrap().into();
         let v1: Vec<BunyanLogRecord> = vec![BunyanLogRecord {
-            time: t1.into(),
+            time: t1,
             name: "dummy_name".to_string(),
             hostname: "dummy_hostname".to_string(),
             pid: 123,
@@ -1097,7 +1097,7 @@ mod test {
         let t2: DateTime<Utc> =
             DateTime::parse_from_rfc3339(T2_STR).unwrap().into();
         let v1: Vec<BunyanLogRecord> = vec![BunyanLogRecord {
-            time: t2.into(),
+            time: t2,
             name: "dummy_name".to_string(),
             hostname: "dummy_hostname".to_string(),
             pid: 123,
@@ -1117,7 +1117,7 @@ mod test {
             DateTime::parse_from_rfc3339(T2_STR).unwrap().into();
         let v2: Vec<BunyanLogRecord> = vec![
             BunyanLogRecord {
-                time: t2.into(),
+                time: t2,
                 name: "dummy_name".to_string(),
                 hostname: "dummy_hostname".to_string(),
                 pid: 123,
@@ -1125,7 +1125,7 @@ mod test {
                 v: 0,
             },
             BunyanLogRecord {
-                time: t1.into(),
+                time: t1,
                 name: "dummy_name".to_string(),
                 hostname: "dummy_hostname".to_string(),
                 pid: 123,

--- a/dropshot/src/type_util.rs
+++ b/dropshot/src/type_util.rs
@@ -249,7 +249,7 @@ mod tests {
         });
 
         let mut dependencies = IndexMap::new();
-        dependencies.insert("Selfie".to_string(), schema.clone());
+        dependencies.insert("Selfie".to_string(), schema);
         let schema_ref = &dependencies[0];
 
         type_resolve(schema_ref, &dependencies);

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -350,7 +350,10 @@ mod tests {
         ws_upg_from_mock_rqctx()
             .await
             .unwrap()
-            .handle(move |_upgrade| async move { Ok(send.send(()).unwrap()) })
+            .handle(move |_upgrade| async move {
+                send.send(()).unwrap();
+                Ok(())
+            })
             .unwrap();
         // note: not a real connection, so we don't get our future's Ok, but we *do* spawn the task
         let _ = tokio::time::timeout(Duration::from_secs(1), recv)

--- a/dropshot/tests/common/mod.rs
+++ b/dropshot/tests/common/mod.rs
@@ -27,7 +27,7 @@ pub fn test_setup(
 
     let logctx = create_log_context(test_name);
     let log = logctx.log.new(o!());
-    TestContext::new(api, 0 as usize, &config_dropshot, Some(logctx), log)
+    TestContext::new(api, 0_usize, &config_dropshot, Some(logctx), log)
 }
 
 pub fn create_log_context(test_name: &str) -> LogContext {

--- a/dropshot/tests/common/mod.rs
+++ b/dropshot/tests/common/mod.rs
@@ -142,7 +142,7 @@ pub fn tls_key_to_buffer(
             contents: cert.0.clone(),
         });
         cert_writer
-            .write(encoded_cert.as_bytes())
+            .write_all(encoded_cert.as_bytes())
             .expect("failed to serialize cert");
     }
     drop(cert_writer);
@@ -153,7 +153,9 @@ pub fn tls_key_to_buffer(
         tag: "PRIVATE KEY".to_string(),
         contents: key.0.clone(),
     });
-    key_writer.write(encoded_key.as_bytes()).expect("failed to serialize key");
+    key_writer
+        .write_all(encoded_key.as_bytes())
+        .expect("failed to serialize key");
     drop(key_writer);
 
     (serialized_certs, serialized_key)
@@ -169,8 +171,8 @@ pub fn tls_key_to_file(
 
     let (certs, key) = tls_key_to_buffer(certs, key);
 
-    cert_file.write(certs.as_slice()).expect("Failed to write certs");
-    key_file.write(key.as_slice()).expect("Failed to write key");
+    cert_file.write_all(certs.as_slice()).expect("Failed to write certs");
+    key_file.write_all(key.as_slice()).expect("Failed to write key");
 
     (cert_file, key_file)
 }

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -614,7 +614,7 @@ async fn api_dictionary(
 ) -> Result<HttpResponseOk<ResultsPage<DictionaryWord>>, HttpError> {
     let pag_params = query.into_inner();
     let limit = rqctx.page_limit(&pag_params)?.get() as usize;
-    let dictionary: &BTreeSet<String> = &*WORD_LIST;
+    let dictionary: &BTreeSet<String> = &WORD_LIST;
 
     let (bound, scan_params) = match &pag_params.page {
         WhichPage::First(scan) => (Bound::Unbounded, scan),
@@ -782,7 +782,9 @@ struct ExampleContext {
 
 impl ExampleContext {
     fn cleanup_successful(&mut self) {
-        self.logctx.take().map(|l| l.cleanup_successful());
+        if let Some(l) = self.logctx.take() {
+            l.cleanup_successful()
+        }
     }
 }
 


### PR DESCRIPTION
As I understand it, `cargo clippy` with no target specification is the same as `cargo check` with no target specification, which means it checks binary and library targets.  Tests, examples, and other stuff aren't checked.  This change modifies CI to check everything.  It also fixes everything newly found (done using `--fix`).