### PR TITLE
[dropshot] add bad_channel fixtures

### DIFF
--- a/dropshot/tests/fail/README.adoc
+++ b/dropshot/tests/fail/README.adoc
@@ -1,0 +1,20 @@
+:showtitle:
+:toc: left
+:icons: font
+
+= Trybuild fail tests
+
+This directory contains a number of test fixtures run via https://docs.rs/trybuild[trybuild]. All of these tests are expected to produce compile-time failures. The goal of these tests is to ensure that we produce reasonable error messages--or at least that we turn good error messages into bad ones.
+
+Each test fixture should test one endpoint. While it's possible to stuff several endpoints into a single test fixture, it becomes hard to read the errors and ensure that all the right ones are being generated.
+
+== Numbered tests
+
+There are several tests here of the general form:
+
+- `bad_endpointN.rs`
+- `bad_channelN.rs`
+
+The specific situations being tested are mirrored across tests with the same N. For example, `bad_endpoint1.rs` and `bad_channel1.rs` test the situation where a `RequestContext` hasn't been provided.
+
+Some of these tests may be moot for one of the variants. We do not renumber tests--instead, we skip that number so the fixtures afterwards stay consistent, and check in text files with the rationale for skipping. (For example, `bad_channel7.txt`.)

--- a/dropshot/tests/fail/bad_channel1.rs
+++ b/dropshot/tests/fail/bad_channel1.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel1.stderr
+++ b/dropshot/tests/fail/bad_channel1.stderr
@@ -1,0 +1,6 @@
+error: An argument of type dropshot::WebsocketConnection must be provided last.
+  --> tests/fail/bad_channel1.rs:10:5
+   |
+10 | /     protocol = WEBSOCKETS,
+11 | |     path = "/test",
+   | |___________________^

