### PR TITLE
optionally include additional header values in request log

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -36,7 +36,7 @@ serde_path_to_error = "0.1.16"
 serde_urlencoded = "0.7.1"
 sha1 = "0.10.6"
 simple-mermaid = { version = "0.1.1", optional = true }
-slog = "2.5.0"
+slog = { version = "2.5.0", features = ["dynamic-keys"] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
 slog-json = "2.6.1"

--- a/dropshot/src/config.rs
+++ b/dropshot/src/config.rs
@@ -52,6 +52,14 @@ pub struct ConfigDropshot {
     /// Default behavior for HTTP handler functions with respect to clients
     /// disconnecting early.
     pub default_handler_task_mode: HandlerTaskMode,
+    /// A list of header names to include as extra properties in the log
+    /// messages emitted by the per-request logger.  Each header will, if
+    /// present, be included in the output with a "hdr_"-prefixed property name
+    /// in lower case that has all hyphens replaced with underscores; e.g.,
+    /// "X-Forwarded-For" will be included as "hdr_x_forwarded_for".  No attempt
+    /// is made to deal with headers that appear multiple times in a single
+    /// request.
+    pub log_headers: Vec<String>,
 }
 
 /// Enum specifying options for how a Dropshot server should run its handler
@@ -107,6 +115,7 @@ impl Default for ConfigDropshot {
             bind_address: "127.0.0.1:0".parse().unwrap(),
             request_body_max_bytes: 1024,
             default_handler_task_mode: HandlerTaskMode::Detached,
+            log_headers: Default::default(),
         }
     }
 }

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -73,6 +73,7 @@
 //!                 bind_address: "127.0.0.1:0".parse().unwrap(),
 //!                 request_body_max_bytes: 1024,
 //!                 default_handler_task_mode: HandlerTaskMode::Detached,
+//!                 log_headers: Default::default(),
 //!             },
 //!             api,
 //!             Arc::new(()),

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -97,6 +97,14 @@ pub struct ServerConfig {
     /// Default behavior for HTTP handler functions with respect to clients
     /// disconnecting early.
     pub default_handler_task_mode: HandlerTaskMode,
+    /// A list of header names to include as extra properties in the log
+    /// messages emitted by the per-request logger.  Each header will, if
+    /// present, be included in the output with a "hdr_"-prefixed property name
+    /// in lower case that has all hyphens replaced with underscores; e.g.,
+    /// "X-Forwarded-For" will be included as "hdr_x_forwarded_for".  No attempt
+    /// is made to deal with headers that appear multiple times in a single
+    /// request.
+    pub log_headers: Vec<String>,
 }
 
 pub struct HttpServerStarter<C: ServerContext> {
@@ -129,6 +137,7 @@ impl<C: ServerContext> HttpServerStarter<C> {
             page_max_nitems: NonZeroU32::new(10000).unwrap(),
             page_default_nitems: NonZeroU32::new(100).unwrap(),
             default_handler_task_mode: config.default_handler_task_mode,
+            log_headers: config.log_headers.clone(),
         };
 
         let handler_waitgroup = WaitGroup::new();
@@ -782,12 +791,39 @@ async fn http_request_handle_wrap<C: ServerContext>(
     // themselves.
     let start_time = std::time::Instant::now();
     let request_id = generate_request_id();
-    let request_log = server.log.new(o!(
+
+    let mut request_log = server.log.new(o!(
         "remote_addr" => remote_addr,
         "req_id" => request_id.clone(),
         "method" => request.method().as_str().to_string(),
         "uri" => format!("{}", request.uri()),
     ));
+    // If we have been asked to include any headers from the request in the
+    // log messages, do so here:
+    for name in server.config.log_headers.iter() {
+        let v = request
+            .headers()
+            .get(name)
+            .and_then(|v| v.to_str().ok().map(str::to_string));
+
+        if let Some(v) = v {
+            // This is unfortunate in at least two ways: first, we would like to
+            // just construct _one_ key value map, but OwnedKV is opaque and can
+            // only be constructed with the o!() macro, so the only way to layer
+            // on a dynamic set of additional properties is by creating a chain
+            // of child loggers to add each one; second, we would like to be
+            // able to include all header values under a single map-valued
+            // "header" property, but slog only allows us a single-level
+            // property hierarchy.  Alas!
+            //
+            // We also replace the hyphens with underscores to make it easier to
+            // refer to the generated properties in dynamic languages used for
+            // filtering like rhai.
+            let k = format!("hdr_{}", name.to_lowercase().replace('-', "_"));
+            request_log = request_log.new(o!(k => v));
+        }
+    }
+
     trace!(request_log, "incoming request");
     #[cfg(feature = "usdt-probes")]
     probes::request__start!(|| {

--- a/dropshot/src/websocket.rs
+++ b/dropshot/src/websocket.rs
@@ -330,6 +330,7 @@ mod tests {
                     page_default_nitems: NonZeroU32::new(1).unwrap(),
                     default_handler_task_mode:
                         HandlerTaskMode::CancelOnDisconnect,
+                    log_headers: Default::default(),
                 },
                 router: HttpRouter::new(),
                 log: log.clone(),

--- a/dropshot/tests/test_config.rs
+++ b/dropshot/tests/test_config.rs
@@ -111,6 +111,7 @@ fn make_config(
         ),
         request_body_max_bytes: 1024,
         default_handler_task_mode,
+        log_headers: Default::default(),
     }
 }
 

--- a/dropshot/tests/test_tls.rs
+++ b/dropshot/tests/test_tls.rs
@@ -114,6 +114,7 @@ fn make_server(
         bind_address: "127.0.0.1:0".parse().unwrap(),
         request_body_max_bytes: 1024,
         default_handler_task_mode: HandlerTaskMode::CancelOnDisconnect,
+        log_headers: Default::default(),
     };
     let config_tls = Some(ConfigTls::AsFile {
         cert_file: cert_file.to_path_buf(),
@@ -426,6 +427,7 @@ async fn test_server_is_https() {
         bind_address: "127.0.0.1:0".parse().unwrap(),
         request_body_max_bytes: 1024,
         default_handler_task_mode: HandlerTaskMode::CancelOnDisconnect,
+        log_headers: Default::default(),
     };
     let config_tls = Some(ConfigTls::AsFile {
         cert_file: cert_file.path().to_path_buf(),


### PR DESCRIPTION
I would like to be able to log additional headers in some applications, like **X-Forwarded-For**, which is potentially critical for programs that sit behind a reverse proxy.  This change allows the consumer to list additional headers for inclusion in request log records.