### PR TITLE
Add a `HeaderMap` to `HttpError`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -88,7 +88,7 @@ error.
 * `HttpError` now contains an `Option<Box<http::HeaderMap>>` of headers to add
 to error responses constructed for the error.
 +
-Code which constructs `HttpError` literals must now initialize this field.
+Code that constructs `HttpError` literals must now initialize this field.
 
 === Other notable changes
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -85,6 +85,37 @@ Additionally, `ErrorStatusCode` provides an `as_client_error` method that
 returns a `ClientErrorStatusCode` if the status code is a client error, or an
 error.
 
+* `HttpError` now contains an `Option<Box<http::HeaderMap>>` of headers to add
+to error responses constructed for the error.
++
+Code which constructs `HttpError` literals must now initialize this field. For
+example, this will no longer compile:
++
+```rust
+let err = dropshot::HttpError {
+    status_code: ErrorStatusCode::INTERNAL_SERVER_ERROR,
+    error_code: None
+    internal_message: "something bad happened".to_string(),
+    external_message: "Internal Error".to_string(),
+};
+```
++
+Instead, write:
++
+```rust
+let err = dropshot::HttpError {
+    status_code: ErrorStatusCode::INTERNAL_SERVER_ERROR,
+    error_code: None
+    internal_message: "something bad happened".to_string(),
+    external_message: "Internal Error".to_string(),
+    headers: None, // <-- Add this
+};
+```
++
+Similarly, code which destructures `HttpError`s, such as in a `match` or `let`
+expression, must now either destructure the `headers` field or add `..` to
+ignore it.
+
 === Other notable changes
 
 * Endpoint handler functions may now return any error type that implements the

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -88,33 +88,7 @@ error.
 * `HttpError` now contains an `Option<Box<http::HeaderMap>>` of headers to add
 to error responses constructed for the error.
 +