--- a/dropshot/tests/fail/bad_channel10.rs
+++ b/dropshot/tests/fail/bad_channel10.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) -> Result<(), String> {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel10.stderr
+++ b/dropshot/tests/fail/bad_channel10.stderr
@@ -1,0 +1,20 @@
+error[E0271]: expected `{async block@$DIR/tests/fail/bad_channel10.rs:9:1: 12:3}` to be a future that resolves to `Result<(), Box<dyn Error + Send + Sync>>`, but it resolves to `Result<(), String>`
+  --> tests/fail/bad_channel10.rs:9:1
+   |
+9  | / #[channel {
+10 | |     protocol = WEBSOCKETS,
+11 | |     path = "/test",
+12 | | }]
+   | |__^ expected `Result<(), Box<...>>`, found `Result<(), String>`
+   |
+   = note: expected enum `Result<_, Box<(dyn std::error::Error + Send + Sync + 'static)>>`
+              found enum `Result<_, String>`
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+...
+   |         F: Future<Output = WebsocketChannelResult> + Send + 'static,
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dropshot/tests/fail/bad_channel11.rs
+++ b/dropshot/tests/fail/bad_channel11.rs
@@ -1,0 +1,19 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) {
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel11.stderr
+++ b/dropshot/tests/fail/bad_channel11.stderr
@@ -1,0 +1,20 @@
+error[E0271]: expected `{async block@$DIR/tests/fail/bad_channel11.rs:9:1: 12:3}` to be a future that resolves to `Result<(), Box<dyn Error + Send + Sync>>`, but it resolves to `()`
+  --> tests/fail/bad_channel11.rs:9:1
+   |
+9  | / #[channel {
+10 | |     protocol = WEBSOCKETS,
+11 | |     path = "/test",
+12 | | }]
+   | |__^ expected `Result<(), Box<...>>`, found `()`
+   |
+   = note:   expected enum `Result<(), Box<(dyn std::error::Error + Send + Sync + 'static)>>`
+           found unit type `()`
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+...
+   |         F: Future<Output = WebsocketChannelResult> + Send + 'static,
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dropshot/tests/fail/bad_channel12.rs
+++ b/dropshot/tests/fail/bad_channel12.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::HttpError;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_response_type(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    Ok("aok".to_string())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel12.stderr
+++ b/dropshot/tests/fail/bad_channel12.stderr
@@ -1,0 +1,20 @@
+error[E0271]: expected `{async block@$DIR/tests/fail/bad_channel12.rs:10:1: 13:3}` to be a future that resolves to `Result<(), Box<dyn Error + Send + Sync>>`, but it resolves to `Result<String, Box<dyn Error + Send + Sync>>`
+  --> tests/fail/bad_channel12.rs:10:1
+   |
+10 | / #[channel {
+11 | |     protocol = WEBSOCKETS,
+12 | |     path = "/test",
+13 | | }]
+   | |__^ expected `Result<(), Box<...>>`, found `Result<String, Box<...>>`
+   |
+   = note: expected enum `Result<(), Box<(dyn std::error::Error + Send + Sync + 'static)>>`
+              found enum `Result<String, Box<dyn std::error::Error + Send + Sync>>`
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+...
+   |         F: Future<Output = WebsocketChannelResult> + Send + 'static,
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dropshot/tests/fail/bad_channel13.rs
+++ b/dropshot/tests/fail/bad_channel13.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 Oxide Computer Company
+
+// XXX: The error message produced by this test isn't great -- we should fix it.
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+trait Stuff {
+    fn do_stuff();
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel<S: Stuff + Sync + Send + 'static>(
+    _rqctx: RequestContext<S>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    S::do_stuff();
+    panic!()
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel13.stderr
+++ b/dropshot/tests/fail/bad_channel13.stderr
@@ -1,0 +1,63 @@
+error: Endpoint handlers must have the following signature:
+           async fn(
+               rqctx: dropshot::RequestContext<MyContext>,
+               [query_params: Query<Q>,]
+               [path_params: Path<P>,]
+               [body_param: TypedBody<J>,]
+               [body_param: UntypedBody,]
+               [body_param: StreamingBody,]
+               [raw_request: RawRequest,]
+           ) -> Result<HttpResponse*, HttpError>
+  --> tests/fail/bad_channel13.rs:15:1
+   |
+15 | / #[channel {
+16 | |     protocol = WEBSOCKETS,
+17 | |     path = "/test",
+18 | | }]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: generics are not permitted for endpoint handlers
+  --> tests/fail/bad_channel13.rs:19:21
+   |
+19 | async fn bad_channel<S: Stuff + Sync + Send + 'static>(
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0401]: can't use generic parameters from outer item
+  --> tests/fail/bad_channel13.rs:20:28
+   |
+18 | }]
+   |   - help: try introducing a local generic parameter here: `<S>`
+19 | async fn bad_channel<S: Stuff + Sync + Send + 'static>(
+   |                      - type parameter from outer item
+20 |     _rqctx: RequestContext<S>,
+   |                            ^ use of generic parameter from outer item
+
+error[E0401]: can't use generic parameters from outer item
+  --> tests/fail/bad_channel13.rs:23:5
+   |
+18 | }]
+   |   - help: try introducing a local generic parameter here: `<S>`
+19 | async fn bad_channel<S: Stuff + Sync + Send + 'static>(
+   |                      - type parameter from outer item
+...
+23 |     S::do_stuff();
+   |     ^^^^^^^^^^^ use of generic parameter from outer item
+
+error[E0412]: cannot find type `S` in this scope
+  --> tests/fail/bad_channel13.rs:20:28
+   |
+20 |     _rqctx: RequestContext<S>,
+   |                            ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+20 |     _rqctx: RequestContext<S><S>,
+   |                           +++
+
+error[E0412]: cannot find type `S` in this scope
+  --> tests/fail/bad_channel13.rs:20:28
+   |
+20 |     _rqctx: RequestContext<S>,
+   |                            ^ not found in this scope

