### PR TITLE
CI builds should test with and without features

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -14,7 +14,7 @@ cargo --version
 rustc --version
 
 banner build
-ptime -m cargo build --locked --all-targets --verbose
+ptime -m cargo build --all-features --locked --all-targets --verbose
 
 banner test
-ptime -m cargo test --locked --verbose
+ptime -m cargo test --all-features --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-12]
+        features: [ all, default ]
+        include:
+          - features: all
+            feature_flags: --all-features
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Report cargo version
@@ -47,6 +51,6 @@ jobs:
       - name: Report rustc version
         run: rustc --version
       - name: Build
-        run: cargo build --locked --all-targets --verbose
+        run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
-        run: cargo test --locked --verbose
+        run: cargo test ${{ matrix.feature_flags }} --locked --verbose


### PR DESCRIPTION
Our CI builds do not test with the "usdt-probes" feature enabled.  It's also not enabled by default so it would be easy to not notice while testing locally if you broke it.

This change:

- updates the Helios build to test with all features
- updates the GitHub Actions builds to test all OS's twice: once without features and once with.  This might be overkill but it was easy to do and covers everything.

We're not running clippy with features right now but that seems less critical.