### PR TITLE
Add required-without-page_token information to pagination extension

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,9 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.9.0\...HEAD[Full list of commits]
 
-* https://github.com/oxidecomputer/dropshot/pull/651[#651]  The address of the remote peer is now available to request handlers via the `RequestInfo` struct.
+=== Breaking Changes
+
+* https://github.com/oxidecomputer/dropshot/pull/651[#651]  The address of the remote peer is now available to request handlers via the `RequestInfo` struct. With this change we've removed the related `From<hyper::Request<B>>` implementation; instead use `RequestInfo::new<B>(&hyper::Request<B>, std::net::SocketAddr)`.
 
 == 0.9.0 (released 2023-01-20)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,7 +17,11 @@ https://github.com/oxidecomputer/dropshot/compare/v0.9.0\...HEAD[Full list of co
 
 === Breaking Changes
 
-* https://github.com/oxidecomputer/dropshot/pull/651[#651]  The address of the remote peer is now available to request handlers via the `RequestInfo` struct. With this change we've removed the related `From<hyper::Request<B>>` implementation; instead use `RequestInfo::new<B>(&hyper::Request<B>, std::net::SocketAddr)`.
+* https://github.com/oxidecomputer/dropshot/pull/651[#651] The address of the remote peer is now available to request handlers via the `RequestInfo` struct. With this change we've removed the related `From<hyper::Request<B>>` implementation; instead use `RequestInfo::new<B>(&hyper::Request<B>, std::net::SocketAddr)`.
+
+=== Other notable Changes
+
+* https://github.com/oxidecomputer/dropshot/pull/660[#660] The `x-dropshot-pagination` extension used to be simply the value `true`. Now it is an object with a field, `required`, that is an array of parameters that are mandatory on the first invocation.
 
 == 0.9.0 (released 2023-01-20)
 

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -670,12 +670,12 @@ impl<Context: ServerContext> ApiDescription<Context> {
                 })
                 .next();
 