--- a/dropshot/tests/fail/bad_channel14.rs
+++ b/dropshot/tests/fail/bad_channel14.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Path;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(JsonSchema, Deserialize)]
+struct PathParams {
+    stuff: Vec<String>,
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/assets/{stuff:.*}",
+}]
+async fn must_be_unpublished(
+    _rqctx: RequestContext<()>,
+    _path: Path<PathParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    panic!()
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel14.stderr
+++ b/dropshot/tests/fail/bad_channel14.stderr
@@ -1,0 +1,6 @@
+error: paths that contain a wildcard match must include 'unpublished = true'
+  --> tests/fail/bad_channel14.rs:18:5
+   |
+18 | /     protocol = WEBSOCKETS,
+19 | |     path = "/assets/{stuff:.*}",
+   | |________________________________^

--- a/dropshot/tests/fail/bad_channel15.rs
+++ b/dropshot/tests/fail/bad_channel15.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use std::rc::Rc;
+use std::time::Duration;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    let _non_send_type = Rc::new(0);
+    tokio::time::sleep(Duration::from_millis(1)).await;
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel15.stderr
+++ b/dropshot/tests/fail/bad_channel15.stderr
@@ -1,0 +1,26 @@
+error: future cannot be sent between threads safely
+  --> tests/fail/bad_channel15.rs:11:1
+   |
+11 | / #[channel {
+12 | |     protocol = WEBSOCKETS,
+13 | |     path = "/test",
+14 | | }]
+   | |__^ future created by async block is not `Send`
+   |
+   = help: within `{async block@$DIR/tests/fail/bad_channel15.rs:11:1: 14:3}`, the trait `Send` is not implemented for `Rc<i32>`
+note: future is not `Send` as this value is used across an await
+  --> tests/fail/bad_channel15.rs:20:50
+   |
+19 |     let _non_send_type = Rc::new(0);
+   |         -------------- has type `Rc<i32>` which is not `Send`
+20 |     tokio::time::sleep(Duration::from_millis(1)).await;
+   |                                                  ^^^^^ await occurs here, with `_non_send_type` maybe used later
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+...
+   |         F: Future<Output = WebsocketChannelResult> + Send + 'static,
+   |                                                      ^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dropshot/tests/fail/bad_channel16.txt
+++ b/dropshot/tests/fail/bad_channel16.txt
@@ -1,0 +1,2 @@
+bad_endpoint16.rs tests a Content-Type that isn't allowed -- the #[channel]
+macro doesn't support custom content types so this test is moot.

