### PR TITLE
fixup documentation link

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -31,12 +31,12 @@
 //! (sometimes without even knowing it!).  There's hardly a clear standard, yet
 //! this is a really basic operation for any REST API.)
 //!
-//! For a discussion of alternative crates considered, see [Oxide RFD 10]
-//! (https://github.com/oxidecomputer/dropshot/issues/56#issuecomment-705710515).
+//! For a discussion of alternative crates considered, see [Oxide RFD 10].
 //!
 //! We hope Dropshot will be fairly general-purpose, but it's primarily intended
 //! to address the needs of the Oxide control plane.
 //!
+//! [Oxide RFD 10]: https://github.com/oxidecomputer/dropshot/issues/56#issuecomment-705710515
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
There was a broken link in the documentation:
https://docs.rs/dropshot/latest/dropshot/

And this was throwing warnings during doc compilation:
```
warning: this URL is not a hyperlink
  --> dropshot/src/lib.rs:35:6
   |
35 | //! (https://github.com/oxidecomputer/dropshot/issues/56#issuecomment-705710515).
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/oxidecomputer/dropshot/issues/56#issuecomment-705710515>`
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: `dropshot` (lib doc) generated 1 warning (run `cargo fix --lib -p dropshot` to apply 1 suggestion)
```