### PR TITLE
[ci] freshen up

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,5 +60,3 @@ jobs:
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
         run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose
-      - name: Run doctests
-        run: cargo test ${{ matrix.feature_flags }} --doc --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9b4c13b0bfa31b4514c14f74b5a166c2708f43c6
-      - uses: taiki-e/install-action@nextest
       - name: Report cargo version
         run: cargo --version
       - name: Report rustfmt version
@@ -49,7 +48,6 @@ jobs:
             feature_flags: --all-features
     steps:
       - uses: actions/checkout@9b4c13b0bfa31b4514c14f74b5a166c2708f43c6
-      - uses: taiki-e/install-action@nextest
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
@@ -61,6 +59,6 @@ jobs:
       - name: Build
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
-        run: cargo nextest run ${{ matrix.feature_flags }} --locked --all-targets --cargo-verbose
+        run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run doctests
         run: cargo test ${{ matrix.feature_flags }} --doc --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Build
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
-        run: cargo nextest run ${{ matrix.feature_flags }} --locked --all-targets
+        run: cargo nextest run ${{ matrix.feature_flags }} --locked --all-targets --cargo-verbose
       - name: Run doctests
-        run: cargo test ${{ matrix.feature_flags }} --doc --locked --all-targets --verbose
+        run: cargo test ${{ matrix.feature_flags }} --doc --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,15 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   check-style:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9b4c13b0bfa31b4514c14f74b5a166c2708f43c6
+      - uses: taiki-e/install-action@nextest
       - name: Report cargo version
         run: cargo --version
       - name: Report rustfmt version
@@ -29,28 +33,34 @@ jobs:
         run: cargo --version
       - name: Report Clippy version
         run: cargo clippy -- --version
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
       - name: Run Clippy Lints
-        # Clippy's style nits are useful, but not worth keeping in CI.  This
-        # override belongs in src/lib.rs, but that doesn't reliably work due to
-        # rust-lang/rust-clippy#6610.
-        run: cargo clippy --all-targets -- --deny warnings --allow clippy::style
+        run: cargo clippy --all-targets -- --deny warnings
 
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-12]
-        features: [ all, default ]
+        # macos-14 for M1 runners
+        os: [ubuntu-22.04, windows-2022, macos-14]
+        features: [all, default]
         include:
           - features: all
             feature_flags: --all-features
     steps:
       - uses: actions/checkout@9b4c13b0bfa31b4514c14f74b5a166c2708f43c6
+      - uses: taiki-e/install-action@nextest
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
         run: rustc --version
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+        with:
+          # Matrix instances other than OS need to be added to this explicitly
+          key: ${{ matrix.features }}
       - name: Build
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
-        run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose
+        run: cargo nextest run ${{ matrix.feature_flags }} --locked --all-targets
+      - name: Run doctests
+        run: cargo test ${{ matrix.feature_flags }} --doc --locked --all-targets --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ iter_skip_next = "warn"
 len_zero = "warn"
 redundant_field_names = "warn"
 # `declare_interior_mutable_const` is classified as a style lint, but it can
-# identify real bugs (e.g., declarying a `const Atomic` and using it like
+# identify real bugs (e.g., declaring a `const Atomic` and using it like
 # a `static Atomic`). However, it is also subject to false positives (e.g.,
 # idiomatically declaring a static array of atomics uses `const Atomic`). We
 # warn on this to catch the former, and expect any uses of the latter to allow

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,38 @@ members = ["dropshot", "dropshot_endpoint" ]
 default-members = ["dropshot", "dropshot_endpoint" ]
 
 resolver = "2"