--- a/dropshot/tests/fail/bad_channel17.rs
+++ b/dropshot/tests/fail/bad_channel17.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+// Test: two websocket channels.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn two_websocket_channels(
+    _rqctx: RequestContext<()>,
+    _upgraded1: WebsocketConnection,
+    _upgraded2: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel17.stderr
+++ b/dropshot/tests/fail/bad_channel17.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the trait bound `WebsocketConnection: SharedExtractor` is not satisfied
+  --> tests/fail/bad_channel17.rs:18:17
+   |
+18 |     _upgraded1: WebsocketConnection,
+   |                 ^^^^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `WebsocketConnection`
+   |
+   = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Path<PathType>
+             dropshot::Query<QueryType>
+note: required by a bound in `need_shared_extractor`
+  --> tests/fail/bad_channel17.rs:12:1
+   |
+12 | / #[channel {
+13 | |     protocol = WEBSOCKETS,
+14 | |     path = "/test",
+15 | | }]
+   | |__^ required by this bound in `need_shared_extractor`
+...
+18 |       _upgraded1: WebsocketConnection,
+   |                   ------------------- required by a bound in this function
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `fn(RequestContext<()>, WebsocketConnection, WebsocketUpgrade) -> impl Future<Output = Result<http::response::Response<hyper::body::body::Body>, HttpError>> {<impl From<two_websocket_channels> for ApiEndpoint<<RequestContext<()> as RequestContextArgument>::Context>>::from::two_websocket_channels}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
+  --> tests/fail/bad_channel17.rs:16:10
+   |
+12 | / #[channel {
+13 | |     protocol = WEBSOCKETS,
+14 | |     path = "/test",
+15 | | }]
+   | |__- required by a bound introduced by this call
+16 |   async fn two_websocket_channels(
+   |            ^^^^^^^^^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for fn item `fn(RequestContext<()>, WebsocketConnection, WebsocketUpgrade) -> ... {two_websocket_channels}`
+   |
+note: required by a bound in `ApiEndpoint::<Context>::new`
+  --> src/api_description.rs
+   |
+   |     pub fn new<HandlerType, FuncParams, ResponseType>(
+   |            --- required by a bound in this associated function
+...
+   |         HandlerType: HttpHandlerFunc<Context, FuncParams, ResponseType>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_channel18.rs
+++ b/dropshot/tests/fail/bad_channel18.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct Stuff {
+    x: String,
+}
+
+// Test: websocket channel not as the last argument
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn websocket_channel_not_last(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+    _query: Query<Stuff>,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel18.stderr
+++ b/dropshot/tests/fail/bad_channel18.stderr
@@ -1,0 +1,65 @@
+error[E0277]: the trait bound `WebsocketConnection: SharedExtractor` is not satisfied
+  --> tests/fail/bad_channel18.rs:25:16
+   |
+25 |     _upgraded: WebsocketConnection,
+   |                ^^^^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `WebsocketConnection`
+   |
+   = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Path<PathType>
+             dropshot::Query<QueryType>
+note: required by a bound in `need_shared_extractor`
+  --> tests/fail/bad_channel18.rs:19:1
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |__^ required by this bound in `need_shared_extractor`
+...
+25 |       _upgraded: WebsocketConnection,
+   |                  ------------------- required by a bound in this function
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0631]: type mismatch in closure arguments
+  --> tests/fail/bad_channel18.rs:19:1
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |  ^
+   | |  |
+   | |__expected due to this
+   |    found signature defined here
+   |
+   = note: expected closure signature `fn(WebsocketConnection) -> _`
+              found closure signature `fn(dropshot::Query<Stuff>) -> _`
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+   |     where
+   |         C: FnOnce(WebsocketConnection) -> F + Send + 'static,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `fn(RequestContext<()>, WebsocketConnection, WebsocketUpgrade) -> impl Future<Output = Result<http::response::Response<hyper::body::body::Body>, HttpError>> {<impl From<websocket_channel_not_last> for ApiEndpoint<<RequestContext<()> as RequestContextArgument>::Context>>::from::websocket_channel_not_last}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
+  --> tests/fail/bad_channel18.rs:23:10
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |__- required by a bound introduced by this call
+23 |   async fn websocket_channel_not_last(
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for fn item `fn(RequestContext<()>, WebsocketConnection, WebsocketUpgrade) -> ... {websocket_channel_not_last}`
+   |
+note: required by a bound in `ApiEndpoint::<Context>::new`
+  --> src/api_description.rs
+   |
+   |     pub fn new<HandlerType, FuncParams, ResponseType>(
+   |            --- required by a bound in this associated function
+...
+   |         HandlerType: HttpHandlerFunc<Context, FuncParams, ResponseType>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_channel19.rs
+++ b/dropshot/tests/fail/bad_channel19.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: middle parameter is not a SharedExtractor.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn non_extractor_as_last_argument(
+    _rqctx: RequestContext<()>,
+    _param: String,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel19.stderr
+++ b/dropshot/tests/fail/bad_channel19.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the trait bound `std::string::String: SharedExtractor` is not satisfied
+  --> tests/fail/bad_channel19.rs:25:13
+   |
+25 |     _param: String,
+   |             ^^^^^^ the trait `SharedExtractor` is not implemented for `std::string::String`
+   |
+   = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Path<PathType>
+             dropshot::Query<QueryType>
+note: required by a bound in `need_shared_extractor`
+  --> tests/fail/bad_channel19.rs:19:1
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |__^ required by this bound in `need_shared_extractor`
+...
+25 |       _param: String,
+   |               ------ required by a bound in this function
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `fn(RequestContext<()>, std::string::String, WebsocketUpgrade) -> impl Future<Output = Result<http::response::Response<hyper::body::body::Body>, HttpError>> {<impl From<non_extractor_as_last_argument> for ApiEndpoint<<RequestContext<()> as RequestContextArgument>::Context>>::from::non_extractor_as_last_argument}: dropshot::handler::HttpHandlerFunc<_, _, _>` is not satisfied
+  --> tests/fail/bad_channel19.rs:23:10
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |__- required by a bound introduced by this call
+23 |   async fn non_extractor_as_last_argument(
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `dropshot::handler::HttpHandlerFunc<_, _, _>` is not implemented for fn item `fn(RequestContext<()>, String, WebsocketUpgrade) -> impl Future<Output = ...> {non_extractor_as_last_argument}`
+   |
+note: required by a bound in `ApiEndpoint::<Context>::new`
+  --> src/api_description.rs
+   |
+   |     pub fn new<HandlerType, FuncParams, ResponseType>(
+   |            --- required by a bound in this associated function
+...
+   |         HandlerType: HttpHandlerFunc<Context, FuncParams, ResponseType>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ApiEndpoint::<Context>::new`

--- a/dropshot/tests/fail/bad_channel2.rs
+++ b/dropshot/tests/fail/bad_channel2.rs
@@ -1,0 +1,19 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    self,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel2.stderr
+++ b/dropshot/tests/fail/bad_channel2.stderr
@@ -1,0 +1,45 @@
+error: Endpoint handlers must have the following signature:
+           async fn(
+               rqctx: dropshot::RequestContext<MyContext>,
+               [query_params: Query<Q>,]
+               [path_params: Path<P>,]
+               [body_param: TypedBody<J>,]
+               [body_param: UntypedBody,]
+               [body_param: StreamingBody,]
+               [raw_request: RawRequest,]
+           ) -> Result<HttpResponse*, HttpError>
+  --> tests/fail/bad_channel2.rs:8:1
+   |
+8  | / #[channel {
+9  | |     protocol = WEBSOCKETS,
+10 | |     path = "/test",
+11 | | }]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Expected a non-receiver argument
+  --> tests/fail/bad_channel2.rs:13:5
+   |
+13 |     self,
+   |     ^^^^
+
+error: `self` parameter is only allowed in associated functions
+  --> tests/fail/bad_channel2.rs:13:5
+   |
+13 |     self,
+   |     ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0401]: can't use generic parameters from outer item
+  --> tests/fail/bad_channel2.rs:13:5
+   |
+8  | #[channel {
+   | --------- `Self` type implicitly declared here, by this `impl`
+...
+13 |     self,
+   |     ^^^^
+   |     |
+   |     use of generic parameter from outer item
+   |     refer to the type directly here instead

--- a/dropshot/tests/fail/bad_channel3.rs
+++ b/dropshot/tests/fail/bad_channel3.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use std::sync::Arc;
+
+// Test: final parameter is not a WebsocketConnection
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _param: String,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel3.stderr
+++ b/dropshot/tests/fail/bad_channel3.stderr
@@ -1,0 +1,23 @@
+error[E0631]: type mismatch in closure arguments
+  --> tests/fail/bad_channel3.rs:10:1
+   |
+10 | / #[channel {
+11 | |     protocol = WEBSOCKETS,
+12 | |     path = "/test",
+13 | | }]
+   | |  ^
+   | |  |
+   | |__expected due to this
+   |    found signature defined here
+   |
+   = note: expected closure signature `fn(WebsocketConnection) -> _`
+              found closure signature `fn(String) -> _`
+note: required by a bound in `WebsocketUpgrade::handle`
+  --> src/websocket.rs
+   |
+   |     pub fn handle<C, F>(mut self, handler: C) -> WebsocketEndpointResult
+   |            ------ required by a bound in this associated function
+   |     where
+   |         C: FnOnce(WebsocketConnection) -> F + Send + 'static,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WebsocketUpgrade::handle`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/dropshot/tests/fail/bad_channel4.rs
+++ b/dropshot/tests/fail/bad_channel4.rs
@@ -1,0 +1,28 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+#[allow(dead_code)]
+struct QueryParams {
+    x: String,
+    y: u32,
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _params: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel4.stderr
+++ b/dropshot/tests/fail/bad_channel4.stderr
@@ -1,0 +1,140 @@
+error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
+  --> tests/fail/bad_channel4.rs:22:14
+   |
+22 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `schemars::JsonSchema`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                                                ^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel4.rs:22:14
+   |
+22 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
+  --> tests/fail/bad_channel4.rs:22:5
+   |
+22 |     _params: Query<QueryParams>,
+   |     ^^^^^^^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `schemars::JsonSchema`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                                                ^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel4.rs:22:5
+   |
+22 |     _params: Query<QueryParams>,
+   |     ^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `QueryParams: schemars::JsonSchema` is not satisfied
+  --> tests/fail/bad_channel4.rs:16:1
+   |
+16 | / #[channel {
+17 | |     protocol = WEBSOCKETS,
+18 | |     path = "/test",
+19 | | }]
+   | |__^ the trait `schemars::JsonSchema` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `schemars::JsonSchema`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                                                ^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel4.rs:16:1
+   |
+16 | / #[channel {
+17 | |     protocol = WEBSOCKETS,
+18 | |     path = "/test",
+19 | | }]
+   | |__^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`

--- a/dropshot/tests/fail/bad_channel5.rs
+++ b/dropshot/tests/fail/bad_channel5.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+
+#[derive(JsonSchema)]
+#[allow(dead_code)]
+struct QueryParams {
+    x: String,
+    y: u32,
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _params: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel5.stderr
+++ b/dropshot/tests/fail/bad_channel5.stderr
@@ -1,0 +1,71 @@
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel5.rs:24:14
+   |
+24 |     _params: Query<QueryParams>,
+   |              ^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel5.rs:24:5
+   |
+24 |     _params: Query<QueryParams>,
+   |     ^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`
+
+error[E0277]: the trait bound `for<'de> QueryParams: serde::de::Deserialize<'de>` is not satisfied
+  --> tests/fail/bad_channel5.rs:18:1
+   |
+18 | / #[channel {
+19 | |     protocol = WEBSOCKETS,
+20 | |     path = "/test",
+21 | | }]
+   | |__^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `QueryParams`
+   |
+   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+   = note: required for `QueryParams` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `dropshot::Query`
+  --> src/extractor/query.rs
+   |
+   | pub struct Query<QueryType: DeserializeOwned + JsonSchema + Send + Sync> {
+   |                             ^^^^^^^^^^^^^^^^ required by this bound in `Query`

--- a/dropshot/tests/fail/bad_channel6.rs
+++ b/dropshot/tests/fail/bad_channel6.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+#[derive(JsonSchema, Serialize)]
+#[allow(dead_code)]
+struct Ret {
+    x: String,
+    y: u32,
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    // Validate that compiler errors show up with useful context and aren't
+    // obscured by the macro.
+    let _ = Ret { "Oxide".to_string(), 0x1de };
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel6.stderr
+++ b/dropshot/tests/fail/bad_channel6.stderr
@@ -1,0 +1,21 @@
+error: expected identifier, found `"Oxide"`
+  --> tests/fail/bad_channel6.rs:28:19
+   |
+28 |     let _ = Ret { "Oxide".to_string(), 0x1de };
+   |             ---   ^^^^^^^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error: expected identifier, found `0x1de`
+  --> tests/fail/bad_channel6.rs:28:40
+   |
+28 |     let _ = Ret { "Oxide".to_string(), 0x1de };
+   |             ---                        ^^^^^ expected identifier
+   |             |
+   |             while parsing this struct
+
+error[E0063]: missing fields `x` and `y` in initializer of `Ret`
+  --> tests/fail/bad_channel6.rs:28:13
+   |
+28 |     let _ = Ret { "Oxide".to_string(), 0x1de };
+   |             ^^^ missing `x` and `y`

--- a/dropshot/tests/fail/bad_channel7.txt
+++ b/dropshot/tests/fail/bad_channel7.txt
@@ -1,0 +1,3 @@
+bad_endpoint7.rs ensures that if the return value isn't Serialize, the macro
+produces a reasonable error message. But websockets are a binary protocol and
+have no such requirement, so this test is moot.

--- a/dropshot/tests/fail/bad_channel8.rs
+++ b/dropshot/tests/fail/bad_channel8.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+fn bad_channel(
+    _rqctx: RequestContext<()>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel8.stderr
+++ b/dropshot/tests/fail/bad_channel8.stderr
@@ -1,0 +1,25 @@
+error: Endpoint handlers must have the following signature:
+           async fn(
+               rqctx: dropshot::RequestContext<MyContext>,
+               [query_params: Query<Q>,]
+               [path_params: Path<P>,]
+               [body_param: TypedBody<J>,]
+               [body_param: UntypedBody,]
+               [body_param: StreamingBody,]
+               [raw_request: RawRequest,]
+           ) -> Result<HttpResponse*, HttpError>
+  --> tests/fail/bad_channel8.rs:9:1
+   |
+9  | / #[channel {
+10 | |     protocol = WEBSOCKETS,
+11 | |     path = "/test",
+12 | | }]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: endpoint handler functions must be async
+  --> tests/fail/bad_channel8.rs:13:1
+   |
+13 | fn bad_channel(
+   | ^^

--- a/dropshot/tests/fail/bad_channel9.rs
+++ b/dropshot/tests/fail/bad_channel9.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+    y: u32,
+}
+
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn bad_channel(
+    _params: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel9.stderr
+++ b/dropshot/tests/fail/bad_channel9.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `dropshot::Query<QueryParams>: RequestContextArgument` is not satisfied
+  --> tests/fail/bad_channel9.rs:24:14
+   |
+24 |     _params: Query<QueryParams>,
+   |              ^^^^^ the trait `RequestContextArgument` is not implemented for `dropshot::Query<QueryParams>`
+   |
+   = help: the trait `RequestContextArgument` is implemented for `RequestContext<T>`
+
+error[E0277]: the trait bound `dropshot::Query<QueryParams>: RequestContextArgument` is not satisfied
+  --> tests/fail/bad_channel9.rs:19:1
+   |
+19 | / #[channel {
+20 | |     protocol = WEBSOCKETS,
+21 | |     path = "/test",
+22 | | }]
+   | |__^ the trait `RequestContextArgument` is not implemented for `dropshot::Query<QueryParams>`
+   |
+   = help: the trait `RequestContextArgument` is implemented for `RequestContext<T>`
+   = note: this error originates in the attribute macro `channel` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
I'm going to be touching a bunch of this code soon, and I realized we didn't
really have any fixtures to check that we were producing good error messages
for channels. So add some.

The current bad_channel tests provide a baseline -- we can definitely do better
for some of these tests. For now, we can ensure that we aren't regressing them.
