### PR TITLE
Preserve blank lines in endpoint descriptions

### DIFF
--- a/dropshot_endpoint/src/doc.rs
+++ b/dropshot_endpoint/src/doc.rs
@@ -53,7 +53,8 @@ impl ExtractedDoc {
                         // Continuation lines and newlines.
                         format!("{}{}", acc, comment)
                     } else if comment.is_empty() {
-                        // Handle fully blank comments as newlines we keep.
+                        // Blank lines get a markdown paragraph break (unless
+                        // acc already ends in '\n' -- see above)
                         format!("{}\n\n", acc)
                     } else {
                         // Default to space-separating comment fragments.

--- a/dropshot_endpoint/src/doc.rs
+++ b/dropshot_endpoint/src/doc.rs
@@ -54,7 +54,7 @@ impl ExtractedDoc {
                         format!("{}{}", acc, comment)
                     } else if comment.is_empty() {
                         // Handle fully blank comments as newlines we keep.
-                        format!("{}\n", acc)
+                        format!("{}\n\n", acc)
                     } else {
                         // Default to space-separating comment fragments.
                         format!("{} {}", acc, comment)
@@ -227,13 +227,21 @@ mod tests {
         ///
         /// Even
         /// More
+        ///
+        ///
+        ///
+        /// And another
+        /// paragraph
         #[derive(Schema)]
         struct SummaryDescriptionBreak;
         assert_eq!(
             ExtractedDoc::from_attrs(&SummaryDescriptionBreak::schema().attrs),
             ExtractedDoc {
                 summary: Some("Summary".to_string()),
-                description: Some("Text More\nEven More".to_string())
+                description: Some(
+                    "Text More\n\nEven More\n\nAnd another paragraph"
+                        .to_string()
+                )
             },
         );
     }


### PR DESCRIPTION
Currently we turn blank lines in a doc comment into a single `\n`. When we then try to treat that text as markdown (e.g., on the docs site), markdown ignores single blank lines. This is the difference between this

![image](https://github.com/user-attachments/assets/52b2882a-d759-44c2-b3ac-2d493d4cb136)

and this

![image](https://github.com/user-attachments/assets/5d8c253f-3ece-446a-97bf-4d90084ae79e)

So here we keep those blank lines as a double `\n\n`.