### PR TITLE
Exposing ServerConfig options

### DIFF
--- a/dropshot/examples/basic.rs
+++ b/dropshot/examples/basic.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), String> {
 
     // Set up the server.
     let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+        HttpServerStarter::new(config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
 

--- a/dropshot/examples/file_server.rs
+++ b/dropshot/examples/file_server.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), String> {
     let context = FileServerContext { base: PathBuf::from(".") };
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, context, &log)
+    let server = HttpServerStarter::new(config_dropshot, api, context, &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/https.rs
+++ b/dropshot/examples/https.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), String> {
 
     // Set up the server.
     let server = HttpServerStarter::new_with_tls(
-        &config_dropshot,
+        config_dropshot,
         api,
         api_context,
         &log,

--- a/dropshot/examples/index.rs
+++ b/dropshot/examples/index.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), String> {
     api.register(index).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+    let server = HttpServerStarter::new(config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/module-basic.rs
+++ b/dropshot/examples/module-basic.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), String> {
 
     // Set up the server.
     let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+        HttpServerStarter::new(config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
 

--- a/dropshot/examples/module-shared-context.rs
+++ b/dropshot/examples/module-shared-context.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), String> {
 
     // Set up the server.
     let server = HttpServerStarter::new(
-        &config_dropshot,
+        config_dropshot,
         api,
         api_context.clone(),
         &log,

--- a/dropshot/examples/multipart.rs
+++ b/dropshot/examples/multipart.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), String> {
     api.register(index).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+    let server = HttpServerStarter::new(config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/multiple-servers.rs
+++ b/dropshot/examples/multiple-servers.rs
@@ -219,7 +219,7 @@ impl SharedMultiServerContext {
             log: log.clone(),
         };
         let server =
-            HttpServerStarter::new(&config_dropshot, api, context, &log)
+            HttpServerStarter::new(config_dropshot, api, context, &log)
                 .map_err(|error| format!("failed to create server: {}", error))?
                 .start();
         let shutdown_handle = server.wait_for_shutdown();

--- a/dropshot/examples/pagination-basic.rs
+++ b/dropshot/examples/pagination-basic.rs
@@ -128,7 +128,7 @@ async fn main() -> Result<(), String> {
         .map_err(|error| format!("failed to create logger: {}", error))?;
     let mut api = ApiDescription::new();
     api.register(example_list_projects).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
+    let server = HttpServerStarter::new(config_dropshot, api, ctx, &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
     server.await

--- a/dropshot/examples/pagination-multiple-resources.rs
+++ b/dropshot/examples/pagination-multiple-resources.rs
@@ -290,7 +290,7 @@ async fn main() -> Result<(), String> {
     api.register(example_list_projects).unwrap();
     api.register(example_list_disks).unwrap();
     api.register(example_list_instances).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
+    let server = HttpServerStarter::new(config_dropshot, api, ctx, &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/pagination-multiple-sorts.rs
+++ b/dropshot/examples/pagination-multiple-sorts.rs
@@ -304,7 +304,7 @@ async fn main() -> Result<(), String> {
         .map_err(|error| format!("failed to create logger: {}", error))?;
     let mut api = ApiDescription::new();
     api.register(example_list_projects).unwrap();
-    let server = HttpServerStarter::new(&config_dropshot, api, ctx, &log)
+    let server = HttpServerStarter::new(config_dropshot, api, ctx, &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/request-headers.rs
+++ b/dropshot/examples/request-headers.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), String> {
 
     let api_context = ();
     let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+        HttpServerStarter::new(config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
     server.await

--- a/dropshot/examples/self-referential.rs
+++ b/dropshot/examples/self-referential.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), String> {
 
     // Set up the server.
     let server =
-        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+        HttpServerStarter::new(config_dropshot, api, api_context, &log)
             .map_err(|error| format!("failed to create server: {}", error))?
             .start();
     let shutdown = server.wait_for_shutdown();

--- a/dropshot/examples/websocket.rs
+++ b/dropshot/examples/websocket.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), String> {
     api.register(example_api_websocket_counter).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+    let server = HttpServerStarter::new(config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/examples/well-tagged.rs
+++ b/dropshot/examples/well-tagged.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), String> {
     api.register(get_fryism).unwrap();
 
     // Set up the server.
-    let server = HttpServerStarter::new(&config_dropshot, api, (), &log)
+    let server = HttpServerStarter::new(config_dropshot, api, (), &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 

--- a/dropshot/src/config.rs
+++ b/dropshot/src/config.rs
@@ -4,6 +4,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::SocketAddr;
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 /// Raw [`rustls::ServerConfig`] TLS configuration for use with
@@ -49,6 +50,10 @@ pub struct ConfigDropshot {
     pub bind_address: SocketAddr,
     /// maximum allowed size of a request body, defaults to 1024
     pub request_body_max_bytes: usize,
+    /// maximum size of any page of results
+    pub page_max_nitems: NonZeroU32,
+    /// default size for a page of results
+    pub page_default_nitems: NonZeroU32,
     /// Default behavior for HTTP handler functions with respect to clients
     /// disconnecting early.
     pub default_handler_task_mode: HandlerTaskMode,
@@ -106,6 +111,8 @@ impl Default for ConfigDropshot {
         ConfigDropshot {
             bind_address: "127.0.0.1:0".parse().unwrap(),
             request_body_max_bytes: 1024,
+            page_max_nitems: NonZeroU32::new(10000).unwrap(),
+            page_default_nitems: NonZeroU32::new(100).unwrap(),
             default_handler_task_mode: HandlerTaskMode::Detached,
         }
     }

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -49,7 +49,7 @@
 //! use dropshot::ConfigLoggingLevel;
 //! use dropshot::HandlerTaskMode;
 //! use dropshot::HttpServerStarter;
-//! use std::sync::Arc;
+//! use std::{num::NonZeroU32, sync::Arc};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), String> {
@@ -68,9 +68,11 @@
 //!     // Start the server.
 //!     let server =
 //!         HttpServerStarter::new(
-//!             &ConfigDropshot {
+//!             ConfigDropshot {
 //!                 bind_address: "127.0.0.1:0".parse().unwrap(),
 //!                 request_body_max_bytes: 1024,
+//!                 page_max_nitems: NonZeroU32::new(10000).unwrap(),
+//!                 page_default_nitems: NonZeroU32::new(100).unwrap(),
 //!                 default_handler_task_mode: HandlerTaskMode::Detached,
 //!             },
 //!             api,

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -480,7 +480,7 @@ impl<Context: ServerContext> TestContext<Context> {
     pub fn new(
         api: ApiDescription<Context>,
         private: Context,
-        config_dropshot: &ConfigDropshot,
+        config_dropshot: ConfigDropshot,
         log_context: Option<LogContext>,
         log: Logger,
     ) -> TestContext<Context> {
@@ -492,7 +492,7 @@ impl<Context: ServerContext> TestContext<Context> {
 
         // Set up the server itself.
         let server =
-            HttpServerStarter::new(&config_dropshot, api, private, &log)
+            HttpServerStarter::new(config_dropshot, api, private, &log)
                 .unwrap()
                 .start();
 

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -296,10 +296,9 @@ impl JsonSchema for WebsocketUpgrade {
 mod tests {
     use crate::config::HandlerTaskMode;
     use crate::router::HttpRouter;
-    use crate::server::{DropshotState, ServerConfig};
+    use crate::server::DropshotState;
     use crate::{
-        ExclusiveExtractor, HttpError, RequestContext, RequestInfo,
-        WebsocketUpgrade,
+        ConfigDropshot, ExclusiveExtractor, HttpError, RequestContext, RequestInfo, WebsocketUpgrade
     };
     use debug_ignore::DebugIgnore;
     use http::Request;
@@ -324,12 +323,13 @@ mod tests {
         let rqctx = RequestContext {
             server: Arc::new(DropshotState {
                 private: (),
-                config: ServerConfig {
+                config: ConfigDropshot {
                     request_body_max_bytes: 0,
                     page_max_nitems: NonZeroU32::new(1).unwrap(),
                     page_default_nitems: NonZeroU32::new(1).unwrap(),
                     default_handler_task_mode:
                         HandlerTaskMode::CancelOnDisconnect,
+                    ..Default::default()
                 },
                 router: HttpRouter::new(),
                 log: log.clone(),

--- a/dropshot/tests/common/mod.rs
+++ b/dropshot/tests/common/mod.rs
@@ -39,7 +39,7 @@ pub fn test_setup_with_context<Context: ServerContext>(
 
     let logctx = create_log_context(test_name);
     let log = logctx.log.new(o!());
-    TestContext::new(api, ctx, &config_dropshot, Some(logctx), log)
+    TestContext::new(api, ctx, config_dropshot, Some(logctx), log)
 }
 
 pub fn create_log_context(test_name: &str) -> LogContext {

--- a/dropshot/tests/test_config.rs
+++ b/dropshot/tests/test_config.rs
@@ -84,7 +84,7 @@ fn test_config_bad_request_body_max_bytes_too_large() {
 
 fn make_server<T: Send + Sync + 'static>(
     context: T,
-    config: &ConfigDropshot,
+    config: ConfigDropshot,
     log: &Logger,
     tls: Option<ConfigTls>,
     api_description: Option<dropshot::ApiDescription<T>>,
@@ -111,6 +111,7 @@ fn make_config(
         ),
         request_body_max_bytes: 1024,
         default_handler_task_mode,
+        ..Default::default()
     }
 }
 
@@ -206,7 +207,7 @@ async fn test_config_bind_address_http() {
                 bind_port,
                 HandlerTaskMode::CancelOnDisconnect,
             );
-            make_server(0, &config, &self.log, None, None).start()
+            make_server(0, config, &self.log, None, None).start()
         }
 
         fn log(&self) -> &slog::Logger {
@@ -274,7 +275,7 @@ async fn test_config_bind_address_https() {
                 bind_port,
                 HandlerTaskMode::CancelOnDisconnect,
             );
-            make_server(0, &config, &self.log, tls, None).start()
+            make_server(0, config, &self.log, tls, None).start()
         }
 
         fn log(&self) -> &Logger {
@@ -350,7 +351,7 @@ async fn test_config_bind_address_https_buffer() {
                 bind_port,
                 HandlerTaskMode::CancelOnDisconnect,
             );
-            make_server(0, &config, &self.log, tls, None).start()
+            make_server(0, config, &self.log, tls, None).start()
         }
 
         fn log(&self) -> &Logger {
@@ -478,7 +479,7 @@ impl TestConfigBindServer<hyper::client::connect::HttpConnector>
         api.register(track_cancel_endpoint).unwrap();
 
         let server =
-            make_server(context, &config, &self.log, None, Some(api)).start();
+            make_server(context, config, &self.log, None, Some(api)).start();
 
         self.bound_port.store(server.local_addr().port(), Ordering::SeqCst);
 

--- a/dropshot/tests/test_tls.rs
+++ b/dropshot/tests/test_tls.rs
@@ -114,13 +114,14 @@ fn make_server(
         bind_address: "127.0.0.1:0".parse().unwrap(),
         request_body_max_bytes: 1024,
         default_handler_task_mode: HandlerTaskMode::CancelOnDisconnect,
+        ..Default::default()
     };
     let config_tls = Some(ConfigTls::AsFile {
         cert_file: cert_file.to_path_buf(),
         key_file: key_file.to_path_buf(),
     });
     HttpServerStarter::new_with_tls(
-        &config,
+        config,
         dropshot::ApiDescription::new(),
         0,
         log,
@@ -426,6 +427,7 @@ async fn test_server_is_https() {
         bind_address: "127.0.0.1:0".parse().unwrap(),
         request_body_max_bytes: 1024,
         default_handler_task_mode: HandlerTaskMode::CancelOnDisconnect,
+        ..Default::default()
     };
     let config_tls = Some(ConfigTls::AsFile {
         cert_file: cert_file.path().to_path_buf(),
@@ -434,7 +436,7 @@ async fn test_server_is_https() {
     let mut api = dropshot::ApiDescription::new();
     api.register(tls_check_handler).unwrap();
     let server =
-        HttpServerStarter::new_with_tls(&config, api, 0, &log, config_tls)
+        HttpServerStarter::new_with_tls(config, api, 0, &log, config_tls)
             .unwrap()
             .start();
     let port = server.local_addr().port();


### PR DESCRIPTION
I wanted to start a discussion on how we might go about exposing some additional server settings to the end user, namely the pagination default values. This PR is the most straightforward take and does not consider backwards compatibility. The main changes are:
1. Wherever `ServerConfig` was used `ConfigDropshot` is now used
2. Instead of passing a reference to a `ConfigDropshot` during construction, the value is passed.
3. There are two new fields on `ConfigDropshot`. `page_max_nitems` and `page_default_nitems`.

This causes two breaking changes:
1. We no longer accept a reference during construction.
2. Callers not using the `Default` implementation will have to add the new fields.

The are a couple options we could also consider here.

1. `ConfigDropshot` already derives Clone. We could continue accepting a reference and clone the users config. Not as ideal, but one less breaking change.
2. As we have move fields on the `ConfigDropshot` struct, we could consider a builder for it. I'm not sure how helpful this is at the moment given the `Default` impl.

Either way the primary goal here is to come up with a pattern to expose some of these configurations to end users at the server level.