### PR TITLE
Use a named type instead of returning `impl Future` in wait_for_shutdown()

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -637,6 +637,7 @@ pub use pagination::PaginationParams;
 pub use pagination::ResultsPage;
 pub use pagination::WhichPage;
 pub use server::ServerContext;
+pub use server::ShutdownWaitFuture;
 pub use server::{HttpServer, HttpServerStarter};
 pub use websocket::WebsocketChannelResult;
 pub use websocket::WebsocketConnection;

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -538,7 +538,7 @@ impl<C: ServerContext> Service<&TlsConn> for ServerConnectionHandler<C> {
     }
 }
 
-type SharedBoxFuture<T> = Shared<Pin<Box<dyn Future<Output = T> + Send>>>;
+pub type SharedBoxFuture<T> = Shared<Pin<Box<dyn Future<Output = T> + Send>>>;
 
 /// A running Dropshot HTTP server.
 ///
@@ -597,9 +597,7 @@ impl<C: ServerContext> HttpServer<C> {
     /// the shutdown to happen.
     ///
     /// To trigger a shutdown, Call [HttpServer::close] (which also awaits shutdown).
-    pub fn wait_for_shutdown(
-        &self,
-    ) -> impl FusedFuture<Output = Result<(), String>> {
+    pub fn wait_for_shutdown(&self) -> SharedBoxFuture<Result<(), String>> {
         self.join_future.clone()
     }
 


### PR DESCRIPTION
This allows callers to store the shutdown futures without having to box them again.

The context where this came up was in MGS where I want to have multiple dropshot servers running _and_ change that set over time. To wait for shutdown of all of them I want to collect the `wait_for_shutdown()` handles into a `FuturesUnordered<Fut>` and store that `FuturesUnordered` in another struct (in order to insert new servers into it later).