### PR TITLE
[dropshot_endpoint] unify error message style

### DIFF
--- a/dropshot/tests/fail/bad_channel13.stderr
+++ b/dropshot/tests/fail/bad_channel13.stderr
@@ -13,7 +13,7 @@ error: channel handlers must have the following signature:
 20 | | ) -> dropshot::WebsocketChannelResult {
    | |_____________________________________^
 
-error: generics are not permitted for endpoint handlers
+error: endpoint `bad_channel` must not have generics
   --> tests/fail/bad_channel13.rs:17:21
    |
 17 | async fn bad_channel<S: Stuff + Sync + Send + 'static>(

--- a/dropshot/tests/fail/bad_channel14.stderr
+++ b/dropshot/tests/fail/bad_channel14.stderr
@@ -1,4 +1,4 @@
-error: paths that contain a wildcard match must include 'unpublished = true'
+error: endpoint `must_be_unpublished` has paths that contain a wildcard match, but is not marked 'unpublished = true'
   --> tests/fail/bad_channel14.rs:21:5
    |
 21 | /     protocol = WEBSOCKETS,

--- a/dropshot/tests/fail/bad_channel1a.stderr
+++ b/dropshot/tests/fail/bad_channel1a.stderr
@@ -10,7 +10,7 @@ error: channel handlers must have the following signature:
 11 | async fn bad_channel() -> dropshot::WebsocketChannelResult {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: An argument of type dropshot::WebsocketConnection must be provided last.
+error: endpoint `bad_channel` must have a WebsocketConnection as its last argument
   --> tests/fail/bad_channel1a.rs:11:1
    |
 11 | async fn bad_channel() -> dropshot::WebsocketChannelResult {

--- a/dropshot/tests/fail/bad_channel2.stderr
+++ b/dropshot/tests/fail/bad_channel2.stderr
@@ -13,7 +13,7 @@ error: channel handlers must have the following signature:
 15 | | ) -> dropshot::WebsocketChannelResult {
    | |_____________________________________^
 
-error: Expected a non-receiver argument
+error: endpoint `bad_channel` must not have a `self` argument
   --> tests/fail/bad_channel2.rs:13:5
    |
 13 |     self,

--- a/dropshot/tests/fail/bad_channel21.rs
+++ b/dropshot/tests/fail/bad_channel21.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: last parameter is variadic.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async fn variadic_argument(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+    ...
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel21.stderr
+++ b/dropshot/tests/fail/bad_channel21.stderr
@@ -5,16 +5,17 @@ error: channel handlers must have the following signature:
                [path_params: Path<P>,]
                websocket_connection: dropshot::WebsocketConnection,
            ) -> dropshot::WebsocketChannelResult
-  --> tests/fail/bad_channel8.rs:13:1
+  --> tests/fail/bad_channel21.rs:23:1
    |
-13 | / fn bad_channel(
-14 | |     _rqctx: RequestContext<()>,
-15 | |     _upgraded: WebsocketConnection,
-16 | | ) -> dropshot::WebsocketChannelResult {
+23 | / async fn variadic_argument(
+24 | |     _rqctx: RequestContext<()>,
+25 | |     _param1: Query<QueryParams>,
+26 | |     ...
+27 | | ) -> dropshot::WebsocketChannelResult {
    | |_____________________________________^
 
-error: endpoint `bad_channel` must be async
-  --> tests/fail/bad_channel8.rs:13:1
+error: endpoint `variadic_argument` must not have a variadic argument
+  --> tests/fail/bad_channel21.rs:26:5
    |
-13 | fn bad_channel(
-   | ^^
+26 |     ...
+   |     ^^^

--- a/dropshot/tests/fail/bad_channel22.rs
+++ b/dropshot/tests/fail/bad_channel22.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: unsafe fn.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async unsafe fn unsafe_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel22.stderr
+++ b/dropshot/tests/fail/bad_channel22.stderr
@@ -1,0 +1,21 @@
+error: channel handlers must have the following signature:
+           async fn(
+               rqctx: dropshot::RequestContext<MyContext>,
+               [query_params: Query<Q>,]
+               [path_params: Path<P>,]
+               websocket_connection: dropshot::WebsocketConnection,
+           ) -> dropshot::WebsocketChannelResult
+  --> tests/fail/bad_channel22.rs:23:1
+   |
+23 | / async unsafe fn unsafe_endpoint(
+24 | |     _rqctx: RequestContext<()>,
+25 | |     _param1: Query<QueryParams>,
+26 | |     _upgraded: WebsocketConnection,
+27 | | ) -> dropshot::WebsocketChannelResult {
+   | |_____________________________________^
+
+error: endpoint `unsafe_endpoint` must not be unsafe
+  --> tests/fail/bad_channel22.rs:23:7
+   |
+23 | async unsafe fn unsafe_endpoint(
+   |       ^^^^^^

--- a/dropshot/tests/fail/bad_channel23.rs
+++ b/dropshot/tests/fail/bad_channel23.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: const fn.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+const async fn const_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel23.stderr
+++ b/dropshot/tests/fail/bad_channel23.stderr
@@ -5,16 +5,17 @@ error: channel handlers must have the following signature:
                [path_params: Path<P>,]
                websocket_connection: dropshot::WebsocketConnection,
            ) -> dropshot::WebsocketChannelResult
-  --> tests/fail/bad_channel8.rs:13:1
+  --> tests/fail/bad_channel23.rs:23:1
    |
-13 | / fn bad_channel(
-14 | |     _rqctx: RequestContext<()>,
-15 | |     _upgraded: WebsocketConnection,
-16 | | ) -> dropshot::WebsocketChannelResult {
+23 | / const async fn const_endpoint(
+24 | |     _rqctx: RequestContext<()>,
+25 | |     _param1: Query<QueryParams>,
+26 | |     _upgraded: WebsocketConnection,
+27 | | ) -> dropshot::WebsocketChannelResult {
    | |_____________________________________^
 
-error: endpoint `bad_channel` must be async
-  --> tests/fail/bad_channel8.rs:13:1
+error: endpoint `const_endpoint` must not be a const fn
+  --> tests/fail/bad_channel23.rs:23:1
    |
-13 | fn bad_channel(
-   | ^^
+23 | const async fn const_endpoint(
+   | ^^^^^

--- a/dropshot/tests/fail/bad_channel24.rs
+++ b/dropshot/tests/fail/bad_channel24.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::channel;
+use dropshot::Query;
+use dropshot::RequestContext;
+use dropshot::WebsocketConnection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: ABI in endpoint.
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/test",
+}]
+async extern "ABI" fn abi_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+    _upgraded: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_channel24.stderr
+++ b/dropshot/tests/fail/bad_channel24.stderr
@@ -1,0 +1,21 @@
+error: channel handlers must have the following signature:
+           async fn(
+               rqctx: dropshot::RequestContext<MyContext>,
+               [query_params: Query<Q>,]
+               [path_params: Path<P>,]
+               websocket_connection: dropshot::WebsocketConnection,
+           ) -> dropshot::WebsocketChannelResult
+  --> tests/fail/bad_channel24.rs:23:1
+   |
+23 | / async extern "ABI" fn abi_endpoint(
+24 | |     _rqctx: RequestContext<()>,
+25 | |     _param1: Query<QueryParams>,
+26 | |     _upgraded: WebsocketConnection,
+27 | | ) -> dropshot::WebsocketChannelResult {
+   | |_____________________________________^
+
+error: endpoint `abi_endpoint` must not use an alternate ABI
+  --> tests/fail/bad_channel24.rs:23:7
+   |
+23 | async extern "ABI" fn abi_endpoint(
+   |       ^^^^^^^^^^^^

--- a/dropshot/tests/fail/bad_endpoint1.stderr
+++ b/dropshot/tests/fail/bad_endpoint1.stderr
@@ -1,4 +1,4 @@
-error: Endpoint handlers must have the following signature:
+error: endpoint handlers must have the following signature:
            async fn(
                rqctx: dropshot::RequestContext<MyContext>,
                [query_params: Query<Q>,]
@@ -13,7 +13,7 @@ error: Endpoint handlers must have the following signature:
 13 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Endpoint requires arguments
+error: endpoint `bad_endpoint` must have at least one RequestContext argument
   --> tests/fail/bad_endpoint1.rs:13:22
    |
 13 | async fn bad_endpoint() -> Result<HttpResponseOk<()>, HttpError> {

--- a/dropshot/tests/fail/bad_endpoint11.stderr
+++ b/dropshot/tests/fail/bad_endpoint11.stderr
@@ -1,4 +1,4 @@
-error: Endpoint handlers must have the following signature:
+error: endpoint handlers must have the following signature:
            async fn(
                rqctx: dropshot::RequestContext<MyContext>,
                [query_params: Query<Q>,]
@@ -13,7 +13,7 @@ error: Endpoint handlers must have the following signature:
 12 | async fn bad_no_result(_: RequestContext<()>) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Endpoint must return a Result
+error: endpoint `bad_no_result` must return a Result
   --> tests/fail/bad_endpoint11.rs:12:1
    |
 12 | async fn bad_no_result(_: RequestContext<()>) {}

--- a/dropshot/tests/fail/bad_endpoint13.stderr
+++ b/dropshot/tests/fail/bad_endpoint13.stderr
@@ -1,4 +1,4 @@
-error: Endpoint handlers must have the following signature:
+error: endpoint handlers must have the following signature:
            async fn(
                rqctx: dropshot::RequestContext<MyContext>,
                [query_params: Query<Q>,]
@@ -15,7 +15,7 @@ error: Endpoint handlers must have the following signature:
 20 | | ) -> Result<HttpResponseOk<String>, HttpError> {
    | |______________________________________________^
 
-error: generics are not permitted for endpoint handlers
+error: endpoint `bad_response_type` must not have generics
   --> tests/fail/bad_endpoint13.rs:18:27
    |
 18 | async fn bad_response_type<S: Stuff + Sync + Send + 'static>(

--- a/dropshot/tests/fail/bad_endpoint14.stderr
+++ b/dropshot/tests/fail/bad_endpoint14.stderr
@@ -1,4 +1,4 @@
-error: paths that contain a wildcard match must include 'unpublished = true'
+error: endpoint `must_be_unpublished` has paths that contain a wildcard match, but is not marked 'unpublished = true'
   --> tests/fail/bad_endpoint14.rs:20:5
    |
 20 | /     method = GET,

--- a/dropshot/tests/fail/bad_endpoint16.stderr
+++ b/dropshot/tests/fail/bad_endpoint16.stderr
@@ -1,4 +1,5 @@
-error: invalid content type for endpoint
+error: endpoint `bad_endpoint` has an invalid content type
+       note: supported content types are: application/json, application/x-www-form-urlencoded, multipart/form-data
   --> tests/fail/bad_endpoint16.rs:12:5
    |
 12 | /     method = GET,

--- a/dropshot/tests/fail/bad_endpoint21.rs
+++ b/dropshot/tests/fail/bad_endpoint21.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: last parameter is variadic.
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async fn variadic_argument(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+    ...
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint21.stderr
+++ b/dropshot/tests/fail/bad_endpoint21.stderr
@@ -8,13 +8,17 @@ error: endpoint handlers must have the following signature:
                [body_param: StreamingBody,]
                [raw_request: RawRequest,]
            ) -> Result<HttpResponse*, HttpError>
-  --> tests/fail/bad_endpoint2.rs:13:1
+  --> tests/fail/bad_endpoint21.rs:24:1
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 | / async fn variadic_argument(
+25 | |     _rqctx: RequestContext<()>,
+26 | |     _param1: Query<QueryParams>,
+27 | |     ...
+28 | | ) -> Result<HttpResponseOk<()>, HttpError> {
+   | |__________________________________________^
 
-error: endpoint `bad_endpoint` must not have a `self` argument
-  --> tests/fail/bad_endpoint2.rs:13:23
+error: endpoint `variadic_argument` must not have a variadic argument
+  --> tests/fail/bad_endpoint21.rs:27:5
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   |                       ^^^^
+27 |     ...
+   |     ^^^

--- a/dropshot/tests/fail/bad_endpoint22.rs
+++ b/dropshot/tests/fail/bad_endpoint22.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: unsafe fn.
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async unsafe fn unsafe_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint22.stderr
+++ b/dropshot/tests/fail/bad_endpoint22.stderr
@@ -8,13 +8,16 @@ error: endpoint handlers must have the following signature:
                [body_param: StreamingBody,]
                [raw_request: RawRequest,]
            ) -> Result<HttpResponse*, HttpError>
-  --> tests/fail/bad_endpoint2.rs:13:1
+  --> tests/fail/bad_endpoint22.rs:24:1
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 | / async unsafe fn unsafe_endpoint(
+25 | |     _rqctx: RequestContext<()>,
+26 | |     _param1: Query<QueryParams>,
+27 | | ) -> Result<HttpResponseOk<()>, HttpError> {
+   | |__________________________________________^
 
-error: endpoint `bad_endpoint` must not have a `self` argument
-  --> tests/fail/bad_endpoint2.rs:13:23
+error: endpoint `unsafe_endpoint` must not be unsafe
+  --> tests/fail/bad_endpoint22.rs:24:7
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   |                       ^^^^
+24 | async unsafe fn unsafe_endpoint(
+   |       ^^^^^^

--- a/dropshot/tests/fail/bad_endpoint23.rs
+++ b/dropshot/tests/fail/bad_endpoint23.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: const fn.
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+const async fn const_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint23.stderr
+++ b/dropshot/tests/fail/bad_endpoint23.stderr
@@ -8,13 +8,16 @@ error: endpoint handlers must have the following signature:
                [body_param: StreamingBody,]
                [raw_request: RawRequest,]
            ) -> Result<HttpResponse*, HttpError>
-  --> tests/fail/bad_endpoint2.rs:13:1
+  --> tests/fail/bad_endpoint23.rs:24:1
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 | / const async fn const_endpoint(
+25 | |     _rqctx: RequestContext<()>,
+26 | |     _param1: Query<QueryParams>,
+27 | | ) -> Result<HttpResponseOk<()>, HttpError> {
+   | |__________________________________________^
 
-error: endpoint `bad_endpoint` must not have a `self` argument
-  --> tests/fail/bad_endpoint2.rs:13:23
+error: endpoint `const_endpoint` must not be a const fn
+  --> tests/fail/bad_endpoint23.rs:24:1
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   |                       ^^^^
+24 | const async fn const_endpoint(
+   | ^^^^^

--- a/dropshot/tests/fail/bad_endpoint24.rs
+++ b/dropshot/tests/fail/bad_endpoint24.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Oxide Computer Company
+
+#![allow(unused_imports)]
+
+use dropshot::endpoint;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Query;
+use dropshot::RequestContext;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Deserialize, JsonSchema)]
+struct QueryParams {
+    x: String,
+}
+
+// Test: ABI in fn.
+#[endpoint {
+    method = GET,
+    path = "/test",
+}]
+async extern "ABI" fn abi_endpoint(
+    _rqctx: RequestContext<()>,
+    _param1: Query<QueryParams>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    Ok(HttpResponseOk(()))
+}
+
+fn main() {}

--- a/dropshot/tests/fail/bad_endpoint24.stderr
+++ b/dropshot/tests/fail/bad_endpoint24.stderr
@@ -8,13 +8,16 @@ error: endpoint handlers must have the following signature:
                [body_param: StreamingBody,]
                [raw_request: RawRequest,]
            ) -> Result<HttpResponse*, HttpError>
-  --> tests/fail/bad_endpoint2.rs:13:1
+  --> tests/fail/bad_endpoint24.rs:24:1
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 | / async extern "ABI" fn abi_endpoint(
+25 | |     _rqctx: RequestContext<()>,
+26 | |     _param1: Query<QueryParams>,
+27 | | ) -> Result<HttpResponseOk<()>, HttpError> {
+   | |__________________________________________^
 
-error: endpoint `bad_endpoint` must not have a `self` argument
-  --> tests/fail/bad_endpoint2.rs:13:23
+error: endpoint `abi_endpoint` must not use an alternate ABI
+  --> tests/fail/bad_endpoint24.rs:24:7
    |
-13 | async fn bad_endpoint(self) -> Result<HttpResponseOk<()>, HttpError> {
-   |                       ^^^^
+24 | async extern "ABI" fn abi_endpoint(
+   |       ^^^^^^^^^^^^

--- a/dropshot/tests/fail/bad_endpoint8.stderr
+++ b/dropshot/tests/fail/bad_endpoint8.stderr
@@ -1,4 +1,4 @@
-error: Endpoint handlers must have the following signature:
+error: endpoint handlers must have the following signature:
            async fn(
                rqctx: dropshot::RequestContext<MyContext>,
                [query_params: Query<Q>,]
@@ -15,7 +15,7 @@ error: Endpoint handlers must have the following signature:
 21 | | ) -> Result<HttpResponseOk<Ret>, HttpError> {
    | |___________________________________________^
 
-error: endpoint handler functions must be async
+error: endpoint `bad_endpoint` must be async
   --> tests/fail/bad_endpoint8.rs:19:1
    |
 19 | fn bad_endpoint(

--- a/dropshot_endpoint/src/channel.rs
+++ b/dropshot_endpoint/src/channel.rs
@@ -134,6 +134,7 @@ impl ParsedChannel {
                 // an extractor, with WebsocketUpgrade, which is.
                 let ItemFnForSignature { attrs, vis, mut sig, _block: body } =
                     item;
+                let name_str = sig.ident.to_string();
 
                 let inner_args = sig.inputs.clone();
                 let inner_output = sig.output.clone();
@@ -177,9 +178,12 @@ impl ParsedChannel {
                     Some(f) => f,
                     None => {
                         errors.push(Error::new_spanned(
-                    &sig,
-                    "An argument of type dropshot::WebsocketConnection must be provided last.",
-                ));
+                            &sig,
+                            format!(
+                                "endpoint `{name_str}` must have a \
+                                 WebsocketConnection as its last argument",
+                            ),
+                        ));
                         return None;
                     }
                 };

--- a/dropshot_endpoint/src/util.rs
+++ b/dropshot_endpoint/src/util.rs
@@ -25,6 +25,15 @@ impl ValidContentType {
             ValidContentType::MultipartFormData => MULTIPART_FORM_DATA,
         }
     }
+
+    pub(crate) fn to_supported_string() -> String {
+        format!(
+            "{}, {}, {}",
+            APPLICATION_JSON,
+            APPLICATION_X_WWW_FORM_URLENCODED,
+            MULTIPART_FORM_DATA,
+        )
+    }
 }
 
 impl FromStr for ValidContentType {


### PR DESCRIPTION
Always use messages of the form "endpoint `{name_str}` ...", without a period
at the end. The casing and lack of period at the end matches rustc's style.

One difference from that style is that we now include the name of the endpoint
in error messages. That's particularly important for trait-based Dropshot
servers, where in some cases we might end up losing span info and producing
messages that don't include which endpoint they're talking about. Include the
name of the endpoint unconditionally for a unified style, and so that we don't
have to have unnecessary conditionals. (I personally found having the endpoint
name to be friendlier anyway.)
