### PR TITLE
bump async log buffer size

### DIFF
--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -118,7 +118,8 @@ where
     <T as slog::Drain>::Err: std::fmt::Debug,
 {
     let level_drain = slog::LevelFilter(drain, Level::from(level)).fuse();
-    let async_drain = slog_async::Async::new(level_drain).build().fuse();
+    let async_drain =
+        slog_async::Async::new(level_drain).chan_size(1024).build().fuse();
     slog::Logger::root(async_drain, o!())
 }
 


### PR DESCRIPTION
For historical reasons, Dropshot provides `ConfigLogging` as a convenient way to set up a slog logger.  (Dropshot doesn't really depend on this.   You just end up giving it a slog logger.  This stuff could move to its own crate.)  Anyway, it sets up an async logger.  This is kind of problematic and not trivial to fix: see oxidecomputer/omicron#1014 for discussion.

Short of a real fix, this change bumps the async log buffer size from the default (which [appears to be 128 messages](https://docs.rs/slog-async/latest/src/slog_async/lib.rs.html#251)) to 1024 messages.  It's sort of unfortunate to change this constant deep in Dropshot in order to fix several consumers (that aren't even all _using_ the rest of Dropshot).  But I don't think there's any harm in this change.

The motivation is that I somewhat frequently see slog report a message about having dropped some messages.  Fortunately, it tells you how many it's dropped.  When I noticed this problem, the largest number I ever saw was about 60 messages dropped.  Bumping from 128 to 1024 ought to give us plenty of breathing room.  (This will cost some memory, but right now, I think that's a cost we want to pay.)