### PR TITLE
fix #664: Generalize dtrace support to allow other tracing tools

### DIFF
--- a/dropshot/examples/basic.rs
+++ b/dropshot/examples/basic.rs
@@ -2,6 +2,7 @@
 //! Example use of Dropshot.
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -43,10 +44,15 @@ async fn main() -> Result<(), String> {
     let api_context = ExampleContext::new();
 
     // Set up the server.
-    let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
-            .map_err(|error| format!("failed to create server: {}", error))?
-            .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        api_context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/file_server.rs
+++ b/dropshot/examples/file_server.rs
@@ -2,6 +2,7 @@
 
 //! Example using Dropshot to serve files
 
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
@@ -44,9 +45,15 @@ async fn main() -> Result<(), String> {
     let context = FileServerContext { base: PathBuf::from(".") };
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, context, &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/https.rs
+++ b/dropshot/examples/https.rs
@@ -3,6 +3,7 @@
 //! Example use of Dropshot with TLS enabled
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -87,10 +88,15 @@ async fn main() -> Result<(), String> {
     let api_context = ExampleContext::new();
 
     // Set up the server.
-    let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
-            .map_err(|error| format!("failed to create server: {}", error))?
-            .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        api_context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/index.rs
+++ b/dropshot/examples/index.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Oxide Computer Company
 //! Example use of Dropshot for matching wildcard paths to serve static content.
 
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -35,9 +36,15 @@ async fn main() -> Result<(), String> {
     api.register(index).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        (),
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/module-basic.rs
+++ b/dropshot/examples/module-basic.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Oxide Computer Company
 //! Example use of Dropshot.
 
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
@@ -35,10 +36,15 @@ async fn main() -> Result<(), String> {
     let api_context = ExampleContext::new();
 
     // Set up the server.
-    let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
-            .map_err(|error| format!("failed to create server: {}", error))?
-            .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        api_context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/module-shared-context.rs
+++ b/dropshot/examples/module-shared-context.rs
@@ -3,6 +3,7 @@
 //! a custom context object that outlives endpoint functions.
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
@@ -47,6 +48,7 @@ async fn main() -> Result<(), String> {
         api,
         api_context.clone(),
         &log,
+        Noop::default(),
     )
     .map_err(|error| format!("failed to create server: {}", error))?
     .start();

--- a/dropshot/examples/pagination-basic.rs
+++ b/dropshot/examples/pagination-basic.rs
@@ -15,6 +15,7 @@
 //! next page token from the response as a query parameter, too.
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -128,8 +129,14 @@ async fn main() -> Result<(), String> {
         .map_err(|error| format!("failed to create logger: {}", error))?;
     let mut api = ApiDescription::new();
     api.register(example_list_projects).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        ctx,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
     server.await
 }

--- a/dropshot/examples/pagination-multiple-resources.rs
+++ b/dropshot/examples/pagination-multiple-resources.rs
@@ -4,6 +4,7 @@
 //! about how to run this.
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -290,9 +291,15 @@ async fn main() -> Result<(), String> {
     api.register(example_list_projects).unwrap();
     api.register(example_list_disks).unwrap();
     api.register(example_list_instances).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        ctx,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     server.await
 }

--- a/dropshot/examples/pagination-multiple-sorts.rs
+++ b/dropshot/examples/pagination-multiple-sorts.rs
@@ -92,6 +92,7 @@ use chrono::offset::TimeZone;
 use chrono::DateTime;
 use chrono::Utc;
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -304,9 +305,15 @@ async fn main() -> Result<(), String> {
         .map_err(|error| format!("failed to create logger: {}", error))?;
     let mut api = ApiDescription::new();
     api.register(example_list_projects).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        ctx,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Print out some example requests to start with.
     print_example_requests(log, &server.local_addr());

--- a/dropshot/examples/request-headers.rs
+++ b/dropshot/examples/request-headers.rs
@@ -11,6 +11,7 @@
 //! comments on the common code.
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -32,10 +33,15 @@ async fn main() -> Result<(), String> {
     api.register(example_api_get_header_generic).unwrap();
 
     let api_context = ();
-    let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
-            .map_err(|error| format!("failed to create server: {}", error))?
-            .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        api_context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
     server.await
 }
 

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -3,6 +3,7 @@
 //! An example that demonstrates server shutdown (and waiting for shutdown).
 
 use dropshot::endpoint;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -33,10 +34,15 @@ async fn main() -> Result<(), String> {
     let api_context = Arc::new(ExampleContext::new());
 
     // Set up the server.
-    let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
-            .map_err(|error| format!("failed to create server: {}", error))?
-            .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        api_context,
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
     let shutdown = server.wait_for_shutdown();
 
     tokio::task::spawn(async move {

--- a/dropshot/examples/websocket.rs
+++ b/dropshot/examples/websocket.rs
@@ -2,6 +2,7 @@
 //! Example use of Dropshot with a websocket endpoint.
 
 use dropshot::channel;
+use dropshot::tracing::Noop;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -37,9 +38,15 @@ async fn main() -> Result<(), String> {
     api.register(example_api_websocket_counter).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        (),
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/examples/well-tagged.rs
+++ b/dropshot/examples/well-tagged.rs
@@ -6,7 +6,7 @@
 //! proper tagging innate.
 
 use dropshot::{
-    endpoint, ApiDescription, ConfigLogging, ConfigLoggingLevel,
+    endpoint, tracing::Noop, ApiDescription, ConfigLogging, ConfigLoggingLevel,
     EndpointTagPolicy, HttpError, HttpResponseOk, HttpServerStarter,
     RequestContext, TagConfig, TagDetails, TagExternalDocs,
 };
@@ -99,9 +99,15 @@ async fn main() -> Result<(), String> {
     api.register(get_fryism).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
-        .start();
+    let server = HttpServerStarter::new(
+        &config_dropshot,
+        api,
+        (),
+        &log,
+        Noop::default(),
+    )
+    .map_err(|error| format!("failed to create server: {}", error))?
+    .start();
 
     // Wait for the server to stop.  Note that there's not any code to shut down
     // this server, so we should never get past this point.

--- a/dropshot/src/dtrace.rs
+++ b/dropshot/src/dtrace.rs
@@ -2,7 +2,7 @@
 //! DTrace probes and support
 
 #[derive(Debug, Clone, serde::Serialize)]
-pub(crate) struct RequestInfo {
+pub struct RequestInfo {
     pub id: String,
     pub local_addr: std::net::SocketAddr,
     pub remote_addr: std::net::SocketAddr,
@@ -12,7 +12,7 @@ pub(crate) struct RequestInfo {
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
-pub(crate) struct ResponseInfo {
+pub struct ResponseInfo {
     pub id: String,
     pub local_addr: std::net::SocketAddr,
     pub remote_addr: std::net::SocketAddr,

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -596,6 +596,7 @@ mod router;
 mod schema_util;
 mod server;
 mod to_map;
+pub mod tracing;
 mod type_util;
 mod websocket;
 

--- a/dropshot/src/tracing.rs
+++ b/dropshot/src/tracing.rs
@@ -1,0 +1,48 @@
+pub use crate::{dtrace::RequestInfo, dtrace::ResponseInfo};
+
+pub trait Tracing: std::fmt::Debug + Clone + Send + Sync + 'static {
+    type Registration: Unpin;
+
+    fn register(&self) -> Self::Registration;
+    fn request_start(&self, request_info: &RequestInfo);
+    fn request_done(&self, response_info: &ResponseInfo);
+}
+
+#[cfg(feature = "usdt-probes")]
+#[derive(Debug, Clone, Copy)]
+pub struct Dtrace;
+
+#[cfg(feature = "usdt-probes")]
+impl Tracing for Dtrace {
+    type Registration = crate::dtrace::ProbeRegistration;
+
+    fn register(&self) -> Self::Registration {
+        match usdt::register_probes() {
+            Ok(()) => crate::dtrace::ProbeRegistration::Succeeded,
+            Err(e) => crate::dtrace::ProbeRegistration::Failed(e),
+        }
+    }
+
+    fn request_start(&self, request_info: &RequestInfo) {
+        crate::dtrace::probes::request__start!(|| request_info);
+    }
+
+    fn request_done(&self, response_info: &ResponseInfo) {
+        crate::dtrace::probes::request_done!(|| response_info);
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Noop;
+
+impl Tracing for Noop {
+    type Registration = ();
+
+    fn register(&self) -> Self::Registration {
+        ()
+    }
+
+    fn request_start(&self, _: &RequestInfo) {}
+
+    fn request_done(&self, _: &ResponseInfo) {}
+}


### PR DESCRIPTION
Currently on main, dropshot supports tracing functions with dtrace probes. Some users, including KittyCAD, would like to add other forms of tracing (e.g. sentry or their own custom tooling). 

This PR adds a new trait `Tracing` which matches the API used by dropshot's dtrace support. It adds two implementations of that trait:

- A dtrace implementation, which runs the same functionality as the current dtrace feature flag
    - This is only available behind the existing dtrace Cargo feature flag for the crate
- A no-op implementation

Users can specify which tracing they want by passing a `Tracing` value into the Dropshot server starters (see updated examples). 

**Changes to user experience**
 - Users now have to pass a value that implements `Tracing` when creating a Dropshot server. This is a minor breaking change -- users can either pass the dtrace implementation, or the no-op implementation, or write their own implementation and use that.

**Implementation changes**
 - This generalizes a lot of Dropshot's core server structs, which were previously generic over `C: ServerContext`. This PR further generalizes many (not all) of them over `Tr: Tracing`. 

**Next steps**
I'm going to experiment with integrating this into some KittyCAD services, to make sure the `Tracing` trait is right for us. I'm opening this PR to Dropshot now, to see if y'all have any objections to the overall idea, or notes about my implementation. I'm going to mark this PR as a draft until I confirm that it suits our needs within KittyCAD first :)