### PR TITLE
allow endpoints and channels to specify the `operation_id`

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -304,6 +304,7 @@
 //!     path = "/path/name/with/{named}/{variables}",
 //!
 //!     // Optional fields
+//!     operation_id = "my_operation" // (default: name of the function)
 //!     tags = [ "all", "your", "OpenAPI", "tags" ],
 //! }]
 //! ```

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -200,6 +200,32 @@
         }
       }
     },
+    "/first_thing": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "vzeroupper",
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/impairment": {
       "get": {
         "tags": [
@@ -267,6 +293,25 @@
             "a_mandatory_string"
           ]
         }
+      }
+    },
+    "/other_thing": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "vzerolower",
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-dropshot-websocket": {}
       }
     },
     "/playing/a/bit/nicer": {

--- a/dropshot/tests/test_openapi.rs
+++ b/dropshot/tests/test_openapi.rs
@@ -1,8 +1,7 @@
 // Copyright 2023 Oxide Computer Company
 
-use dropshot::Body;
 use dropshot::{
-    endpoint, http_response_found, http_response_see_other,
+    channel, endpoint, http_response_found, http_response_see_other,
     http_response_temporary_redirect, ApiDescription,
     ApiDescriptionRegisterError, FreeformBody, HttpError, HttpResponseAccepted,
     HttpResponseCreated, HttpResponseDeleted, HttpResponseFound,
@@ -11,6 +10,7 @@ use dropshot::{
     PaginationParams, Path, Query, RequestContext, ResultsPage, TagConfig,
     TagDetails, TypedBody, UntypedBody,
 };
+use dropshot::{Body, WebsocketConnection};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io::Cursor, str::from_utf8};
@@ -473,6 +473,33 @@ async fn handler25(
     Ok(HttpResponseCreated(Response {}))
 }
 
+// test: Overridden operation id
+#[endpoint {
+    operation_id = "vzeroupper",
+    method = GET,
+    path = "/first_thing",
+    tags = ["it"]
+}]
+async fn handler26(
+    _rqctx: RequestContext<()>,
+) -> Result<HttpResponseCreated<Response>, HttpError> {
+    Ok(HttpResponseCreated(Response {}))
+}
+
+// test: websocket using overriden operation id
+#[channel {
+    protocol = WEBSOCKETS,
+    operation_id = "vzerolower",
+    path = "/other_thing",
+    tags = ["it"]
+}]
+async fn handler27(
+    _rqctx: RequestContext<()>,
+    _: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    Ok(())
+}
+
 fn make_api(
     maybe_tag_config: Option<TagConfig>,
 ) -> Result<ApiDescription<()>, ApiDescriptionRegisterError> {
@@ -507,6 +534,8 @@ fn make_api(
     api.register(handler23)?;
     api.register(handler24)?;
     api.register(handler25)?;
+    api.register(handler26)?;
+    api.register(handler27)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -208,6 +208,32 @@
         }
       }
     },
+    "/first_thing": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "vzeroupper",
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/impairment": {
       "get": {
         "tags": [
@@ -275,6 +301,25 @@
             "a_mandatory_string"
           ]
         }
+      }
+    },
+    "/other_thing": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "vzerolower",
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-dropshot-websocket": {}
       }
     },
     "/playing/a/bit/nicer": {

--- a/dropshot_endpoint/src/api_trait.rs
+++ b/dropshot_endpoint/src/api_trait.rs
@@ -1759,4 +1759,41 @@ mod tests {
             &prettyplease::unparse(&parse_quote! { #item }),
         );
     }
+
+    #[test]
+    fn test_api_trait_operation_id() {
+        let (item, errors) = do_trait(
+            quote! {},
+            quote! {
+                trait MyTrait {
+                    type Context;
+
+                    #[endpoint {
+                        operation_id = "vzerolower",
+                        method = GET,
+                        path = "/xyz"
+                    }]
+                    async fn handler_xyz(
+                        rqctx: RequestContext<Self::Context>,
+                    ) -> Result<HttpResponseOk<()>, HttpError>;
+
+                    #[channel {
+                        protocol = WEBSOCKETS,
+                        path = "/ws",
+                        operation_id = "vzeroupper", 
+                    }]
+                    async fn handler_ws(
+                        rqctx: RequestContext<Self::Context>,
+                        upgraded: WebsocketConnection,
+                    ) -> WebsocketChannelResult;
+                }
+            },
+        );
+
+        assert!(errors.is_empty());
+        assert_contents(
+            "tests/output/api_trait_operation_id.rs",
+            &prettyplease::unparse(&parse_quote! { #item }),
+        );
+    }
 }