+
+[workspace.lints.clippy]
+# Clippy's style nits are useful, but not worth keeping in CI.
+style = { level = "allow", priority = -1 }
+# But continue to warn on anything in the "disallowed_" namespace.
+disallowed_macros = "warn"
+disallowed_methods = "warn"
+disallowed_names = "warn"
+disallowed_script_idents = "warn"
+disallowed_types = "warn"
+# Warn on some more style lints that are relatively stable and make sense.
+iter_cloned_collect = "warn"
+iter_next_slice = "warn"
+iter_nth = "warn"
+iter_nth_zero = "warn"
+iter_skip_next = "warn"
+len_zero = "warn"
+redundant_field_names = "warn"
+# `declare_interior_mutable_const` is classified as a style lint, but it can
+# identify real bugs (e.g., declarying a `const Atomic` and using it like
+# a `static Atomic`). However, it is also subject to false positives (e.g.,
+# idiomatically declaring a static array of atomics uses `const Atomic`). We
+# warn on this to catch the former, and expect any uses of the latter to allow
+# this locally.
+#
+# Note: any const value with a type containing a `bytes::Bytes` hits this lint,
+# and you should `#![allow]` it for now. This is most likely to be seen with
+# `http::header::{HeaderName, HeaderValue}`. This is a Clippy bug which will be
+# fixed in the Rust 1.80 toolchain (rust-lang/rust-clippy#12691).
+declare_interior_mutable_const = "warn"
+# Also warn on casts, preferring explicit conversions instead.
+#
+# We'd like to warn on lossy casts in the future, but lossless casts are the
+# easiest ones to convert over.
+cast_lossless = "warn"

--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,8 @@ $ cargo +nightly doc
 
 == Contributing
 
-You can **build and run the whole test suite** with https://nexte.st/[nextest]:
-`cargo nextest run`.  The test suite runs cleanly and should remain clean.
+You can **build and run the whole test suite** with `cargo test`.  The test
+suite runs cleanly and should remain clean.
 
 You can format the code using `cargo fmt`.  CI checks that code is correctly formatted.
 

--- a/README.adoc
+++ b/README.adoc
@@ -17,12 +17,12 @@ $ cargo +nightly doc
 
 == Contributing
 
-You can **build and run the whole test suite** with `cargo test`.  The test
-suite runs cleanly and should remain clean.
+You can **build and run the whole test suite** with https://nexte.st/[nextest]:
+`cargo nextest run`.  The test suite runs cleanly and should remain clean.
 
 You can format the code using `cargo fmt`.  CI checks that code is correctly formatted.
 
-https://github.com/rust-lang/rust-clippy[Clippy] is used to check for common code issues.  (We disable the style checks.)  You can run it with `cargo clippy --all-targets -- --deny warnings --allow clippy::style`.  CI will run clippy as well.
+https://github.com/rust-lang/rust-clippy[Clippy] is used to check for common code issues.  (We disable most style checks; see the `[workspace.lints.clippy]` section in `Cargo.toml` for the full configuration.)  You can run it with `cargo clippy --all-targets -- --deny warnings`.  CI will run clippy as well.
 
 For maintainers (e.g., publishing new releases and managing dependabot), see link:./MAINTAINERS.adoc[MAINTAINERS.adoc].
 

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README-crates.io.md"
 keywords = ["rest", "openapi", "async"]
 categories = ["network-programming", "web-programming::http-server"]
 
+[lints]
+workspace = true
+
 [dependencies]
 async-stream = "0.3.5"
 async-trait = "0.1.80"