-            match endpoint.extension_mode {
+            match &endpoint.extension_mode {
                 ExtensionMode::None => {}
-                ExtensionMode::Paginated => {
+                ExtensionMode::Paginated(first_page_schema) => {
                     operation.extensions.insert(
                         crate::pagination::PAGINATION_EXTENSION.to_string(),
-                        serde_json::json! {true},
+                        first_page_schema.clone(),
                     );
                 }
                 ExtensionMode::Websocket => {
@@ -1105,11 +1105,11 @@ pub struct TagExternalDocs {
 }
 
 /// Dropshot/Progenitor features used by endpoints which are not a part of the base OpenAPI spec.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum ExtensionMode {
     #[default]
     None,
-    Paginated,
+    Paginated(serde_json::Value),
     Websocket,
 }
 

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -89,7 +89,7 @@ pub struct RequestContext<Context: ServerContext> {
 }
 
 // This is deliberately as close to compatible with `hyper::Request` as
-// reasonable.
+// reasonable with the addition of the remote address.
 #[derive(Debug)]
 pub struct RequestInfo {
     method: http::Method,
@@ -100,7 +100,7 @@ pub struct RequestInfo {
 }
 
 impl RequestInfo {
-    pub(crate) fn new<B>(
+    pub fn new<B>(
         request: &hyper::Request<B>,
         remote_addr: std::net::SocketAddr,
     ) -> Self {

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -392,7 +392,7 @@
 //!
 //! ```json
 //! {
-//!     "page_token": "abc123...",
+//!     "next_page": "abc123...",
 //!     "items": [
 //!         {
 //!             "name": "aardvark",
@@ -413,7 +413,7 @@
 //! The page token `"abc123..."` is an opaque token to the client, but typically
 //! encodes the scan parameters and the value of the last item seen
 //! (`"name=badger"`).  The client knows it has completed the scan when it
-//! receives a response with no `page_token` in it.
+//! receives a response with no `next_page` in it.
 //!
 //! Our API endpoint can also support scanning in reverse order.  In this case,
 //! when the client makes the first request, it should fetch
@@ -507,7 +507,27 @@
 //! this ought to work, but it currently doesn't due to serde_urlencoded#33,
 //! which is really serde#1183.
 //!
-//! ### DTrace probes
+//! Note that any parameters defined by `MyScanParams` are effectively encoded
+//! into the page token and need not be supplied invocations when `page_token`
+//! is specified. That is not the case for required parameters defined by
+//! `MyExtraQueryParams`--those must be supplied on each invocation.
+//!
+//! ### OpenAPI extension
+//!
+//! In generated OpenAPI documents, Dropshot adds the `x-dropshot-paginated`
+//! extension to paginated operations. The value is currently a structure
+//! with this format:
+//! ```json
+//! {
+//!     "required": [ .. ]
+//! }
+//! ```
+//!
+//! The string values in the `required` array are the names of those query
+//! parameters that are mandatory if `page_token` is not specified (when
+//! fetching the first page of data).
+//!
+//! ## DTrace probes
 //!
 //! Dropshot optionally exposes two DTrace probes, `request_start` and
 //! `request_finish`. These provide detailed information about each request,
@@ -515,7 +535,7 @@
 //! See the dropshot::dtrace::RequestInfo` and `dropshot::dtrace::ResponseInfo`
 //! types for a complete listing of what's available.
 //!
-//! These probes are implemented via the [`usdt`] crate. They may require a
+//! These probes are implemented via the `usdt` crate. They may require a
 //! nightly toolchain if built on macOS prior to Rust version 1.66. Otherwise a
 //! stable compiler >= v1.59 is required in order to present the necessary
 //! features. Given these constraints, USDT functionality is behind the feature

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -514,7 +514,7 @@
 //!
 //! ### OpenAPI extension
 //!
-//! In generated OpenAPI documents, Dropshot adds the `x-dropshot-paginated`
+//! In generated OpenAPI documents, Dropshot adds the `x-dropshot-pagination`
 //! extension to paginated operations. The value is currently a structure
 //! with this format:
 //! ```json

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -540,7 +540,7 @@ impl<C: ServerContext> Service<&TlsConn> for ServerConnectionHandler<C> {
 
 type SharedBoxFuture<T> = Shared<Pin<Box<dyn Future<Output = T> + Send>>>;
 
-/// Future returned by [`Server::wait_for_shutdown()`].
+/// Future returned by [`HttpServer::wait_for_shutdown()`].
 pub struct ShutdownWaitFuture(SharedBoxFuture<Result<(), String>>);
 
 impl Future for ShutdownWaitFuture {

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 //! Automated testing facilities.  These are intended for use both by this crate
 //! and dependents of this crate.
 
@@ -130,8 +130,8 @@ impl ClientTestContext {
     }
 
     /// Execute an HTTP request against the test server and perform basic
-    /// validation of the result like [`make_request`], but with a content
-    /// type of "application/x-www-form-urlencoded".
+    /// validation of the result like [`ClientTestContext::make_request`], but
+    /// with a content type of "application/x-www-form-urlencoded".
     pub async fn make_request_url_encoded<
         RequestBodyType: Serialize + Debug,
     >(

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -209,6 +209,13 @@
         "parameters": [
           {
             "in": "query",
+            "name": "a_mandatory_string",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "a_number",
             "schema": {
               "type": "integer",
@@ -255,7 +262,11 @@
             "$ref": "#/components/responses/Error"
           }
         },
-        "x-dropshot-pagination": true
+        "x-dropshot-pagination": {
+          "required": [
+            "a_mandatory_string"
+          ]
+        }
       }
     },
     "/playing/a/bit/nicer": {

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 use dropshot::{
     endpoint, http_response_found, http_response_see_other,
@@ -138,6 +138,7 @@ struct ResponseItem {
 struct ExampleScanParams {
     #[serde(default)]
     a_number: u16,
+    a_mandatory_string: String,
 }
 
 #[derive(Deserialize, JsonSchema, Serialize)]

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -217,6 +217,13 @@
         "parameters": [
           {
             "in": "query",
+            "name": "a_mandatory_string",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "a_number",
             "schema": {
               "type": "integer",
@@ -263,7 +270,11 @@
             "$ref": "#/components/responses/Error"
           }
         },
-        "x-dropshot-pagination": true
+        "x-dropshot-pagination": {
+          "required": [
+            "a_mandatory_string"
+          ]
+        }
       }
     },
     "/playing/a/bit/nicer": {

--- a/dropshot/tests/test_pagination_schema.json
+++ b/dropshot/tests/test_pagination_schema.json
@@ -63,7 +63,11 @@
             "$ref": "#/components/responses/Error"
           }
         },
-        "x-dropshot-pagination": true
+        "x-dropshot-pagination": {
+          "required": [
+            "garbage_goes_in"
+          ]
+        }
       }
     }
   },

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -134,7 +134,7 @@ fn do_endpoint(
     do_endpoint_inner(metadata, attr, item)
 }
 
-/// As with [`endpoint`], this attribute turns a handler function into a
+/// As with [`macro@endpoint`], this attribute turns a handler function into a
 /// Dropshot endpoint, but first wraps the handler function in such a way
 /// that is spawned asynchronously and given the upgraded connection of
 /// the given `protocol` (i.e. `WEBSOCKETS`).

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -142,11 +142,13 @@ fn do_endpoint(
 /// The first argument still must be a `RequestContext<_>`.
 ///
 /// The last argument passed to the handler function must be a
-/// [`dropshot::WebsocketConnection`].
+/// [`WebsocketConnection`](../dropshot/struct.WebsocketConnection.html).
 ///
-/// The function must return a [`dropshot::WebsocketChannelResult`] (which is
-/// a general-purpose `Result<(), Box<dyn Error + Send + Sync + 'static>>`).
-/// Returned error values will be written to the RequestContext's log.
+/// The function must return a
+/// [`WebsocketChannelResult`](dropshot/type.WebsocketChannelResult.html)
+/// (which is a general-purpose `Result<(), Box<dyn Error + Send + Sync +
+/// 'static>>`). Returned error values will be written to the RequestContext's
+/// log.
 ///
 /// ```ignore
 /// #[dropshot::channel { protocol = WEBSOCKETS, path = "/my/ws/channel/{id}" }]


### PR DESCRIPTION
Previously `x-dropshot-pagination` was simply the value `true`. Now it's an object with a field `required` that is an array of strings that tell us what query parameters are required to fetch the first page (i.e. when `page_token` is not specified).

This also cleans up some stray doc nits.