### PR TITLE
[dropshot-endpoint] with API traits, add _mod to default module name

### DIFF
--- a/dropshot/examples/api-trait-alternate.rs
+++ b/dropshot/examples/api-trait-alternate.rs
@@ -149,7 +149,7 @@ mod api {
     // If the interface and implementation (see below) are in different crates, then
     // this function would live in the interface crate.
     pub(crate) fn generate_openapi_spec() -> String {
-        let api = counter_api::stub_api_description().unwrap();
+        let api = counter_api_mod::stub_api_description().unwrap();
         let spec = api.openapi("Counter Server", "1.0.0");
         serde_json::to_string_pretty(&spec.json().unwrap()).unwrap()
     }
@@ -217,7 +217,7 @@ async fn main() -> Result<(), String> {
     println!("{}", api::generate_openapi_spec());
 
     let my_api =
-        api::counter_api::api_description::<imp::CounterImpl>().unwrap();
+        api::counter_api_mod::api_description::<imp::CounterImpl>().unwrap();
     let server = HttpServerStarter::new(
         &config_dropshot,
         my_api,

--- a/dropshot/examples/api-trait-websocket.rs
+++ b/dropshot/examples/api-trait-websocket.rs
@@ -49,7 +49,7 @@ mod api {
     // If the interface and implementation (see below) are in different crates, then
     // this function would live in the interface crate.
     pub(crate) fn generate_openapi_spec() -> String {
-        let my_server = counter_api::stub_api_description().unwrap();
+        let my_server = counter_api_mod::stub_api_description().unwrap();
         let spec = my_server.openapi("Counter Server", "1.0.0");
         serde_json::to_string_pretty(&spec.json().unwrap()).unwrap()
     }
@@ -147,7 +147,7 @@ async fn main() -> Result<(), String> {
     println!("{}", api::generate_openapi_spec());
 
     let my_server =
-        api::counter_api::api_description::<imp::CounterImpl>().unwrap();
+        api::counter_api_mod::api_description::<imp::CounterImpl>().unwrap();
     let server = HttpServerStarter::new(
         &config_dropshot,
         my_server,

--- a/dropshot/examples/api-trait.rs
+++ b/dropshot/examples/api-trait.rs
@@ -60,7 +60,7 @@ mod api {
     // If the interface and implementation (see below) are in different crates, then
     // this function would live in the interface crate.
     pub(crate) fn generate_openapi_spec() -> String {
-        let description = counter_api::stub_api_description().unwrap();
+        let description = counter_api_mod::stub_api_description().unwrap();
         let spec = description.openapi("Counter Server", "1.0.0");
         serde_json::to_string_pretty(&spec.json().unwrap()).unwrap()
     }
@@ -150,7 +150,7 @@ async fn main() -> Result<(), String> {
     // The api_description function accepts the specific implementation as a
     // type parameter.
     let my_api =
-        api::counter_api::api_description::<imp::CounterImpl>().unwrap();
+        api::counter_api_mod::api_description::<imp::CounterImpl>().unwrap();
     let server = HttpServerStarter::new(
         &config_dropshot,
         my_api,

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -230,7 +230,7 @@
 //! }
 //!
 //! // The `dropshot::api_description` macro generates a module called
-//! // `project_api`. This module has a method called `api_description`
+//! // `project_api_mod`. This module has a method called `api_description`
 //! // that, given an implementation of the trait, returns an `ApiDescription`.
 //! // The `ApiDescription` can then be used to set up an `HttpServer`.
 //!
@@ -257,7 +257,7 @@
 //!     // The type of `api` is provided for clarity -- it is generally inferred.
 //!     // "api" will automatically register all endpoints defined in the trait.
 //!     let mut api: ApiDescription<()> =
-//!         project_api::api_description::<ServerImpl>().unwrap();
+//!         project_api_mod::api_description::<ServerImpl>().unwrap();
 //!
 //!     // ... (use `api` to set up an `HttpServer` )
 //! }
@@ -500,7 +500,7 @@
 //!
 //! # // defining fn main puts the doctest in a module context
 //! # fn main() {
-//! let description = project_api::stub_api_description().unwrap();
+//! let description = project_api_mod::stub_api_description().unwrap();
 //! let mut openapi = description.openapi("Project Server", "1.0.0");
 //! openapi.write(&mut std::io::stdout().lock()).unwrap();
 //! # }

--- a/dropshot/tests/fail/bad_trait_channel10.rs
+++ b/dropshot/tests/fail/bad_trait_channel10.rs
@@ -35,6 +35,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel11.rs
+++ b/dropshot/tests/fail/bad_trait_channel11.rs
@@ -34,6 +34,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel12.rs
+++ b/dropshot/tests/fail/bad_trait_channel12.rs
@@ -37,6 +37,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel13.rs
+++ b/dropshot/tests/fail/bad_trait_channel13.rs
@@ -46,6 +46,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel14.rs
+++ b/dropshot/tests/fail/bad_trait_channel14.rs
@@ -49,6 +49,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel15.rs
+++ b/dropshot/tests/fail/bad_trait_channel15.rs
@@ -36,6 +36,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel17.rs
+++ b/dropshot/tests/fail/bad_trait_channel17.rs
@@ -40,6 +40,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel18.rs
+++ b/dropshot/tests/fail/bad_trait_channel18.rs
@@ -47,6 +47,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel19.rs
+++ b/dropshot/tests/fail/bad_trait_channel19.rs
@@ -48,6 +48,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel1a.rs
+++ b/dropshot/tests/fail/bad_trait_channel1a.rs
@@ -28,6 +28,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel1b.rs
+++ b/dropshot/tests/fail/bad_trait_channel1b.rs
@@ -34,6 +34,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel2.rs
+++ b/dropshot/tests/fail/bad_trait_channel2.rs
@@ -110,6 +110,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel20.rs
+++ b/dropshot/tests/fail/bad_trait_channel20.rs
@@ -36,6 +36,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel21.rs
+++ b/dropshot/tests/fail/bad_trait_channel21.rs
@@ -50,6 +50,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel22.rs
+++ b/dropshot/tests/fail/bad_trait_channel22.rs
@@ -47,6 +47,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel23.rs
+++ b/dropshot/tests/fail/bad_trait_channel23.rs
@@ -50,6 +50,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel24.rs
+++ b/dropshot/tests/fail/bad_trait_channel24.rs
@@ -49,6 +49,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel25.rs
+++ b/dropshot/tests/fail/bad_trait_channel25.rs
@@ -54,6 +54,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel26.rs
+++ b/dropshot/tests/fail/bad_trait_channel26.rs
@@ -36,6 +36,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel3.rs
+++ b/dropshot/tests/fail/bad_trait_channel3.rs
@@ -39,6 +39,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel4.rs
+++ b/dropshot/tests/fail/bad_trait_channel4.rs
@@ -47,6 +47,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel5.rs
+++ b/dropshot/tests/fail/bad_trait_channel5.rs
@@ -47,6 +47,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel6.rs
+++ b/dropshot/tests/fail/bad_trait_channel6.rs
@@ -52,6 +52,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();    
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();    
 }

--- a/dropshot/tests/fail/bad_trait_channel8.rs
+++ b/dropshot/tests/fail/bad_trait_channel8.rs
@@ -37,6 +37,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_channel9.rs
+++ b/dropshot/tests/fail/bad_trait_channel9.rs
@@ -45,6 +45,6 @@ impl MyServer for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_server::api_description::<MyImpl>();
-    my_server::stub_api_description();
+    my_server_mod::api_description::<MyImpl>();
+    my_server_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint1.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint1.rs
@@ -29,6 +29,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint10.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint10.rs
@@ -35,6 +35,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint11.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint11.rs
@@ -33,6 +33,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint12.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint12.rs
@@ -39,6 +39,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint13.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint13.rs
@@ -46,6 +46,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint14.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint14.rs
@@ -44,6 +44,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint15.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint15.rs
@@ -36,6 +36,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint16.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint16.rs
@@ -35,6 +35,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint17.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint17.rs
@@ -52,6 +52,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint18.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint18.rs
@@ -50,6 +50,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint19.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint19.rs
@@ -49,6 +49,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint2.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint2.rs
@@ -86,6 +86,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint20.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint20.rs
@@ -36,6 +36,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint21.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint21.rs
@@ -51,6 +51,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint22.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint22.rs
@@ -46,6 +46,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint23.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint23.rs
@@ -49,6 +49,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint24.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint24.rs
@@ -46,6 +46,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint25.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint25.rs
@@ -54,6 +54,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint26.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint26.rs
@@ -36,6 +36,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint3.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint3.rs
@@ -37,6 +37,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint4.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint4.rs
@@ -45,6 +45,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint5.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint5.rs
@@ -46,6 +46,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint6.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint6.rs
@@ -49,6 +49,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();    
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();    
 }

--- a/dropshot/tests/fail/bad_trait_endpoint7.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint7.rs
@@ -44,6 +44,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint8.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint8.rs
@@ -41,6 +41,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_endpoint9.rs
+++ b/dropshot/tests/fail/bad_trait_endpoint9.rs
@@ -45,6 +45,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only1.rs
+++ b/dropshot/tests/fail/bad_trait_only1.rs
@@ -103,6 +103,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only10.rs
+++ b/dropshot/tests/fail/bad_trait_only10.rs
@@ -20,6 +20,6 @@ unsafe impl MyApi for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid trait, and will
     // cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only10.stderr
+++ b/dropshot/tests/fail/bad_trait_only10.stderr
@@ -4,14 +4,14 @@ error: API trait `MyApi` must not be marked as `unsafe`
 8 | unsafe trait MyApi {
   | ^^^^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only10.rs:23:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only10.rs:23:17
    |
-23 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only10.rs:24:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only10.rs:24:17
    |
-24 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+24 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only11.rs
+++ b/dropshot/tests/fail/bad_trait_only11.rs
@@ -23,6 +23,6 @@ impl MyApi for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid trait, and will
     // cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only11.stderr
+++ b/dropshot/tests/fail/bad_trait_only11.stderr
@@ -5,14 +5,14 @@ error: API trait `MyApi` must not have a where clause
 10 | |     usize: std::fmt::Debug,
    | |___________________________^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only11.rs:26:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only11.rs:26:17
    |
-26 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+26 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only11.rs:27:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only11.rs:27:17
    |
-27 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+27 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only13.rs
+++ b/dropshot/tests/fail/bad_trait_only13.rs
@@ -58,6 +58,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only15.rs
+++ b/dropshot/tests/fail/bad_trait_only15.rs
@@ -28,6 +28,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only16.rs
+++ b/dropshot/tests/fail/bad_trait_only16.rs
@@ -27,6 +27,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only17.rs
+++ b/dropshot/tests/fail/bad_trait_only17.rs
@@ -46,6 +46,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only18.rs
+++ b/dropshot/tests/fail/bad_trait_only18.rs
@@ -47,6 +47,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only19.rs
+++ b/dropshot/tests/fail/bad_trait_only19.rs
@@ -48,6 +48,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only2.rs
+++ b/dropshot/tests/fail/bad_trait_only2.rs
@@ -100,6 +100,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only3.rs
+++ b/dropshot/tests/fail/bad_trait_only3.rs
@@ -99,6 +99,6 @@ impl MyApi for MyImpl {
 
 fn main() {
     // These items should be generated and accessible.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only4.rs
+++ b/dropshot/tests/fail/bad_trait_only4.rs
@@ -15,6 +15,6 @@ impl MyApi for MyImpl {}
 fn main() {
     // These items will NOT be present because of the lack of a context type,
     // and will cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only4.stderr
+++ b/dropshot/tests/fail/bad_trait_only4.stderr
@@ -5,14 +5,14 @@ error: API trait `MyApi` does not have associated type `Context`
 8 | trait MyApi {}
   |       ^^^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only4.rs:18:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only4.rs:18:17
    |
-18 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+18 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only4.rs:19:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only4.rs:19:17
    |
-19 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+19 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only5.rs
+++ b/dropshot/tests/fail/bad_trait_only5.rs
@@ -19,6 +19,6 @@ impl MyApi for MyImpl {
 fn main() {
     // These items will NOT be present because of the lack of a context type,
     // and will cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only5.stderr
+++ b/dropshot/tests/fail/bad_trait_only5.stderr
@@ -5,14 +5,14 @@ error: API trait `MyApi` does not have associated type `OtherContext`
 8 | trait MyApi {
   |       ^^^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only5.rs:22:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only5.rs:22:17
    |
-22 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+22 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only5.rs:23:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only5.rs:23:17
    |
-23 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only6.rs
+++ b/dropshot/tests/fail/bad_trait_only6.rs
@@ -20,6 +20,6 @@ impl MyApi for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid context type, and
     // will cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only6.stderr
+++ b/dropshot/tests/fail/bad_trait_only6.stderr
@@ -4,14 +4,14 @@ error: context type `Context` must not have generics
 9 |     type Context<T>;
   |                 ^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only6.rs:23:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only6.rs:23:17
    |
-23 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only6.rs:24:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only6.rs:24:17
    |
-24 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+24 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only7.rs
+++ b/dropshot/tests/fail/bad_trait_only7.rs
@@ -20,6 +20,6 @@ impl MyApi for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid context type, and
     // will cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only7.stderr
+++ b/dropshot/tests/fail/bad_trait_only7.stderr
@@ -4,14 +4,14 @@ error: context type `Context` must not have generics
 9 |     type Context<'a>;
   |                 ^^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only7.rs:23:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only7.rs:23:17
    |
-23 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only7.rs:24:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only7.rs:24:17
    |
-24 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+24 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only8.rs
+++ b/dropshot/tests/fail/bad_trait_only8.rs
@@ -20,6 +20,6 @@ impl<T> MyApi<T> for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid trait, and will
     // cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only8.stderr
+++ b/dropshot/tests/fail/bad_trait_only8.stderr
@@ -4,14 +4,14 @@ error: API trait `MyApi` must not have generics
 8 | trait MyApi<T> {
   |            ^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only8.rs:23:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only8.rs:23:17
    |
-23 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only8.rs:24:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only8.rs:24:17
    |
-24 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+24 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot/tests/fail/bad_trait_only9.rs
+++ b/dropshot/tests/fail/bad_trait_only9.rs
@@ -20,6 +20,6 @@ impl<'a> MyApi<'a> for MyImpl {
 fn main() {
     // These items will NOT be present because of the invalid trait, and will
     // cause errors to be generated.
-    my_api::api_description::<MyImpl>();
-    my_api::stub_api_description();
+    my_api_mod::api_description::<MyImpl>();
+    my_api_mod::stub_api_description();
 }

--- a/dropshot/tests/fail/bad_trait_only9.stderr
+++ b/dropshot/tests/fail/bad_trait_only9.stderr
@@ -4,14 +4,14 @@ error: API trait `MyApi` must not have generics
 8 | trait MyApi<'a> {
   |            ^^^^
 
-error[E0425]: cannot find function `api_description` in module `my_api`
-  --> tests/fail/bad_trait_only9.rs:23:13
+error[E0425]: cannot find function `api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only9.rs:23:17
    |
-23 |     my_api::api_description::<MyImpl>();
-   |             ^^^^^^^^^^^^^^^ not found in `my_api`
+23 |     my_api_mod::api_description::<MyImpl>();
+   |                 ^^^^^^^^^^^^^^^ not found in `my_api_mod`
 
-error[E0425]: cannot find function `stub_api_description` in module `my_api`
-  --> tests/fail/bad_trait_only9.rs:24:13
+error[E0425]: cannot find function `stub_api_description` in module `my_api_mod`
+  --> tests/fail/bad_trait_only9.rs:24:17
    |
-24 |     my_api::stub_api_description();
-   |             ^^^^^^^^^^^^^^^^^^^^ not found in `my_api`
+24 |     my_api_mod::stub_api_description();
+   |                 ^^^^^^^^^^^^^^^^^^^^ not found in `my_api_mod`

--- a/dropshot_endpoint/src/api_trait.rs
+++ b/dropshot_endpoint/src/api_trait.rs
@@ -150,7 +150,7 @@ impl ApiMetadata {
     fn module_name(&self, trait_ident: &syn::Ident) -> String {
         self.module
             .clone()
-            .unwrap_or_else(|| trait_ident.to_string().to_snake_case())
+            .unwrap_or_else(|| trait_ident.to_string().to_snake_case() + "_mod")
     }
 }
 

--- a/dropshot_endpoint/src/lib.rs
+++ b/dropshot_endpoint/src/lib.rs
@@ -130,7 +130,13 @@ pub fn channel(
 /// * `context`: The type of the context on the trait. Optional, defaults to
 ///   `Self::Context`.
 /// * `module`: The name of the support module. Optional, defaults to the
-///   `snake_case` version of the trait name.
+///   `{T}_mod`, where `T` is the snake_case version of the trait name.
+///
+///    For example, for a trait called `MyApi` the corresponding module name
+///    would be `my_api_mod`.
+///
+///    (The suffix `_mod` is added to module names so that a crate called
+///    `my-api` can define a trait `MyApi`, avoiding name conflicts.)
 ///
 /// ## Limitations
 ///

--- a/dropshot_endpoint/tests/output/api_trait_basic.rs
+++ b/dropshot_endpoint/tests/output/api_trait_basic.rs
@@ -12,7 +12,7 @@ trait MyTrait: 'static {
 }
 /// Support module for the Dropshot API trait [`MyTrait`](MyTrait).
 #[automatically_derived]
-mod my_trait {
+mod my_trait_mod {
     use super::*;
     const _: fn() = || {
         trait TypeEq {
@@ -44,7 +44,7 @@ mod my_trait {
     ///
     /// ```rust,ignore
     /// fn print_openapi_spec() {
-    ///     let stub = my_trait::stub_api_description().unwrap();
+    ///     let stub = my_trait_mod::stub_api_description().unwrap();
     ///
     ///     // Generate OpenAPI spec from `stub`.
     ///     let spec = stub.openapi("MyTrait", "0.1.0");
@@ -53,7 +53,7 @@ mod my_trait {
     /// ```
     ///
     /// [`MyTrait`]: MyTrait
-    /// [`api_description`]: my_trait::api_description
+    /// [`api_description`]: my_trait_mod::api_description
     /// [`ApiDescription`]: dropshot::ApiDescription
     /// [`StubContext`]: dropshot::StubContext
     #[automatically_derived]
@@ -122,7 +122,7 @@ mod my_trait {
     /// #[tokio::main]
     /// async fn main() {
     ///     // Generate the description for `MyTraitImpl`.
-    ///     let description = my_trait::api_description::<MyTraitImpl>().unwrap();
+    ///     let description = my_trait_mod::api_description::<MyTraitImpl>().unwrap();
     ///
     ///     // Create a value of the concrete context type.
     ///     let context = /* some value of type `MyTraitImpl::Context` */;

--- a/dropshot_endpoint/tests/output/api_trait_no_endpoints.rs
+++ b/dropshot_endpoint/tests/output/api_trait_no_endpoints.rs
@@ -3,7 +3,7 @@ pub(crate) trait MyTrait: 'static {
 }
 /// Support module for the Dropshot API trait [`MyTrait`](MyTrait).
 #[automatically_derived]
-pub(crate) mod my_trait {
+pub(crate) mod my_trait_mod {
     use super::*;
     /// Generate a _stub_ API description for [`MyTrait`], meant for OpenAPI
     /// generation.
@@ -22,7 +22,7 @@ pub(crate) mod my_trait {
     ///
     /// ```rust,ignore
     /// fn print_openapi_spec() {
-    ///     let stub = my_trait::stub_api_description().unwrap();
+    ///     let stub = my_trait_mod::stub_api_description().unwrap();
     ///
     ///     // Generate OpenAPI spec from `stub`.
     ///     let spec = stub.openapi("MyTrait", "0.1.0");
@@ -31,7 +31,7 @@ pub(crate) mod my_trait {
     /// ```
     ///
     /// [`MyTrait`]: MyTrait
-    /// [`api_description`]: my_trait::api_description
+    /// [`api_description`]: my_trait_mod::api_description
     /// [`ApiDescription`]: dropshot::ApiDescription
     /// [`StubContext`]: dropshot::StubContext
     #[automatically_derived]
@@ -72,7 +72,7 @@ pub(crate) mod my_trait {
     /// #[tokio::main]
     /// async fn main() {
     ///     // Generate the description for `MyTraitImpl`.
-    ///     let description = my_trait::api_description::<MyTraitImpl>().unwrap();
+    ///     let description = my_trait_mod::api_description::<MyTraitImpl>().unwrap();
     ///
     ///     // Create a value of the concrete context type.
     ///     let context = /* some value of type `MyTraitImpl::Context` */;


### PR DESCRIPTION
One of the recurring issues I ran into with using API traits is that I'd
define, e.g. `NexusInternalApi` in a crate called `nexus-internal-api`. The
default module name would then clash with the crate name, leading to unhelpful
errors.

As a workaround I've been adding `_mod` to the end of support module names, and
I think it makes sense for `_mod` to be the default. It's a little strange at
first, but it makes sense if you think about it and is quite inoffensive.