### PR TITLE
Simplify tls.type example in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,9 +51,9 @@ include:
 |Specifies the maximum number of bytes allowed in a request body. Larger requests will receive a 400 error. Defaults to 1024.
 
 |`tls.type`
-|`"AsFile", "AsBytes"`
+|`"AsFile"
 |No
-|Specifies if and how TLS certificate and key information is provided.
+|Specifies if and how TLS certificate and key information is provided.  Valid values include "AsFile" and "AsBytes".
 
 |`tls.cert_file`
 |`"/path/to/cert.pem"`


### PR DESCRIPTION
All of the other examples are set to just a single value, and then all potential values are enumerated as a "Valid values include ..." statement in the description.