### PR TITLE
Make server shutdown wait on any Detached handler futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +358,7 @@ dependencies = [
  "bytes",
  "camino",
  "chrono",
+ "debug-ignore",
  "dropshot_endpoint",
  "expectorate",
  "form_urlencoded",
@@ -388,6 +401,7 @@ dependencies = [
  "usdt",
  "uuid",
  "version_check",
+ "waitgroup",
 ]
 
 [[package]]
@@ -2096,6 +2110,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
 
 [[package]]
 name = "want"

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1.68"
 base64 = "0.21.2"
 bytes = "1"
 camino = { version = "1.1.4", features = ["serde1"] }
+debug-ignore = "1.0.5"
 form_urlencoded = "1.1.0"
 futures = "0.3.28"
 hostname = "0.3.0"
@@ -37,6 +38,7 @@ slog-json = "2.6.1"
 slog-term = "2.9.0"
 tokio-rustls = "0.24.0"
 toml = "0.7.4"
+waitgroup = "0.1.2"
 
 [dependencies.chrono]
 version = "0.4.26"

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -72,6 +72,7 @@ const ALLOWED_HEADERS: [AllowedHeader<'static>; 8] = [
 
 /// ClientTestContext encapsulates several facilities associated with using an
 /// HTTP client for testing.
+#[derive(Clone)]
 pub struct ClientTestContext {
     /// actual bind address of the HTTP server under test
     pub bind_address: SocketAddr,

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -301,12 +301,14 @@ mod tests {
         ExclusiveExtractor, HttpError, RequestContext, RequestInfo,
         WebsocketUpgrade,
     };
+    use debug_ignore::DebugIgnore;
     use http::Request;
     use hyper::Body;
     use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     use std::num::NonZeroU32;
     use std::sync::Arc;
     use std::time::Duration;
+    use waitgroup::WaitGroup;
 
     async fn ws_upg_from_mock_rqctx() -> Result<WebsocketUpgrade, HttpError> {
         let log = slog::Logger::root(slog::Discard, slog::o!()).new(slog::o!());
@@ -336,6 +338,9 @@ mod tests {
                     8080,
                 ),
                 tls_acceptor: None,
+                handler_waitgroup_worker: DebugIgnore(
+                    WaitGroup::new().worker(),
+                ),
             }),
             request: RequestInfo::new(&request, remote_addr),
             path_variables: Default::default(),

--- a/dropshot/tests/test_detached_shutdown.rs
+++ b/dropshot/tests/test_detached_shutdown.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 Oxide Computer Company
+
+//! Test cases for graceful shutdown of a server running tasks in
+//! `HandlerTaskMode::Detached`.
+
+use dropshot::{
+    endpoint, ApiDescription, HandlerTaskMode, HttpError, RequestContext,
+};
+use http::{Method, Response, StatusCode};
+use hyper::Body;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+pub mod common;
+
+struct Context {
+    endpoint_started_tx: mpsc::UnboundedSender<()>,
+    release_endpoint_rx: async_channel::Receiver<()>,
+}
+
+fn api() -> ApiDescription<Context> {
+    let mut api = ApiDescription::new();
+    api.register(root).unwrap();
+    api
+}
+
+#[endpoint {
+    method = GET,
+    path = "/",
+}]
+async fn root(
+    rqctx: RequestContext<Context>,
+) -> Result<Response<Body>, HttpError> {
+    let ctx = rqctx.context();
+
+    // Notify test driver we've started handling a request.
+    ctx.endpoint_started_tx.send(()).unwrap();
+
+    // Wait until the test driver tells us to return.
+    () = ctx.release_endpoint_rx.recv().await.unwrap();
+
+    Ok(Response::builder().status(StatusCode::OK).body(Body::empty())?)
+}
+
+#[tokio::test]
+async fn test_graceful_shutdown_with_detached_handler() {
+    let (endpoint_started_tx, mut endpoint_started_rx) =
+        mpsc::unbounded_channel();
+    let (release_endpoint_tx, release_endpoint_rx) = async_channel::unbounded();
+
+    let api = api();
+    let testctx = common::test_setup_with_context(
+        "graceful_shutdown_with_detached_handler",
+        api,
+        Context { endpoint_started_tx, release_endpoint_rx },
+        HandlerTaskMode::Detached,
+    );
+    let client = testctx.client_testctx.clone();
+
+    // Spawn a task sending a request to our endpoint.
+    let client_task = tokio::spawn(async move {
+        client
+            .make_request_no_body(Method::GET, "/", StatusCode::OK)
+            .await
+            .expect("Expected GET request to succeed")
+    });
+
+    // Wait for the handler to start running.
+    () = endpoint_started_rx.recv().await.unwrap();
+
+    // Kill the client, which cancels the dropshot server future that spawned
+    // our detached handler, but does not cancel the endpoint future itself
+    // (because we're using HandlerTaskMode::Detached).
+    client_task.abort();
+
+    // Create a future to tear down the server.
+    let teardown_fut = testctx.teardown();
+    tokio::pin!(teardown_fut);
+
+    // Actually tearing down should time out, because it's waiting for the
+    // handler to return (which in turn is waiting on us to signal it!).
+    if tokio::time::timeout(Duration::from_secs(2), &mut teardown_fut)
+        .await
+        .is_ok()
+    {
+        panic!("server shutdown returned while handler running");
+    }
+
+    // Signal the handler to complete.
+    release_endpoint_tx.send(()).await.unwrap();
+
+    // Now we can finish waiting for server shutdown.
+    teardown_fut.await;
+}


### PR DESCRIPTION
I ended up using a [`WaitGroup`](https://docs.rs/waitgroup/latest/waitgroup/struct.WaitGroup.html) to track outstanding handler futures instead of trying to accumulate them into something like a `FuturesUnordered` or `JoinSet`, because we don't actually care about their results: we just want to know when they're all done.

Testing this was a little weird: we have to force a situation where we have a detached handler future still running after server shutdown has been requested. It uses a similar pattern to the tests added #701, where the handler will wait for a message on a channel from the test driver before returning, allowing us to construct a client request and then cancel it, leaving the detached handler still running.