--- a/dropshot/examples/schema-with-example.rs
+++ b/dropshot/examples/schema-with-example.rs
@@ -67,6 +67,6 @@ fn main() -> Result<(), String> {
 async fn get_foo(
     _rqctx: RequestContext<()>,
 ) -> Result<HttpResponseOk<Foo>, HttpError> {
-    let foo = foo_example();
-    Ok(HttpResponseOk(foo))
+    let ret = foo_example();
+    Ok(HttpResponseOk(ret))
 }

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -619,7 +619,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         ApiEndpointParameterLocation::Query => {
                             Some(openapiv3::ReferenceOr::Item(
                                 openapiv3::Parameter::Query {
-                                    parameter_data: parameter_data,
+                                    parameter_data,
                                     allow_reserved: false,
                                     style: openapiv3::QueryStyle::Form,
                                     allow_empty_value: None,
@@ -629,7 +629,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         ApiEndpointParameterLocation::Path => {
                             Some(openapiv3::ReferenceOr::Item(
                                 openapiv3::Parameter::Path {
-                                    parameter_data: parameter_data,
+                                    parameter_data,
                                     style: openapiv3::PathStyle::Simple,
                                 },
                             ))
@@ -670,7 +670,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
                     );
 
                     Some(openapiv3::ReferenceOr::Item(openapiv3::RequestBody {
-                        content: content,
+                        content,
                         required: true,
                         ..Default::default()
                     }))
@@ -848,7 +848,7 @@ impl<Context: ServerContext> ApiDescription<Context> {
             "Error".to_string(),
             openapiv3::ReferenceOr::Item(openapiv3::Response {
                 description: "Error".to_string(),
-                content: content,
+                content,
                 ..Default::default()
             }),
         );

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -570,9 +570,6 @@
 //! {"ok":{"id":"a53696af-543d-452f-81b6-5a045dd9921d","local_addr":"127.0.0.1:61028","remote_addr":"127.0.0.1:57376","status_code":204,"message":""}}
 //! ```
 
-// Clippy's style advice is definitely valuable, but not worth the trouble for
-// automated enforcement.
-#![allow(clippy::style)]
 // The `usdt` crate may require nightly, enabled if our consumer is enabling
 // DTrace probes.
 #![cfg_attr(all(feature = "usdt-probes", usdt_need_asm), feature(asm))]

--- a/dropshot/tests/test_pagination.rs
+++ b/dropshot/tests/test_pagination.rs
@@ -217,7 +217,7 @@ async fn test_paginate_errors() {
                       string",
         },
         ErrorTestCase {
-            path: format!("/intapi?limit={}", (std::u64::MAX as u128) + 1),
+            path: format!("/intapi?limit={}", u128::from(std::u64::MAX) + 1),
             message: "unable to parse query string: number too large to fit \
                       in target type",
         },
@@ -317,7 +317,7 @@ async fn test_paginate_basic() {
     loop {
         if let Some(ref next_token) = page.next_page {
             if page.items.len() != expected_max as usize {
-                assert!(page.items.len() > 0);
+                assert!(!page.items.is_empty());
                 assert!(page.items.len() < expected_max as usize);
                 assert_eq!(*page.items.last().unwrap(), std::u16::MAX - 1);
             }

--- a/dropshot_endpoint/Cargo.toml
+++ b/dropshot_endpoint/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/oxidecomputer/dropshot/"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2 = "1"
 quote = "1"

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -4,10 +4,6 @@
 //! attributes are used both to define an HTTP API and to generate an OpenAPI
 //! Spec (OAS) v3 document that describes the API.
 
-// Clippy's style advice is definitely valuable, but not worth the trouble for
-// automated enforcement.
-#![allow(clippy::style)]
-
 use quote::quote;
 use serde_tokenstream::Error;
 


### PR DESCRIPTION
* Use ubuntu-22.04, and macos-14 for M1 runners.
* Move clippy configuration to Cargo's config rather than lib.rs or CI.
* Copy over omicron's clippy config.
* Set `CARGO_TERM_COLOR=always` for easier to read GHA output.
* Cache artifacts for quicker builds.
* Update README.

Overall, it's a nice speedup. There's still more potential for improvement via things like hakari which are more invasive.

* On Ubuntu, compared to [this baseline](https://github.com/oxidecomputer/dropshot/actions/runs/9229117299/job/25394620676) which took 4m3s, [this build](https://github.com/oxidecomputer/dropshot/actions/runs/9229402240/job/25395542313?pr=1022) reused the cache and took 2m43s, around 1.5x as fast.
* On macOS, compared to [this baseline](https://github.com/oxidecomputer/dropshot/actions/runs/9229117299/job/25394621599) which took 6m15s, [this build](https://github.com/oxidecomputer/dropshot/actions/runs/9229402240/job/25395543919?pr=1022) reused the cache and took just 2m5s. This is 3x as fast.