### PR TITLE
handler.rs: fix typo

### DIFF
--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -326,7 +326,7 @@ impl HandlerError {
     pub(crate) fn external_message(&self) -> Option<&String> {
         match self {
             Self::Handler { .. } => None,
-            Self::Dropshot(ref e) => Some(&e.internal_message),
+            Self::Dropshot(ref e) => Some(&e.external_message),
         }
     }
 


### PR DESCRIPTION
Looks like a copy-paste that wasn't then edited afterwards. Noticed it while messing around with

https://github.com/nshalman/dropshot/commit/34c441b8e394873af0a2b33217405e637b5a84ae

This is just a bug report with a patch. Feel free to re-implement in a different commit elsewhere, etc.