--- a/dropshot_endpoint/src/api_trait.rs
+++ b/dropshot_endpoint/src/api_trait.rs
@@ -1780,7 +1780,7 @@ mod tests {
                     #[channel {
                         protocol = WEBSOCKETS,
                         path = "/ws",
-                        operation_id = "vzeroupper", 
+                        operation_id = "vzeroupper",
                     }]
                     async fn handler_ws(
                         rqctx: RequestContext<Self::Context>,

--- a/dropshot_endpoint/src/channel.rs
+++ b/dropshot_endpoint/src/channel.rs
@@ -613,4 +613,29 @@ mod tests {
             &prettyplease::unparse(&parse_quote! { #item }),
         );
     }
+
+    #[test]
+    fn test_channel_operation_id() {
+        let (item, errors) = do_channel(
+            quote! {
+                protocol = WEBSOCKETS,
+                path = "/my/ws/channel",
+                operation_id = "vzeroupper"
+            },
+            quote! {
+                async fn handler_xyz(
+                    _rqctx: RequestContext<()>,
+                    _ws: WebsocketConnection,
+                ) -> Result<HttpResponseOk<()>, HttpError> {
+                    Ok(())
+                }
+            },
+        );
+
+        assert!(errors.is_empty());
+        assert_contents(
+            "tests/output/channel_operation_id.rs",
+            &prettyplease::unparse(&parse_quote! { #item }),
+        );
+    }
 }

--- a/dropshot_endpoint/src/endpoint.rs
+++ b/dropshot_endpoint/src/endpoint.rs
@@ -920,4 +920,28 @@ mod tests {
             Some("endpoint `handler_xyz` must have at least one RequestContext argument".to_string())
         );
     }
+
+    #[test]
+    fn test_operation_id() {
+        let (item, errors) = do_endpoint(
+            quote! {
+                method = GET,
+                path = "/a/b/c",
+                operation_id = "vzeroupper"
+            },
+            quote! {
+                pub async fn handler_xyz(
+                    _rqctx: RequestContext<()>,
+                ) -> Result<HttpResponseOk<()>, HttpError> {
+                    Ok(())
+                }
+            },
+        );
+
+        assert!(errors.is_empty());
+        assert_contents(
+            "tests/output/endpoint_operation_id.rs",
+            &prettyplease::unparse(&parse_quote! { #item }),
+        );
+    }
 }

--- a/dropshot_endpoint/tests/output/api_trait_operation_id.rs
+++ b/dropshot_endpoint/tests/output/api_trait_operation_id.rs
@@ -1,0 +1,193 @@
+trait MyTrait: 'static {
+    type Context: dropshot::ServerContext;
+    fn handler_xyz(
+        rqctx: RequestContext<Self::Context>,
+    ) -> impl ::core::future::Future<
+        Output = Result<HttpResponseOk<()>, HttpError>,
+    > + Send + 'static;
+    fn handler_ws(
+        rqctx: RequestContext<Self::Context>,
+        upgraded: WebsocketConnection,
+    ) -> impl ::core::future::Future<Output = WebsocketChannelResult> + Send + 'static;
+}
+/// Support module for the Dropshot API trait [`MyTrait`](MyTrait).
+#[automatically_derived]
+mod my_trait_mod {
+    use super::*;
+    const _: fn() = || {
+        trait TypeEq {
+            type This: ?Sized;
+        }
+        impl<T: ?Sized> TypeEq for T {
+            type This = Self;
+        }
+        fn validate_websocket_connection_type<T>()
+        where
+            T: ?Sized + TypeEq<This = dropshot::WebsocketConnection>,
+        {}
+        validate_websocket_connection_type::<WebsocketConnection>();
+    };
+    /// Generate a _stub_ API description for [`MyTrait`], meant for OpenAPI
+    /// generation.
+    ///
+    /// Unlike [`api_description`], this function does not require an implementation
+    /// of [`MyTrait`] to be available, instead generating handlers that panic.
+    /// The return value is of type [`ApiDescription`]`<`[`StubContext`]`>`.
+    ///
+    /// The main use of this function is in cases where [`MyTrait`] is defined
+    /// in a separate crate from its implementation. The OpenAPI spec can then be
+    /// generated directly from the stub API description.
+    ///
+    /// ## Example
+    ///
+    /// A function that prints the OpenAPI spec to standard output:
+    ///
+    /// ```rust,ignore
+    /// fn print_openapi_spec() {
+    ///     let stub = my_trait_mod::stub_api_description().unwrap();
+    ///
+    ///     // Generate OpenAPI spec from `stub`.
+    ///     let spec = stub.openapi("MyTrait", "0.1.0");
+    ///     spec.write(&mut std::io::stdout()).unwrap();
+    /// }
+    /// ```
+    ///
+    /// [`MyTrait`]: MyTrait
+    /// [`api_description`]: my_trait_mod::api_description
+    /// [`ApiDescription`]: dropshot::ApiDescription
+    /// [`StubContext`]: dropshot::StubContext
+    #[automatically_derived]
+    pub fn stub_api_description() -> ::std::result::Result<
+        dropshot::ApiDescription<dropshot::StubContext>,
+        dropshot::ApiDescriptionBuildErrors,
+    > {
+        let mut dropshot_api = dropshot::ApiDescription::new();
+        let mut dropshot_errors: Vec<dropshot::ApiDescriptionRegisterError> = Vec::new();
+        {
+            let endpoint_handler_xyz = dropshot::ApiEndpoint::new_for_types::<
+                (),
+                Result<HttpResponseOk<()>, HttpError>,
+            >(
+                "vzerolower".to_string(),
+                dropshot::Method::GET,
+                "application/json",
+                "/xyz",
+            );
+            if let Err(error) = dropshot_api.register(endpoint_handler_xyz) {
+                dropshot_errors.push(error);
+            }
+        }
+        {
+            let endpoint_handler_ws = dropshot::ApiEndpoint::new_for_types::<
+                (dropshot::WebsocketUpgrade,),
+                dropshot::WebsocketEndpointResult,
+            >(
+                "vzeroupper".to_string(),
+                dropshot::Method::GET,
+                "application/json",
+                "/ws",
+            );
+            if let Err(error) = dropshot_api.register(endpoint_handler_ws) {
+                dropshot_errors.push(error);
+            }
+        }
+        if !dropshot_errors.is_empty() {
+            Err(dropshot::ApiDescriptionBuildErrors::new(dropshot_errors))
+        } else {
+            Ok(dropshot_api)
+        }
+    }
+    /// Given an implementation of [`MyTrait`], generate an API description.
+    ///
+    /// This function accepts a single type argument `ServerImpl`, turning it into a
+    /// Dropshot [`ApiDescription`]`<ServerImpl::`[`Context`]`>`.
+    /// The returned `ApiDescription` can then be turned into a Dropshot server that
+    /// accepts a concrete `Context`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,ignore
+    /// /// A type used to define the concrete implementation for `MyTrait`.
+    /// ///
+    /// /// This type is never constructed -- it is just a place to define your
+    /// /// implementation of `MyTrait`.
+    /// enum MyTraitImpl {}
+    ///
+    /// impl MyTrait for MyTraitImpl {
+    ///     type Context = /* context type */;
+    ///
+    ///     // ... trait methods
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     // Generate the description for `MyTraitImpl`.
+    ///     let description = my_trait_mod::api_description::<MyTraitImpl>().unwrap();
+    ///
+    ///     // Create a value of the concrete context type.
+    ///     let context = /* some value of type `MyTraitImpl::Context` */;
+    ///
+    ///     // Create a Dropshot server from the description.
+    ///     let log = /* ... */;
+    ///     let server = dropshot::ServerBuilder::new(description, context, log)
+    ///         .start()
+    ///         .unwrap();
+    ///
+    ///     // Run the server.
+    ///     server.await
+    /// }
+    /// ```
+    ///
+    /// [`ApiDescription`]: dropshot::ApiDescription
+    /// [`MyTrait`]: MyTrait
+    /// [`Context`]: MyTrait::Context
+    #[automatically_derived]
+    pub fn api_description<ServerImpl: MyTrait>() -> ::std::result::Result<
+        dropshot::ApiDescription<<ServerImpl as MyTrait>::Context>,
+        dropshot::ApiDescriptionBuildErrors,
+    > {
+        let mut dropshot_api = dropshot::ApiDescription::new();
+        let mut dropshot_errors: Vec<dropshot::ApiDescriptionRegisterError> = Vec::new();
+        {
+            let endpoint_handler_xyz = dropshot::ApiEndpoint::new(
+                "vzerolower".to_string(),
+                <ServerImpl as MyTrait>::handler_xyz,
+                dropshot::Method::GET,
+                "application/json",
+                "/xyz",
+            );
+            if let Err(error) = dropshot_api.register(endpoint_handler_xyz) {
+                dropshot_errors.push(error);
+            }
+        }
+        {
+            async fn handler_ws_adapter<ServerImpl: MyTrait>(
+                arg0: RequestContext<<ServerImpl as MyTrait>::Context>,
+                __dropshot_websocket: dropshot::WebsocketUpgrade,
+            ) -> dropshot::WebsocketEndpointResult {
+                __dropshot_websocket
+                    .handle(move |__dropshot_websocket: WebsocketConnection| async move {
+                        <ServerImpl as MyTrait>::handler_ws(arg0, __dropshot_websocket)
+                            .await
+                    })
+            }
+            {
+                let endpoint_handler_ws = dropshot::ApiEndpoint::new(
+                    "vzeroupper".to_string(),
+                    handler_ws_adapter::<ServerImpl>,
+                    dropshot::Method::GET,
+                    "application/json",
+                    "/ws",
+                );
+                if let Err(error) = dropshot_api.register(endpoint_handler_ws) {
+                    dropshot_errors.push(error);
+                }
+            }
+        }
+        if !dropshot_errors.is_empty() {
+            Err(dropshot::ApiDescriptionBuildErrors::new(dropshot_errors))
+        } else {
+            Ok(dropshot_api)
+        }
+    }
+}

--- a/dropshot_endpoint/tests/output/channel_operation_id.rs
+++ b/dropshot_endpoint/tests/output/channel_operation_id.rs
@@ -1,0 +1,63 @@
+const _: fn() = || {
+    struct NeedRequestContext(
+        <RequestContext<()> as dropshot::RequestContextArgument>::Context,
+    );
+};
+const _: fn() = || {
+    trait TypeEq {
+        type This: ?Sized;
+    }
+    impl<T: ?Sized> TypeEq for T {
+        type This = Self;
+    }
+    fn validate_websocket_connection_type<T>()
+    where
+        T: ?Sized + TypeEq<This = dropshot::WebsocketConnection>,
+    {}
+    validate_websocket_connection_type::<WebsocketConnection>();
+};
+#[allow(non_camel_case_types, missing_docs)]
+///API Endpoint: handler_xyz
+struct handler_xyz {}
+#[allow(non_upper_case_globals, missing_docs)]
+///API Endpoint: handler_xyz
+const handler_xyz: handler_xyz = handler_xyz {};
+impl From<handler_xyz>
+for dropshot::ApiEndpoint<
+    <RequestContext<()> as dropshot::RequestContextArgument>::Context,
+> {
+    fn from(_: handler_xyz) -> Self {
+        #[allow(clippy::unused_async)]
+        async fn handler_xyz(
+            _rqctx: RequestContext<()>,
+            _ws: WebsocketConnection,
+        ) -> Result<HttpResponseOk<()>, HttpError> {
+            Ok(())
+        }
+        const _: fn() = || {
+            fn future_endpoint_must_be_send<T: ::std::marker::Send>(_t: T) {}
+            fn check_future_bounds(
+                arg0: RequestContext<()>,
+                __dropshot_websocket: WebsocketConnection,
+            ) {
+                future_endpoint_must_be_send(handler_xyz(arg0, __dropshot_websocket));
+            }
+        };
+        async fn handler_xyz_adapter(
+            arg0: RequestContext<()>,
+            __dropshot_websocket: dropshot::WebsocketUpgrade,
+        ) -> dropshot::WebsocketEndpointResult {
+            __dropshot_websocket
+                .handle(move |__dropshot_websocket: WebsocketConnection| async move {
+                    handler_xyz(arg0, __dropshot_websocket).await
+                })
+        }
+        dropshot::ApiEndpoint::new(
+            "vzeroupper".to_string(),
+            handler_xyz_adapter,
+            dropshot::Method::GET,
+            "application/json",
+            "/my/ws/channel",
+        )
+    }
+}

--- a/dropshot_endpoint/tests/output/endpoint_operation_id.rs
+++ b/dropshot_endpoint/tests/output/endpoint_operation_id.rs
@@ -1,0 +1,64 @@
+const _: fn() = || {
+    struct NeedRequestContext(
+        <RequestContext<()> as dropshot::RequestContextArgument>::Context,
+    );
+};
+const _: fn() = || {
+    trait ResultTrait {
+        type T;
+        type E;
+    }
+    impl<TT, EE> ResultTrait for Result<TT, EE>
+    where
+        TT: dropshot::HttpResponse,
+    {
+        type T = TT;
+        type E = EE;
+    }
+    struct NeedHttpResponse(<Result<HttpResponseOk<()>, HttpError> as ResultTrait>::T);
+    trait TypeEq {
+        type This: ?Sized;
+    }
+    impl<T: ?Sized> TypeEq for T {
+        type This = Self;
+    }
+    fn validate_result_error_type<T>()
+    where
+        T: ?Sized + TypeEq<This = dropshot::HttpError>,
+    {}
+    validate_result_error_type::<
+        <Result<HttpResponseOk<()>, HttpError> as ResultTrait>::E,
+    >();
+};
+#[allow(non_camel_case_types, missing_docs)]
+///API Endpoint: handler_xyz
+pub struct handler_xyz {}
+#[allow(non_upper_case_globals, missing_docs)]
+///API Endpoint: handler_xyz
+pub const handler_xyz: handler_xyz = handler_xyz {};
+impl From<handler_xyz>
+for dropshot::ApiEndpoint<
+    <RequestContext<()> as dropshot::RequestContextArgument>::Context,
+> {
+    fn from(_: handler_xyz) -> Self {
+        #[allow(clippy::unused_async)]
+        pub async fn handler_xyz(
+            _rqctx: RequestContext<()>,
+        ) -> Result<HttpResponseOk<()>, HttpError> {
+            Ok(())
+        }
+        const _: fn() = || {
+            fn future_endpoint_must_be_send<T: ::std::marker::Send>(_t: T) {}
+            fn check_future_bounds(arg0: RequestContext<()>) {
+                future_endpoint_must_be_send(handler_xyz(arg0));
+            }
+        };
+        dropshot::ApiEndpoint::new(
+            "vzeroupper".to_string(),
+            handler_xyz,
+            dropshot::Method::GET,
+            "application/json",
+            "/a/b/c",
+        )
+    }
+}


### PR DESCRIPTION
By default, we pick the function's name as the OpenAPI `operation_id`.  This allows people to specify their own.  This will become more important after #1115.