### PR TITLE
Add `#[allow(clippy::unused_async)]` to emitted endpoints

### DIFF
--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -611,6 +611,7 @@ fn do_endpoint_inner(
             for #dropshot::ApiEndpoint< #first_arg >
         {
             fn from(_: #name) -> Self {
+                #[allow(clippy::unused_async)]
                 #item
 
                 // The checks on the implementation require #name to be in


### PR DESCRIPTION
We require endpoints to be async, but it's not uncommon to have endpoints that themselves do not need to `.await` anything. If a user wants to enable the (off-by-default) `clippy::unused_async` lint, they would need to add this annotation by hand to each such endpoint, or we could just do it for them.

This came from trying clippy in omicron with `-D clippy::unused_async`; the first (several) things it tripped over are fixed by this.