### PR TITLE
Manually outline ApiDescription::register

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -279,11 +279,21 @@ impl<Context: ServerContext> ApiDescription<Context> {
     {
         let e = endpoint.into();
 
-        self.validate_tags(&e)?;
-        self.validate_path_parameters(&e)?;
-        self.validate_named_parameters(&e)?;
+        // manually outline, see https://matklad.github.io/2021/09/04/fast-rust-builds.html#Keeping-Instantiations-In-Check
+        fn _register<C: ServerContext>(
+            s: &mut ApiDescription<C>,
+            e: ApiEndpoint<C>,
+        ) -> Result<(), String> {
+            s.validate_tags(&e)?;
+            s.validate_path_parameters(&e)?;
+            s.validate_named_parameters(&e)?;
 
-        self.router.insert(e);
+            s.router.insert(e);
+
+            Ok(())
+        }
+
+        _register(self, e)?;
 
         Ok(())
     }


### PR DESCRIPTION
This function often gets called in generic contexts, and so a *lot* of monomorphization happens. By making this small change, you can help the compiler not do as much work.

In my tests, this results in five seconds being knocked off of Omicron's build times.