### PR TITLE
Use `writeln!` over `eprintln!` to avoid a potential panic

### DIFF
--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -112,15 +112,15 @@ impl ConfigLogging {
                 // isn't writeable (e.g., if stderr has been redirected to a
                 // file on a full disk). Our options seem to be:
                 //
-                // a) Return an error if we fail to emit this message b)
-                // Silently swallow errors c) If an error occurs, try to relay
-                // that fact
+                // a) Return an error if we fail to emit this message
+                // b) Silently swallow errors
+                // c) If an error occurs, try to relay that fact
                 //
                 // (a) doesn't seem great, because it's possible we're able to
                 // run just fine (and possibly even use the logger we're about
                 // to create, as we don't know that it will suffer the same fate
                 // that writing to stderr does). (b) is defensible since this is
-                // just an informational message. We go with (c) to attempt to
+                // just an informational message. We go with (c) and attempt to
                 // leave a breadcrumb in the log itself.
                 if let Err(err) = writeln!(
                     io::stderr(),

--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -11,6 +11,7 @@ use slog::Level;
 use slog::Logger;
 use std::fs::OpenOptions;
 use std::io::LineWriter;
+use std::io::Write;
 use std::{io, path::Path};
 
 /// Represents the logging configuration for a server.  This is expected to be a
@@ -101,7 +102,38 @@ impl ConfigLogging {
                     Path::new(path),
                     log_name.as_ref().to_string(),
                 )?;
-                Ok(async_root_logger(level, drain))
+                let logger = async_root_logger(level, drain);
+
+                // Record a message to the stderr so that a reader who doesn't
+                // already know how logging is configured knows where the rest
+                // of the log messages went.
+                //
+                // We don't want to use `eprintln!`, because it panics if stderr
+                // isn't writeable (e.g., if stderr has been redirected to a
+                // file on a full disk). Our options seem to be:
+                //
+                // a) Return an error if we fail to emit this message b)
+                // Silently swallow errors c) If an error occurs, try to relay
+                // that fact
+                //
+                // (a) doesn't seem great, because it's possible we're able to
+                // run just fine (and possibly even use the logger we're about
+                // to create, as we don't know that it will suffer the same fate
+                // that writing to stderr does). (b) is defensible since this is
+                // just an informational message. We go with (c) to attempt to
+                // leave a breadcrumb in the log itself.
+                if let Err(err) = writeln!(
+                    io::stderr(),
+                    "note: configured to log to \"{path}\"",
+                ) {
+                    slog::warn!(
+                        logger,
+                        "failed to report log path on stderr";
+                        "err" => %err,
+                    );
+                }
+
+                Ok(logger)
             }
         }
     }
@@ -134,10 +166,6 @@ fn log_drain_for_file(
 
     // Buffer writes to the file around newlines to minimize syscalls.
     let file = LineWriter::new(open_options.open(path)?);
-
-    // Record a message to the stderr so that a reader who doesn't already know
-    // how logging is configured knows where the rest of the log messages went.
-    eprintln!("note: configured to log to \"{}\"", path.display());
 
     // Using leak() here is dubious.  However, we really want the logger's name
     // to be dynamically generated from the test name.  Unfortunately, the


### PR DESCRIPTION
On startup when logging to a file, we use(d) `eprintln!` to leave a note to the user with the path where logs are emitted. This can cause processes using dropshot to panic, so this PR replaces `eprintln!` with `writeln!`.

Fixes #811.

---

I would have liked to add an automated test for this, but explicitly testing `eprintln!` seems hard; there's no standard library way to reopen stderr, for example. I tested this manually by patching the `basic` example like so:

```diff
--- a/dropshot/examples/basic.rs
+++ b/dropshot/examples/basic.rs
@@ -29,7 +29,11 @@ async fn main() -> Result<(), String> {
     // For simplicity, we'll configure an "info"-level logger that writes to
     // stderr assuming that it's a terminal.
     let config_logging =
-        ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
+        ConfigLogging::File {
+            level: ConfigLoggingLevel::Info,
+            path: "basic.log".into(),
+            if_exists: dropshot::ConfigLoggingIfExists::Append,
+        };
     let log = config_logging
         .to_logger("example-basic")
         .map_err(|error| format!("failed to create logger: {}", error))?;
```

and then running it like this:

```console
./target/debug/examples/basic 2> >(true)
```

On this branch, the example continues to run and contains this in `basic.log`:

```
21:19:54.931Z WARN example-basic: failed to report log path on stderr
    err = Broken pipe (os error 32)
```

On `main`, running the same command immediately exits with code 101 (i.e., a Rust panic).