### PR TITLE
WIP: dropshot support for multiple API versions

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -47,6 +47,7 @@ pub struct ApiEndpoint<Context: ServerContext> {
     pub extension_mode: ExtensionMode,
     pub visible: bool,
     pub deprecated: bool,
+    pub versions: ApiVersions,
 }
 
 impl<'a, Context: ServerContext> ApiEndpoint<Context> {
@@ -81,6 +82,7 @@ impl<'a, Context: ServerContext> ApiEndpoint<Context> {
             extension_mode: func_parameters.extension_mode,
             visible: true,
             deprecated: false,
+            versions: ApiVersions::All,
         }
     }
 
@@ -875,6 +877,14 @@ impl<Context: ServerContext> ApiDescription<Context> {
     pub fn into_router(self) -> HttpRouter<Context> {
         self.router
     }
+}
+
+#[derive(Debug)]
+pub enum ApiVersions {
+    All,
+    From(String),
+    FromUntil(String, String),
+    Until(String),
 }
 
 /// Returns true iff the schema represents the void schema that matches no data.

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -729,6 +729,7 @@ mod test {
     use super::HttpRouter;
     use super::PathSegment;
     use crate::api_description::ApiEndpointBodyContentType;
+    use crate::api_description::ApiVersions;
     use crate::from_map::from_map;
     use crate::router::VariableValue;
     use crate::ApiEndpoint;
@@ -774,6 +775,7 @@ mod test {
             extension_mode: Default::default(),
             visible: true,
             deprecated: false,
+            versions: ApiVersions::All,
         }
     }
 

--- a/dropshot/tests/test_demo.rs
+++ b/dropshot/tests/test_demo.rs
@@ -1060,6 +1060,9 @@ type RequestCtx = RequestContext<usize>;
 #[endpoint {
     method = GET,
     path = "/testing/demo1",
+    // versions = "1.2.3"..,
+    // versions = .."1.2.5",
+    versions = "1.2.3".."1.2.5",
 }]
 async fn demo_handler_args_1(
     _rqctx: RequestCtx,


### PR DESCRIPTION
I think these are most of the steps:

- [x] `#[endpoint]` macro parsing
- [ ] macro creation of versioned endpoints
- [ ] route tree creation of multiple versions including detection of overlapping version ranges
- [ ] enumeration of versions
- [ ] proper routing to versioned handlers
- [ ] extraction of OpenAPI document for a particular version

---
Here's my proposal for how we parse versions with the proc macro:

```rust
#[endpoint {
    method = GET,
    path = "/testing/demo1",
    // versions = "1.2.3"..,
    // versions = .."1.2.5",
    versions = "1.2.3".."1.2.5",
}]
async fn demo_handler_args_1(..) {}
```