-Code which constructs `HttpError` literals must now initialize this field. For
-example, this will no longer compile:
-+
-```rust
-let err = dropshot::HttpError {
-    status_code: ErrorStatusCode::INTERNAL_SERVER_ERROR,
-    error_code: None
-    internal_message: "something bad happened".to_string(),
-    external_message: "Internal Error".to_string(),
-};
-```
-+
-Instead, write:
-+
-```rust
-let err = dropshot::HttpError {
-    status_code: ErrorStatusCode::INTERNAL_SERVER_ERROR,
-    error_code: None
-    internal_message: "something bad happened".to_string(),
-    external_message: "Internal Error".to_string(),
-    headers: None, // <-- Add this
-};
-```
-+
-Similarly, code which destructures `HttpError`s, such as in a `match` or `let`
-expression, must now either destructure the `headers` field or add `..` to
-ignore it.
+Code which constructs `HttpError` literals must now initialize this field.
 
 === Other notable changes
 

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -118,7 +118,7 @@ pub struct HttpError {
     pub external_message: String,
     /// Error message recorded in the log for this error
     pub internal_message: String,
-    /// Headers which should be added to error responses generated from this
+    /// Headers that will be added to responses generated from this
     /// error.
     ///
     /// The [`http::HeaderMap`] is boxed to reduce the size of `HttpError`s
@@ -399,7 +399,7 @@ impl HttpError {
     ) -> hyper::Response<crate::Body> {
         let mut builder = hyper::Response::builder();
 
-        // Set the builder's initial `HeaderMap` to the headers recommended by
+        // Set the builder's initial `HeaderMap` to the headers specified by
         // the error, if any exist.  Replacing the initial `HeaderMap` is more
         // efficient than inserting each header from `self.headers` into the
         // builder one-by-one, as we can just reuse the existing header map.

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -120,6 +120,14 @@ pub struct HttpError {
     pub internal_message: String,
     /// Headers which should be added to error responses generated from this
     /// error.
+    ///
+    /// The [`http::HeaderMap`] is boxed to reduce the size of `HttpError`s
+    /// which don't contain a `HeaderMap` (the common case).  Unlike containers
+    /// such as `Vec` and `HashMap`, an empty [`http::HeaderMap`] contains a
+    /// fairly large number of fields, rather than being a pointer to a heap
+    /// allocation containing the actual data.  Thus, we store an
+    /// `Option<Box<HeaderMap>>` here, so that the empty case is just a null
+    /// pointer.
     pub headers: Option<Box<http::HeaderMap>>,
 }
 

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -308,9 +308,16 @@ impl HttpError {
         }
     }
 
-    /// Mutably borrow the `http::HeaderMap`
+    /// Mutably borrow the `http::HeaderMap` associated with this error, if one
+    /// exists.
     pub fn headers_mut(&mut self) -> Option<&mut http::HeaderMap> {
         self.headers.as_deref_mut()
+    }
+
+    /// Borrow the `http::HeaderMap` associated with this error, if one
+    /// exists.
+    pub fn headers_ref(&self) -> Option<&http::HeaderMap> {
+        self.headers.as_deref()
     }
 
     /// Adds a header to the [`http::HeaderMap`] of headers to add to responses
@@ -324,7 +331,7 @@ impl HttpError {
     ///   header name and value, respectively.
     /// - [`Err`]`(`[`http::Error`]`)` if the header name or value is invalid,
     ///   or the `HeaderMap` is full.
-    pub fn set_header<K, V>(
+    pub fn add_header<K, V>(
         &mut self,
         name: K,
         value: V,

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -305,16 +305,10 @@ impl HttpError {
         }
     }
 
-    /// Mutably borrow the `http::HeaderMap` associated with this error, if one
-    /// exists.
-    pub fn headers_mut(&mut self) -> Option<&mut http::HeaderMap> {
-        self.headers.as_deref_mut()
-    }
-
-    /// Borrow the `http::HeaderMap` associated with this error, if one
-    /// exists.
-    pub fn headers_ref(&self) -> Option<&http::HeaderMap> {
-        self.headers.as_deref()
+    /// Mutably borrow the `http::HeaderMap` associated with this error. If
+    /// there is no header map for this error, this method creates one.
+    pub fn headers_mut(&mut self) -> &mut http::HeaderMap {
+        self.headers.get_or_insert_with(|| Box::new(http::HeaderMap::new()))
     }
 
     /// Adds a header to the [`http::HeaderMap`] of headers to add to responses
@@ -343,9 +337,7 @@ impl HttpError {
             .map_err(Into::into)?;
         let value = <http::HeaderValue as TryFrom<V>>::try_from(value)
             .map_err(Into::into)?;
-        self.headers
-            .get_or_insert_with(|| Box::new(http::HeaderMap::default()))
-            .try_append(name, value)?;
+        self.headers_mut().try_append(name, value)?;
         Ok(self)
     }
 
@@ -382,9 +374,7 @@ impl HttpError {
             .map_err(Into::into)?;
         let value = <http::HeaderValue as TryFrom<V>>::try_from(value)
             .map_err(Into::into)?;
-        self.headers
-            .get_or_insert_with(|| Box::new(http::HeaderMap::default()))
-            .try_append(name, value)?;
+        self.headers_mut().try_append(name, value)?;
         Ok(self)
     }
 

--- a/dropshot/src/error.rs
+++ b/dropshot/src/error.rs
@@ -120,14 +120,11 @@ pub struct HttpError {
     pub internal_message: String,
     /// Headers that will be added to responses generated from this
     /// error.
-    ///
-    /// The [`http::HeaderMap`] is boxed to reduce the size of `HttpError`s
-    /// which don't contain a `HeaderMap` (the common case).  Unlike containers
-    /// such as `Vec` and `HashMap`, an empty [`http::HeaderMap`] contains a
-    /// fairly large number of fields, rather than being a pointer to a heap
-    /// allocation containing the actual data.  Thus, we store an
-    /// `Option<Box<HeaderMap>>` here, so that the empty case is just a null
-    /// pointer.
+    // This is boxed in obeisance to Clippy's `result_large_err` lint
+    // (https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err).
+    // While we could allow that lint for Dropshot, `HttpError` will also be a
+    // common return type for consumers of Dropshot, so let's not force users to
+    // also allow the lint.
     pub headers: Option<Box<http::HeaderMap>>,
 }
 

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -538,7 +538,13 @@ impl<Context: ServerContext> HttpRouter<Context> {
             );
 
             // Add `Allow` headers for the methods that *are* acceptable for
-            // this path.
+            // this path, as specified in § 15.5.0 RFC9110, which states:
+            //
+            // > The origin server MUST generate an Allow header field in a
+            // > 405 response containing a list of the target resource's
+            // > currently supported methods.
+            //
+            // See: https://httpwg.org/specs/rfc9110.html#status.405
             if let Some(hdrs) = err.headers_mut() {
                 hdrs.reserve(node.methods.len());
             }

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -543,7 +543,7 @@ impl<Context: ServerContext> HttpRouter<Context> {
                 hdrs.reserve(node.methods.len());
             }
             for allowed in node.methods.keys() {
-                err.set_header(http::header::ALLOW, allowed)
+                err.add_header(http::header::ALLOW, allowed)
                     .expect("method should be a valid allow header");
             }
             Err(err)

--- a/dropshot/src/router.rs
+++ b/dropshot/src/router.rs
@@ -545,7 +545,7 @@ impl<Context: ServerContext> HttpRouter<Context> {
             // > currently supported methods.
             //
             // See: https://httpwg.org/specs/rfc9110.html#status.405
-            if let Some(hdrs) = err.headers_mut() {
+            if let Some(hdrs) = err.headers.as_deref_mut() {
                 hdrs.reserve(node.methods.len());
             }
             for allowed in node.methods.keys() {


### PR DESCRIPTION
There are certain response headers which the HTTP standard specifies
that servers should send along with particular error responses or status
codes. For example, when returning a 405 Method Not Allowed status, 
[§ 15.5.0 RFC9110] states that:

> The origin server MUST generate an Allow header field in a 405
> response containing a list of the target resource's currently
> supported methods.

Currently, Dropshot does not do this, so we are technically not
compliant with RFC9110.

Similarly, some of Dropshot's extractors return error responses for
which we ought to emit headers. For example, the `TypedBody` extractor
will return a 415 Unsupported Media Type status, for which [§ 15.5.16
RFC9110] recommends returning an `Accept` or `Accept-Encoding` header
as appropriate:

> If the problem was caused by an unsupported content coding, the
> Accept-Encoding response header field (Section 12.5.3) ought to be
> used  to indicate which (if any) content codings would have been
> accepted in the request.
>
> On the other hand, if the cause was an unsupported media type, the
> Accept response header field (Section 12.5.1) can be used to indicate
> which media types would have been accepted in the request.

Note that, unlike the `Allow` header for 405 responses, this is just a
suggestion --- the RFC doesn't include normative language stating that
we MUST do this. But it's nice if we do.

Errors emitted internally by Dropshot are represented by the `HttpError`
type. Currently, there is no way for this type to provide headers which
should be added to responses generated from an `HttpError`. Therefore,
this branch does so by adding a `http::HeaderMap` to `HttpError`. When
the `HttpError` is converted into a response, any headers in the
`HeaderMap` are added to the response. Adding this field is a breaking
change, so I've added it to the changelog.

Because the `http::HeaderMap` type is fairly large even when empty, the
`HeaderMap` is stored in an `Option<Box<HeaderMap>>` to reduce the size
of `HttpError`s, especially in the common case where there is no header
map to add. Unlike containers such as `Vec` and `HashMap`, an empty
`http::HeaderMap` contains a fairly large number of fields, rather than
being a single pointer to a heap allocation containing the actual data.
Thus, we store an `Option<Box<HeaderMap>>` here, so that the empty case
is just a null pointer. Not doing this results in a clippy warning
on...every function returning a `Result<_, HttpError>`, which is
unfortunate because even if we ignored that lint in Dropshot, it would
still trigger for consumers of Dropshot's APIs.

As an initial proof of concept, I've added code to dropshot's router
module to add `Allow` headers with the list of allowed methods when
returning a 405 Method Not Allowed error. There are other places where
we should be returning headers in our error responses, but this felt
like one of the more important ones, since the RFC says we MUST do it.
We can add headers to other errors separately; my priority was to make
the breaking parts of the change first.

For example, note that we now return `Allow` headers in responses to
requests with invalid methods:

```console
eliza@noctis ~/Code/dropshot $ cargo run --example basic &
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/examples/basic`
Dec 04 18:51:47.826 INFO listening, local_addr: 127.0.0.1:41751

eliza@noctis ~/Code/dropshot $ curl -v http://localhost:41751/counter -X DELETE
* Host localhost:41751 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:41751...
* connect to ::1 port 41751 from ::1 port 53992 failed: Connection refused
*   Trying 127.0.0.1:41751...
* Connected to localhost (127.0.0.1) port 41751
* using HTTP/1.x
> DELETE /counter HTTP/1.1
> Host: localhost:41751
> User-Agent: curl/8.11.0
> Accept: */*
>
* Request completely sent off
Dec 04 18:59:14.913 INFO accepted connection, remote_addr: 127.0.0.1:35084, local_addr: 127.0.0.1:41751
Dec 04 18:59:14.917 INFO request completed, error_message_external: Method Not Allowed, error_message_internal: Method Not Allowed, latency_us: 834, response_code: 405, uri: /counter, method: DELETE, req_id: e1d14d57-ca67-49cc-84b0-d1dc1e0e5793, remote_addr: 127.0.0.1:35084, local_addr: 127.0.0.1:41751
< HTTP/1.1 405 Method Not Allowed
< allow: GET
< allow: PUT
< content-type: application/json
< x-request-id: e1d14d57-ca67-49cc-84b0-d1dc1e0e5793
< content-length: 93
< date: Wed, 04 Dec 2024 18:59:14 GMT
<
{
  "request_id": "e1d14d57-ca67-49cc-84b0-d1dc1e0e5793",
  "message": "Method Not Allowed"
* Connection #0 to host localhost left intact
}%

```

[§ 15.5.0 RFC9110]: https://httpwg.org/specs/rfc9110.html#status.405
[§ 15.5.16 RFC9110]: https://httpwg.org/specs/rfc9110.html#status.415