### PR TITLE
update MAINTAINERS doc to match reality

### DIFF
--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -87,47 +87,14 @@ cargo install cargo-release
 +
 Make sure you have a compatible version.  These instructions were written for v0.25.4.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md[check the changelog to make sure it's compatible].
 +
-**You should be able to just run:**
+Run:
 +
 [source,text]
 ----
 $ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv --execute RELEASE_KIND|NEW_VERSION
 ----
 +
-**and then remember to push the commit and the tag!**  (You may have to temporarily allow administrators to override branch protection in order to do this.)
-+
-If you want to be extra careful, you can do this in a dry-run form.  First, check that the log output here looks right (and especially that you got the version number that you expected!):
-+
-[source,text]
-----
-$ cargo release --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND|NEW_VERSION
-----
-+
-Now, run `cargo release` for real (i.e. with `--execute`), but without publishing to crates.io or pushing the git tags:
-+
-[source,text]
-----
-$ cargo release --execute --no-push --no-publish --no-tag --prev-tag-name=PREV_RELEASE_TAG -vv RELEASE_KIND|NEW_VERSION
-----
-+
-Inspect the resulting commit and the new tag. The commit should modify the CHANGELOG.adoc, Cargo.lock, and 2 Cargo.toml files.
-+
-Then undo the above step:
-+
-[source,text]
-----
-$ git reset --hard THE_COMMIT_YOU_STARTED_WITH
-$ git tag -d THE_NEW_TAG
-----
-+
-and do the release again with the publish step:
-+
-[source,text]
-----
-$ cargo release --execute --no-push --prev-tag-name=PREV_RELEASE_TAG -vv minor
-----
-+
-At this point, the new crates should be published to crates.io.  Check and push the commit and the tag.
+At this point, the new crates should be published to crates.io.  **Check and push the commit and the tag.**
 +
 [source,text]
 ----
@@ -136,25 +103,7 @@ $ git push --tags
 ----
 +
 You may have to temporarily allow administrators to override branch protection in order to do this.
-. Increment to a dev version. Add 1 to the patch version and a "-dev" suffix on NEW_VERSION to form DEV_VERSION (e.g. `0.9.0` -> `0.9.1-dev`). Then do:
-+
-[source,text]
-----
-$ cargo release --execute --no-push --no-publish --no-tag DEV_VERSION
-----
-+
-Rewrite the message for the commit with changed Cargo.toml and Cargo.lock files ("starting DEV_VERSION after releasing NEW_VERSION"); there should not be changes to CHANGELOG.adoc. Push to main.
-
-=== Why all that checking?  Is that going overboard?
-
-dap's not familiar enough with Cargo to know what all the safeties are.  Other language package managers (well, npm) make it easy to publish packages that are missing files, contain extra files (like local-only notes or private keys), fail tests, etc.  The worst is not knowing the published package is broken or leaked private information until somebody reports it.
-
-We could automate more of this with a script that takes a commit, checks the GitHub CI status, then does a fresh clone and publishes the release.
 
 === What if something goes wrong
 
-At the end of the day, the release is just a few commits that update the crate versions, a git tag, and the crates.io publish.
-
-If something went wrong prior to the crates.io publish, then you can `git reset` your local clone to the commit you started with, delete your local tag, and try again.  (If you followed the above steps, you won't have pushed any git tags, so there's nothing on GitHub to undo.)
-
-If something went wrong after the crates.io publish, you could try to fix up the Git state to match what it should be.  Or you could yank the version you published, reset your local state, and try again.
+At the end of the day, the release is just a commit that updates the crate versions, a git tag, and the crates.io publish.  These can be un-done by deleting the tag, undoing the commits, and yanking the release.

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -85,7 +85,7 @@ Here's how to cut a release.
 cargo install cargo-release
 ----
 +
-Make sure you have a compatible version.  These instructions were written for v0.25.4.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md[check the changelog to make sure it's compatible].
+Make sure you have a compatible version.  These instructions were written for v0.25.5.  "release.toml" in this repo should also include the version it was written for.  If you've got a different version, https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md[check the changelog to make sure it's compatible].
 +
 Run:
 +

--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,5 @@
 # This file is used by cargo-release.
-# This version is written for cargo-release 0.25.4.
+# This version is written for cargo-release 0.25.5.
 
 # Update the change log to reflect the new release and set us up for the next release.
 pre-release-replacements = [


### PR DESCRIPTION
The release docs are sadly outdated:

- Dry run doesn't seem to work any more.  It fails at the publish dropshot step because dropshot_endpoint hasn't really been published.  I'm not sure when or why this behavior changed.
- Let's not keep doing the dev version thing (publish 0.12.0, then update the repo to 0.12.1-dev).  It sucks that the repo has the same version as a published version but isn't the same, but the pattern we were using was breaking Cargo `patch` directives.  (I think these too used to work and I'm not sure what changed.)
- cargo-release 0.25.4 doesn't build any more because it was implicitly depending on a dependency's feature that it wasn't specifying, but working by accident because of one of its dependencies enabling it.  See crate-ci/cargo-release#752.  So we'll document 0.25.5 instead.

I used 0.25.5 to publish 0.13.0 using:

```
$ cargo release --prev-tag-name=0.12.0 -vv --execute 0.13.0
...
[2024-11-13T17:25:02Z DEBUG cargo_release::steps] cannot detect changes for dropshot_endpoint because tag 0.12.0 is missing. Try setting `--prev-tag-name <TAG>`.
[2024-11-13T17:25:02Z DEBUG cargo_release::steps] cannot detect changes for dropshot because tag 0.12.0 is missing. Try setting `--prev-tag-name <TAG>`.
[2024-11-13T17:25:02Z DEBUG globset] built glob set; 0 literals, 1 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
[2024-11-13T17:25:02Z TRACE cargo_release::ops::index] Reusing index for dropshot_endpoint
[2024-11-13T17:25:02Z TRACE cargo_release::ops::index] Reusing index for dropshot
Release
  dropshot_endpoint 0.13.0
  dropshot 0.13.0
? [y/N] 
y
   Upgrading dropshot_endpoint from 0.12.1-dev to 0.13.0
    Updating dropshot's dependency from ^0.12.1-dev to ^0.13.0
   Upgrading dropshot from 0.12.1-dev to 0.13.0
[2024-11-13T17:25:05Z DEBUG cargo_release::steps::release] updating lock file
[2024-11-13T17:25:06Z DEBUG cargo_release::ops::replace] processing replacements for file /home/dap/dropshot-release/dropshot/../CHANGELOG.adoc
[main 18e935f] release 0.13.0
 4 files changed, 10 insertions(+), 6 deletions(-)
  Publishing dropshot_endpoint
    Updating crates.io index
warning: `/home/dap/.cargo/credentials` is deprecated in favor of `credentials.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `credentials` to `credentials.toml`
   Packaging dropshot_endpoint v0.13.0 (/home/dap/dropshot-release/dropshot_endpoint)
    Packaged 40 files, 274.8KiB (45.6KiB compressed)
   Verifying dropshot_endpoint v0.13.0 (/home/dap/dropshot-release/dropshot_endpoint)
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.05s
   Uploading dropshot_endpoint v0.13.0 (/home/dap/dropshot-release/dropshot_endpoint)
    Uploaded dropshot_endpoint v0.13.0 to registry `crates-io`
note: waiting for `dropshot_endpoint v0.13.0` to be available at registry `crates-io`.
You may press ctrl-c to skip waiting; the crate should be available shortly.
   Published dropshot_endpoint v0.13.0 at registry `crates-io`
[2024-11-13T17:25:25Z TRACE cargo_release::ops::index] Downloading index for dropshot_endpoint
[2024-11-13T17:25:25Z TRACE reqwest::blocking::wait] wait at most 30s
[2024-11-13T17:25:25Z TRACE reqwest::blocking::wait] (ThreadId(1)) park timeout 29.99999095s
[2024-11-13T17:25:25Z TRACE reqwest::blocking::wait] wait at most 30s
  Publishing dropshot
    Updating crates.io index
warning: `/home/dap/.cargo/credentials` is deprecated in favor of `credentials.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `credentials` to `credentials.toml`
   Packaging dropshot v0.13.0 (/home/dap/dropshot-release/dropshot)
    Updating crates.io index
warning: package `cpufeatures v0.2.2` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
warning: package `crossbeam-channel v0.5.1` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
    Packaged 345 files, 1.4MiB (316.4KiB compressed)
   Verifying dropshot v0.13.0 (/home/dap/dropshot-release/dropshot)
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.25s
   Uploading dropshot v0.13.0 (/home/dap/dropshot-release/dropshot)
    Uploaded dropshot v0.13.0 to registry `crates-io`
note: waiting for `dropshot v0.13.0` to be available at registry `crates-io`.
You may press ctrl-c to skip waiting; the crate should be available shortly.
   Published dropshot v0.13.0 at registry `crates-io`
[2024-11-13T17:25:57Z TRACE cargo_release::ops::index] Downloading index for dropshot
[2024-11-13T17:25:57Z TRACE reqwest::blocking::wait] wait at most 30s
[2024-11-13T17:25:57Z TRACE reqwest::blocking::wait] (ThreadId(1)) park timeout 29.99999426s
[2024-11-13T17:25:57Z TRACE reqwest::blocking::wait] wait at most 30s
[2024-11-13T17:25:57Z DEBUG cargo_release::steps::tag] creating git tag v0.13.0
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] closing runtime thread (ThreadId(2))
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] signaled close for runtime thread (ThreadId(2))
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] (ThreadId(2)) Receiver is shutdown
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] (ThreadId(2)) end runtime::block_on
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] (ThreadId(2)) finished
[2024-11-13T17:25:57Z TRACE reqwest::blocking::client] closed runtime thread (ThreadId(2))

$ echo $?
0
```

though it looks like I botched the origin commit name.