### PR TITLE
[DRAFT - DO NOT MERGE] Basic OpenTelemetry integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomicwrites"
@@ -111,23 +111,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -138,21 +138,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -168,15 +162,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -195,18 +189,24 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -232,22 +232,22 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -255,37 +255,33 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -299,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "debug-ignore"
@@ -311,9 +307,9 @@ checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -371,7 +367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -392,7 +388,7 @@ dependencies = [
  "expectorate",
  "form_urlencoded",
  "futures",
- "hostname 0.4.0",
+ "hostname 0.4.1",
  "http",
  "http-body-util",
  "hyper",
@@ -405,6 +401,12 @@ dependencies = [
  "mime_guess",
  "multer",
  "openapiv3",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
  "paste",
  "pem",
  "percent-encoding",
@@ -435,6 +437,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "trybuild",
  "usdt",
@@ -472,46 +475,52 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.4"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.0.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -520,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -542,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -667,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -677,44 +686,48 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "goblin"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
@@ -723,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -742,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -754,9 +767,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hostname"
@@ -771,13 +784,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows-link",
 ]
 
 [[package]]
@@ -816,21 +829,21 @@ dependencies = [
 
 [[package]]
 name = "http-range"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee9694f83d9b7c09682fdb32213682939507884e5bcf227be9aff5d644b90dc"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -874,20 +887,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.5",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -903,7 +915,7 @@ dependencies = [
  "hyper",
  "mime_guess",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "winapi",
@@ -953,35 +965,46 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
- "once_cell",
+ "log",
  "wasm-bindgen",
- "winapi",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -991,30 +1014,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1022,65 +1025,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1096,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1117,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -1133,20 +1123,29 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -1171,6 +1170,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libredox"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,33 +1187,37 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match_cfg"
@@ -1223,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.0"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap"
@@ -1239,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -1255,22 +1268,22 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1292,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1334,39 +1347,36 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openapiv3"
@@ -1381,11 +1391,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1407,20 +1417,116 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "opentelemetry",
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1431,15 +1537,15 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1447,15 +1553,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1482,20 +1588,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1503,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1516,20 +1622,39 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.12"
+name = "pin-project"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1539,9 +1664,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -1550,10 +1675,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "portable-atomic"
-version = "1.9.0"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1563,9 +1691,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.26",
+]
 
 [[package]]
 name = "pretty-hex"
@@ -1575,9 +1706,9 @@ checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1593,46 +1724,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.4"
+name = "prost"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d2fb862b7ba45e615c1429def928f2e15f815bdf933b27a2d3824e224c1f46"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.13",
+ "rustls 0.23.28",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "rand",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
- "rustls 0.23.13",
+ "rustls 0.23.28",
+ "rustls-pki-types",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -1650,15 +1811,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.4"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1668,25 +1844,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
+name = "rand_core"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "rand_core",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1704,21 +1890,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.11",
- "redox_syscall",
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1774,13 +1961,15 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls 0.27.3",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -1790,7 +1979,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1798,7 +1987,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tower",
  "tower-http",
  "tower-service",
@@ -1806,18 +1995,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.11",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1825,15 +2014,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1841,7 +2030,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1850,14 +2039,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1870,30 +2059,30 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1904,11 +2093,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
  "rustls-pki-types",
 ]
 
@@ -1918,6 +2106,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1933,22 +2122,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.5"
+name = "rustls-webpki"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -2020,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2031,11 +2231,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2044,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2080,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2157,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2183,18 +2383,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple-mermaid"
@@ -2204,12 +2404,9 @@ checksum = "589144a964b4b30fe3a83b4bb1a09e2475aac194ec832a046a23e75bddf9eb29"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slog"
@@ -2268,15 +2465,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2306,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2323,18 +2520,18 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2347,7 +2544,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2370,9 +2567,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
@@ -2381,9 +2578,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2400,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -2449,29 +2646,28 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "4.0.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "once_cell",
+ "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -2486,15 +2682,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2502,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2512,18 +2708,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2577,12 +2773,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.13",
- "rustls-pki-types",
+ "rustls 0.23.28",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2600,16 +2806,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2654,6 +2859,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,11 +2896,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2700,9 +2926,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2722,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2742,10 +2968,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
+name = "tracing-opentelemetry"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2761,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
@@ -2792,7 +3036,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -2800,42 +3044,39 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"
@@ -2925,12 +3166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,7 +3177,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -2977,25 +3212,24 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -3028,12 +3262,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -3072,9 +3307,19 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3082,18 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3116,11 +3352,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3130,35 +3366,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.52.0"
+name = "windows-core"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-implement"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
- "windows-targets 0.52.6",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c44a98275e31bfd112bb06ba96c8ab13c03383a3753fdddd715406a1824c7e0"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -3167,44 +3419,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3226,18 +3454,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.42.2"
+name = "windows-sys"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3249,7 +3471,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -3257,10 +3479,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+name = "windows-targets"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3269,10 +3501,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3281,10 +3513,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
+name = "windows_aarch64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3293,16 +3525,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
+name = "windows_i686_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3311,10 +3549,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
+name = "windows_i686_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3323,10 +3561,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+name = "windows_x86_64_gnu"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3335,10 +3573,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3347,34 +3585,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yasna"
@@ -3387,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3399,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3411,19 +3649,39 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3432,18 +3690,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3453,15 +3711,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3470,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +434,8 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-tungstenite",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "trybuild",
  "usdt",
  "uuid",
@@ -1202,6 +1213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1392,6 +1422,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1684,6 +1720,50 @@ dependencies = [
  "getrandom 0.2.11",
  "redox_syscall",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2084,6 +2164,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2616,7 +2705,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2626,6 +2727,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2816,6 +2947,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -50,6 +50,14 @@ tokio-rustls = "0.25.0"
 toml = "0.8.23"
 waitgroup = "0.1.2"
 
+opentelemetry = { version = "0.30", optional = true }
+opentelemetry-http = { version = "0.30", features = ["hyper"], optional = true }
+opentelemetry-semantic-conventions = { version = "0.30", optional = true }
+opentelemetry-otlp = { version = "0.30", features = ["tonic"], optional = true }
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"], optional = true }
+opentelemetry-stdout = { version = "0.30", optional = true }
+tracing-opentelemetry = { version = "0.31", optional = true }
+
 [dependencies.chrono]
 version = "0.4.41"
 features = [ "serde", "std", "clock" ]
@@ -139,6 +147,7 @@ version_check = "0.9.5"
 usdt-probes = ["usdt/asm"]
 internal-docs = ["simple-mermaid"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
+otel-tracing = ["tracing", "opentelemetry", "opentelemetry-http", "opentelemetry-semantic-conventions", "opentelemetry-otlp", "opentelemetry_sdk", "opentelemetry-stdout", "tracing-opentelemetry"]
 
 [package.metadata.docs.rs]
 features = ["internal-docs"]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -43,6 +43,8 @@ slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
 slog-json = "2.6.1"
 slog-term = "2.9.1"
+tracing = { version = "0.1.40", optional = true }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }
 thiserror = "2.0.12"
 tokio-rustls = "0.25.0"
 toml = "0.8.23"
@@ -136,6 +138,7 @@ version_check = "0.9.5"
 [features]
 usdt-probes = ["usdt/asm"]
 internal-docs = ["simple-mermaid"]
+tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 [package.metadata.docs.rs]
 features = ["internal-docs"]

--- a/dropshot/examples/otel.rs
+++ b/dropshot/examples/otel.rs
@@ -211,9 +211,8 @@ async fn example_api_get_counter(
 async fn example_api_error(
     _rqctx: RequestContext<ExampleContext>,
 ) -> Result<HttpResponseOk<CounterValue>, HttpError> {
-    // XXX this should always show up in the logs
     #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
-    tracing::warn!("About to return an error for demonstration XXX FINDME");
+    tracing::warn!("About to return an error for demonstration");
     let error =
         HttpError::for_internal_error("This endpoint is broken".to_string());
     #[cfg(any(feature = "tracing", feature = "otel-tracing"))]

--- a/dropshot/examples/otel.rs
+++ b/dropshot/examples/otel.rs
@@ -1,0 +1,317 @@
+// Copyright 2025 Oxide Computer Company
+//! Example use of Dropshot with OpenTelemetry integration.
+//!
+//! Dropshot's built-in OpenTelemetry support will automatically parse
+//! standard OTEL environment variables.
+//! If you launch an otel-collector or otel-enabled jaeger-all-in-one
+//! listening for otlp over http, then you can do:
+//!
+//! ```bash
+//! export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+//! export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+//! cargo run --features=otel-tracing --example otel&
+//! curl http://localhost:4000/get
+//! ```
+//!
+//! And you should see an example trace.
+
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::HttpResponseUpdatedNoContent;
+use dropshot::HttpServerStarter;
+use dropshot::RequestContext;
+use dropshot::TypedBody;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+use tracing;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let config_dropshot = ConfigDropshot {
+        bind_address: "127.0.0.1:4000".parse().unwrap(),
+        ..Default::default()
+    };
+
+    // For simplicity, we'll configure an "info"-level logger that writes to
+    // stderr assuming that it's a terminal.
+    let config_logging =
+        ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info };
+    let log = config_logging
+        .to_logger("example-basic")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    // Initialize tracing with both slog bridge and OpenTelemetry support
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    let _tracing_guard = dropshot::tracing_support::init_tracing(&log)
+        .await
+        .map_err(|e| format!("failed to initialize tracing: {}", e))?;
+
+    // Build a description of the API.
+    let mut api = ApiDescription::new();
+    api.register(example_api_get_counter).unwrap();
+    api.register(example_api_put_counter).unwrap();
+    api.register(example_api_get).unwrap();
+    api.register(example_api_error).unwrap();
+    api.register(example_api_panic).unwrap();
+    api.register(example_api_sleep).unwrap();
+    api.register(example_api_exit).unwrap();
+
+    // The functions that implement our API endpoints will share this context.
+    let api_context = ExampleContext::new();
+
+    // Set up the server.
+    let server =
+        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+            .map_err(|error| format!("failed to create server: {}", error))?
+            .start();
+
+    let shutdown = server.wait_for_shutdown();
+
+    tokio::task::spawn(async move {
+        loop {
+            if server.app_private().shutdown.load(Ordering::SeqCst) {
+                break;
+            } else {
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        }
+        server.close().await.unwrap();
+    });
+
+    // From a separate task, wait for the server to stop.
+    shutdown.await
+}
+
+/// Application-specific example context (state shared by handler functions)
+#[derive(Debug)]
+struct ExampleContext {
+    /// counter that can be manipulated by requests to the HTTP API
+    counter: AtomicU64,
+    shutdown: AtomicBool,
+}
+
+impl ExampleContext {
+    /// Return a new ExampleContext.
+    pub fn new() -> ExampleContext {
+        ExampleContext {
+            counter: AtomicU64::new(0),
+            shutdown: AtomicBool::new(false),
+        }
+    }
+}
+
+// HTTP API interface
+
+/// `CounterValue` represents the value of the API's counter, either as the
+/// response to a GET request to fetch the counter or as the body of a PUT
+/// request to update the counter.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+struct CounterValue {
+    counter: u64,
+}
+
+/// Demonstrates creating child spans for internal operations using tracing instrumentation
+#[endpoint {
+    method = GET,
+    path = "/get",
+}]
+#[cfg_attr(
+any(feature = "tracing", feature = "otel-tracing"),
+tracing::instrument(skip(rqctx), fields(counter_processing = tracing::field::Empty)))]
+async fn example_api_get(
+    rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::info!("Starting counter fetch with processing");
+
+    // Simulate some work
+    fetch_counter_with_delay().await;
+
+    let api_context = rqctx.context();
+    let counter_value = api_context.counter.load(Ordering::SeqCst);
+
+    // Do some "processing" that would benefit from being traced
+    let processed_value = process_counter_value(counter_value).await;
+
+    // Record the processing result in the span
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::Span::current().record("counter_processing", processed_value);
+
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::info!(
+        processed_value = processed_value,
+        "Counter processing completed"
+    );
+
+    Ok(HttpResponseOk(CounterValue { counter: processed_value }))
+}
+
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument
+)]
+async fn fetch_counter_with_delay() {
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::debug!("Simulating work");
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+}
+
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument
+)]
+async fn process_counter_value(counter_value: u64) -> u64 {
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::debug!(input_value = counter_value, "Processing counter value");
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let result = counter_value * 2; // Some arbitrary processing
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::debug!(output_value = result, "Counter processing complete");
+    result
+}
+
+/// Fetch the current value of the counter.
+#[endpoint {
+    method = GET,
+    path = "/counter",
+}]
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument(skip(rqctx))
+)]
+async fn example_api_get_counter(
+    rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    let api_context = rqctx.context();
+    let counter = api_context.counter.load(Ordering::SeqCst);
+
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::info!(counter_value = counter, "Retrieved counter value");
+
+    Ok(HttpResponseOk(CounterValue { counter }))
+}
+
+/// Demonstrates error tracing - errors will be marked on the span
+#[endpoint {
+    method = GET,
+    path = "/error",
+}]
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument(skip(_rqctx))
+)]
+async fn example_api_error(
+    _rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    // XXX this should always show up in the logs
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::warn!("About to return an error for demonstration XXX FINDME");
+    let error =
+        HttpError::for_internal_error("This endpoint is broken".to_string());
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::error!(error = ?error, "Returning demonstration error");
+    Err(error)
+}
+
+/// Demonstrates panic handling - panics are converted to 500 errors and traced
+#[endpoint {
+    method = GET,
+    path = "/panic",
+}]
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument(skip(_rqctx))
+)]
+async fn example_api_panic(
+    _rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    panic!("This handler panics to demonstrate error tracing");
+}
+
+/// Takes too long so the client disconnects
+#[endpoint {
+    method = GET,
+    path = "/sleep",
+}]
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument(skip(_rqctx))
+)]
+async fn example_api_sleep(
+    _rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseOk<CounterValue>, HttpError> {
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    Err(HttpError::for_internal_error(
+        "This endpoint takes too long".to_string(),
+    ))
+}
+
+/// Exit shortcut
+#[endpoint {
+    method = GET,
+    path = "/exit",
+}]
+#[cfg_attr(
+    any(feature = "tracing", feature = "otel-tracing"),
+    tracing::instrument(skip(rqctx))
+)]
+async fn example_api_exit(
+    rqctx: RequestContext<ExampleContext>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    rqctx.context().shutdown.store(true, Ordering::SeqCst);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/// Update the current value of the counter.  Note that the special value of 10
+/// is not allowed (just to demonstrate how to generate an error).
+#[endpoint {
+    method = PUT,
+    path = "/counter",
+}]
+#[cfg_attr(
+any(feature = "tracing", feature = "otel-tracing"),
+tracing::instrument(skip(rqctx, update), fields(new_value = tracing::field::Empty)))]
+async fn example_api_put_counter(
+    rqctx: RequestContext<ExampleContext>,
+    update: TypedBody<CounterValue>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+    let updated_value = update.into_inner();
+
+    // Record the new value in the span
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::Span::current().record("new_value", updated_value.counter);
+    #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+    tracing::info!(
+        new_counter_value = updated_value.counter,
+        "Updating counter"
+    );
+
+    if updated_value.counter == 10 {
+        #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+        tracing::warn!(
+            rejected_value = updated_value.counter,
+            "Rejecting forbidden value"
+        );
+        Err(HttpError::for_bad_request(
+            Some(String::from("BadInput")),
+            format!("do not like the number {}", updated_value.counter),
+        ))
+    } else {
+        api_context.counter.store(updated_value.counter, Ordering::SeqCst);
+        #[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+        tracing::info!(
+            updated_counter = updated_value.counter,
+            "Counter updated successfully"
+        );
+        Ok(HttpResponseUpdatedNoContent())
+    }
+}

--- a/dropshot/src/handler.rs
+++ b/dropshot/src/handler.rs
@@ -287,6 +287,7 @@ where
 /// This type is not exported to Dropshot consumers; it is purely an internal
 /// implementation detail of the interface between `HttpHandlerFunc` and the
 /// server.
+#[derive(Debug)]
 pub enum HandlerError {
     /// An error returned by a fallible handler function itself.
     ///

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -852,11 +852,15 @@ mod from_map;
 mod handler;
 mod http_util;
 mod logging;
+#[cfg(feature = "otel-tracing")]
+pub mod otel;
 mod pagination;
 mod router;
 mod schema_util;
 mod server;
 mod to_map;
+#[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+pub mod tracing_support;
 mod type_util;
 mod versioning;
 mod websocket;
@@ -946,8 +950,6 @@ pub use server::ServerBuilder;
 pub use server::ServerContext;
 pub use server::ShutdownWaitFuture;
 pub use server::{HttpServer, HttpServerStarter};
-#[cfg(feature = "tracing")]
-pub use tracing::{debug, error, info, trace, warn}; // Re-export tracing macros for convenience
 pub use versioning::ClientSpecifiesVersionInHeader;
 pub use versioning::DynamicVersionPolicy;
 pub use versioning::VersionPolicy;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -946,6 +946,8 @@ pub use server::ServerBuilder;
 pub use server::ServerContext;
 pub use server::ShutdownWaitFuture;
 pub use server::{HttpServer, HttpServerStarter};
+#[cfg(feature = "tracing")]
+pub use tracing::{debug, error, info, trace, warn}; // Re-export tracing macros for convenience
 pub use versioning::ClientSpecifiesVersionInHeader;
 pub use versioning::DynamicVersionPolicy;
 pub use versioning::VersionPolicy;

--- a/dropshot/src/logging.rs
+++ b/dropshot/src/logging.rs
@@ -14,6 +14,11 @@ use std::io::LineWriter;
 use std::io::Write;
 use std::{io, path::Path};
 
+#[cfg(feature = "tracing")]
+use tracing_subscriber::layer::SubscriberExt;
+#[cfg(feature = "tracing")]
+use tracing_subscriber::Layer;
+
 /// Represents the logging configuration for a server.  This is expected to be a
 /// top-level block in a TOML config file, although that's not required.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -72,12 +77,12 @@ impl ConfigLogging {
         &self,
         log_name: S,
     ) -> Result<Logger, io::Error> {
-        match self {
+        let logger = match self {
             ConfigLogging::StderrTerminal { level } => {
                 let decorator = slog_term::TermDecorator::new().build();
                 let drain =
                     slog_term::FullFormat::new(decorator).build().fuse();
-                Ok(async_root_logger(level, drain))
+                async_root_logger(level, drain)
             }
 
             ConfigLogging::File { level, path, if_exists } => {
@@ -133,9 +138,23 @@ impl ConfigLogging {
                     );
                 }
 
-                Ok(logger)
+                logger
+            }
+        };
+
+        // Initialize tracing bridge automatically if feature is enabled
+        #[cfg(feature = "tracing")]
+        {
+            if let Err(e) = init_tracing_bridge(&logger) {
+                slog::error!(
+                    logger,
+                    "failed to initialize tracing bridge";
+                    "error" => %e,
+                );
             }
         }
+
+        Ok(logger)
     }
 }
 
@@ -175,6 +194,190 @@ fn log_drain_for_file(
     let log_name_box = Box::new(log_name);
     let log_name_leaked = Box::leak(log_name_box);
     Ok(slog_bunyan::with_name(log_name_leaked, file).build().fuse())
+}
+
+#[cfg(feature = "tracing")]
+/// A tracing subscriber layer that bridges tracing events to slog.
+/// This allows users to use tracing macros while maintaining slog compatibility.
+pub struct SlogTracingBridge {
+    logger: slog::Logger,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogTracingBridge {
+    pub fn new(logger: slog::Logger) -> Self {
+        Self { logger }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl<S> Layer<S> for SlogTracingBridge
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let metadata = event.metadata();
+        let level = match *metadata.level() {
+            tracing::Level::TRACE => slog::Level::Trace,
+            tracing::Level::DEBUG => slog::Level::Debug,
+            tracing::Level::INFO => slog::Level::Info,
+            tracing::Level::WARN => slog::Level::Warning,
+            tracing::Level::ERROR => slog::Level::Error,
+        };
+
+        // Extract the message and key-value pairs from the tracing event
+        let mut visitor = SlogEventVisitor::new();
+        event.record(&mut visitor);
+
+        // Log to slog with the extracted data
+        let message = visitor.message.unwrap_or_else(|| "".to_string());
+
+        // Create a dynamic key-value object for slog
+        let kv = SlogKV::new(visitor.fields);
+
+        // Use slog macros based on level with proper key-value pairs
+        match level {
+            slog::Level::Trace => {
+                slog::trace!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Debug => {
+                slog::debug!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Info => {
+                slog::info!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Warning => {
+                slog::warn!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Error => {
+                slog::error!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Critical => {
+                slog::crit!(self.logger, "{}", message; kv)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tracing")]
+/// Wrapper for different value types that can be logged
+#[derive(Debug, Clone)]
+enum SlogValue {
+    Str(String),
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+    Debug(String),
+}
+
+#[cfg(feature = "tracing")]
+/// Helper struct to pass tracing fields as slog key-value pairs
+struct SlogKV {
+    fields: Vec<(String, SlogValue)>,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogKV {
+    fn new(fields: Vec<(String, SlogValue)>) -> Self {
+        Self { fields }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl slog::KV for SlogKV {
+    fn serialize(
+        &self,
+        _record: &slog::Record,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        for (key, value) in &self.fields {
+            let key = slog::Key::from(key.clone());
+            match value {
+                SlogValue::Str(s) => serializer.emit_str(key, s)?,
+                SlogValue::I64(i) => serializer.emit_i64(key, *i)?,
+                SlogValue::U64(u) => serializer.emit_u64(key, *u)?,
+                SlogValue::Bool(b) => serializer.emit_bool(key, *b)?,
+                SlogValue::Debug(s) => serializer.emit_str(key, s)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "tracing")]
+/// Visitor to extract fields from tracing events
+struct SlogEventVisitor {
+    message: Option<String>,
+    fields: Vec<(String, SlogValue)>,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogEventVisitor {
+    fn new() -> Self {
+        Self { message: None, fields: Vec::new() }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl tracing::field::Visit for SlogEventVisitor {
+    fn record_debug(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        if field.name() == "message" {
+            self.message = Some(format!("{:?}", value));
+        } else {
+            self.fields.push((
+                field.name().to_string(),
+                SlogValue::Debug(format!("{:?}", value)),
+            ));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.fields.push((
+                field.name().to_string(),
+                SlogValue::Str(value.to_string()),
+            ));
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields.push((field.name().to_string(), SlogValue::I64(value)));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields.push((field.name().to_string(), SlogValue::U64(value)));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields.push((field.name().to_string(), SlogValue::Bool(value)));
+    }
+}
+
+#[cfg(feature = "tracing")]
+/// Initialize tracing with slog bridge support
+pub fn init_tracing_bridge(
+    logger: &slog::Logger,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Check if a global subscriber has already been set
+    if tracing::dispatcher::has_been_set() {
+        return Ok(());
+    }
+
+    let bridge = SlogTracingBridge::new(logger.clone());
+    let subscriber = tracing_subscriber::registry().with(bridge);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
 }
 
 #[cfg(test)]
@@ -574,5 +777,299 @@ mod test {
         assert_eq!(log_records[0].msg, "message3_debug");
         assert_eq!(log_records[1].msg, "message3_warn");
         assert_eq!(log_records[2].msg, "message3_error");
+    }
+
+    /// Test that the tracing-to-slog bridge works with basic logging
+    #[test]
+    fn test_tracing_bridge_basic() {
+        let mut logtest = LogTest::setup("tracing_bridge_basic");
+        let logpath = logtest.will_create_file("bridge.log");
+
+        // Windows paths need to have \ turned into \\
+        let escaped_path =
+            logpath.display().to_string().escape_default().to_string();
+
+        let config = format!(
+            r#"
+            mode = "file"
+            level = "info"
+            if_exists = "truncate"
+            path = "{}"
+            "#,
+            escaped_path
+        );
+
+        {
+            let logger =
+                read_config_and_create_logger("tracing_bridge_basic", &config)
+                    .unwrap();
+
+            // Test slog logging
+            slog::info!(logger, "slog message"; "slog_key" => "slog_value", "slog_num" => 42);
+
+            // Test tracing logging (bridge is automatically initialized when feature is enabled)
+            #[cfg(feature = "tracing")]
+            {
+                tracing::info!(
+                    tracing_key = "tracing_value",
+                    tracing_num = 84,
+                    "tracing message"
+                );
+            }
+
+            // Explicitly drop the logger to ensure async drain flushes
+            drop(logger);
+        }
+
+        // Retry reading the log file to handle async drain flushing
+        let log_records = {
+            let mut records = Vec::new();
+            for _ in 0..10 {
+                records = read_bunyan_log(&logpath);
+                #[cfg(feature = "tracing")]
+                if records.len() >= 2 {
+                    break;
+                }
+                #[cfg(not(feature = "tracing"))]
+                if records.len() >= 1 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            records
+        };
+
+        assert_eq!(log_records[0].msg, "slog message");
+        #[cfg(not(feature = "tracing"))]
+        {
+            assert_eq!(log_records.len(), 1);
+        }
+        #[cfg(feature = "tracing")]
+        {
+            assert_eq!(log_records.len(), 2);
+            assert_eq!(log_records[1].msg, "tracing message");
+            // Check that the structured fields are preserved
+            let log_json: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(&logpath)
+                    .unwrap()
+                    .lines()
+                    .last()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(log_json["tracing_key"], "tracing_value");
+            assert_eq!(log_json["tracing_num"], 84);
+        }
+    }
+
+    /// Test the SlogKV implementation with different value types
+    #[test]
+    #[cfg(feature = "tracing")]
+    fn test_slog_kv_types() {
+        use super::{SlogKV, SlogValue};
+        use slog::KV;
+
+        let fields = vec![
+            (
+                "str_field".to_string(),
+                SlogValue::Str("test_string".to_string()),
+            ),
+            ("i64_field".to_string(), SlogValue::I64(-123)),
+            ("u64_field".to_string(), SlogValue::U64(456)),
+            ("bool_field".to_string(), SlogValue::Bool(true)),
+            (
+                "debug_field".to_string(),
+                SlogValue::Debug("debug_value".to_string()),
+            ),
+        ];
+
+        let kv = SlogKV::new(fields);
+
+        // Create a mock serializer to test the KV implementation
+        struct MockSerializer {
+            pub calls: std::cell::RefCell<Vec<(String, String)>>,
+        }
+
+        impl slog::Serializer for MockSerializer {
+            fn emit_str(&mut self, key: slog::Key, val: &str) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("str:{}", val)));
+                Ok(())
+            }
+
+            fn emit_i64(&mut self, key: slog::Key, val: i64) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("i64:{}", val)));
+                Ok(())
+            }
+
+            fn emit_u64(&mut self, key: slog::Key, val: u64) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("u64:{}", val)));
+                Ok(())
+            }
+
+            fn emit_bool(&mut self, key: slog::Key, val: bool) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("bool:{}", val)));
+                Ok(())
+            }
+
+            fn emit_arguments(
+                &mut self,
+                _key: slog::Key,
+                _val: &std::fmt::Arguments,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_unit(&mut self, _key: slog::Key) -> slog::Result {
+                Ok(())
+            }
+            fn emit_char(
+                &mut self,
+                _key: slog::Key,
+                _val: char,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u8(&mut self, _key: slog::Key, _val: u8) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i8(&mut self, _key: slog::Key, _val: i8) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u16(&mut self, _key: slog::Key, _val: u16) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i16(&mut self, _key: slog::Key, _val: i16) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u32(&mut self, _key: slog::Key, _val: u32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i32(&mut self, _key: slog::Key, _val: i32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_f32(&mut self, _key: slog::Key, _val: f32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_f64(&mut self, _key: slog::Key, _val: f64) -> slog::Result {
+                Ok(())
+            }
+            fn emit_usize(
+                &mut self,
+                _key: slog::Key,
+                _val: usize,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_isize(
+                &mut self,
+                _key: slog::Key,
+                _val: isize,
+            ) -> slog::Result {
+                Ok(())
+            }
+        }
+
+        let mut serializer =
+            MockSerializer { calls: std::cell::RefCell::new(Vec::new()) };
+
+        // Test serialization
+        let args = format_args!("test message");
+        let record = slog::Record::new(
+            &slog::RecordStatic {
+                location: &slog::RecordLocation {
+                    file: "test",
+                    line: 1,
+                    column: 1,
+                    function: "test",
+                    module: "test",
+                },
+                level: slog::Level::Info,
+                tag: "test",
+            },
+            &args,
+            slog::BorrowedKV(&()),
+        );
+
+        kv.serialize(&record, &mut serializer).unwrap();
+
+        let calls = serializer.calls.borrow();
+        assert_eq!(calls.len(), 5);
+        assert_eq!(
+            calls[0],
+            ("str_field".to_string(), "str:test_string".to_string())
+        );
+        assert_eq!(calls[1], ("i64_field".to_string(), "i64:-123".to_string()));
+        assert_eq!(calls[2], ("u64_field".to_string(), "u64:456".to_string()));
+        assert_eq!(
+            calls[3],
+            ("bool_field".to_string(), "bool:true".to_string())
+        );
+        assert_eq!(
+            calls[4],
+            ("debug_field".to_string(), "str:debug_value".to_string())
+        );
+    }
+
+    /// Test the SlogEventVisitor field extraction (without creating real tracing fields)
+    #[test]
+    #[cfg(feature = "tracing")]
+    fn test_slog_event_visitor() {
+        use super::{SlogEventVisitor, SlogValue};
+
+        let mut visitor = SlogEventVisitor::new();
+
+        // Create mock data - we can't easily create real tracing::field::Field instances
+        // in tests, so we'll test by directly populating the visitor fields
+
+        // Directly populate the visitor with test data
+        visitor.fields.push((
+            "str_key".to_string(),
+            SlogValue::Str("string_value".to_string()),
+        ));
+        visitor.fields.push(("i64_key".to_string(), SlogValue::I64(-789)));
+        visitor.fields.push(("u64_key".to_string(), SlogValue::U64(101112)));
+        visitor.fields.push(("bool_key".to_string(), SlogValue::Bool(false)));
+        visitor.message = Some("test message".to_string());
+
+        // Check message extraction
+        assert_eq!(visitor.message, Some("test message".to_string()));
+
+        // Check field extraction and types
+        assert_eq!(visitor.fields.len(), 4);
+
+        let (key, value) = &visitor.fields[0];
+        assert_eq!(key, "str_key");
+        match value {
+            SlogValue::Str(s) => assert_eq!(s, "string_value"),
+            _ => panic!("Expected Str variant"),
+        }
+
+        let (key, value) = &visitor.fields[1];
+        assert_eq!(key, "i64_key");
+        match value {
+            SlogValue::I64(i) => assert_eq!(*i, -789),
+            _ => panic!("Expected I64 variant"),
+        }
+
+        let (key, value) = &visitor.fields[2];
+        assert_eq!(key, "u64_key");
+        match value {
+            SlogValue::U64(u) => assert_eq!(*u, 101112),
+            _ => panic!("Expected U64 variant"),
+        }
+
+        let (key, value) = &visitor.fields[3];
+        assert_eq!(key, "bool_key");
+        match value {
+            SlogValue::Bool(b) => assert_eq!(*b, false),
+            _ => panic!("Expected Bool variant"),
+        }
     }
 }

--- a/dropshot/src/otel.rs
+++ b/dropshot/src/otel.rs
@@ -1,0 +1,205 @@
+// Copyright 2025 Oxide Computer Company
+//! OpenTelemetry tracing support for Dropshot HTTP servers
+//!
+//! This module provides OpenTelemetry integration via tracing-opentelemetry.
+//! All functionality is gated behind the `otel-tracing` feature flag.
+
+use opentelemetry::{global, trace::TracerProvider};
+use opentelemetry_http::HeaderExtractor;
+use std::sync::OnceLock;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+static TRACER_PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    OnceLock::new();
+
+/// Initialize OpenTelemetry tracing with auto-configuration from environment.
+///
+/// This function reads standard OpenTelemetry environment variables like:
+/// - `OTEL_SERVICE_NAME`
+/// - `OTEL_EXPORTER_OTLP_ENDPOINT`
+/// - `OTEL_EXPORTER_OTLP_PROTOCOL`
+///
+/// If no OTLP endpoint is configured, traces will be printed to stdout
+/// in debug builds but not in release builds.
+///
+/// Returns a guard that will shutdown the tracer provider when dropped.
+pub async fn init_tracing(
+    service_name: &str,
+) -> Result<impl Drop, Box<dyn std::error::Error + Send + Sync>> {
+    use opentelemetry_sdk::{
+        resource::{ResourceDetector, SdkProvidedResourceDetector},
+        trace::SdkTracerProvider,
+    };
+
+    // If the environment variable wasn't set, use the value
+    // that was provided to this function.
+    if std::env::var("OTEL_SERVICE_NAME").is_err() {
+        std::env::set_var("OTEL_SERVICE_NAME", service_name);
+    }
+    let resource = SdkProvidedResourceDetector.detect();
+
+    let tracer_provider =
+        if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
+            // Use OTLP exporter if endpoint is configured
+            use opentelemetry_otlp::SpanExporter;
+            let exporter = SpanExporter::builder().with_http().build()?;
+            SdkTracerProvider::builder()
+                .with_resource(resource)
+                .with_batch_exporter(exporter)
+                .build()
+        } else {
+            // In debug builds, use stdout exporter for development/testing
+            // In release builds, don't ship spans at all
+            #[cfg(debug_assertions)]
+            {
+                use opentelemetry_stdout::SpanExporter;
+                let exporter = SpanExporter::default();
+                SdkTracerProvider::builder()
+                    .with_resource(resource)
+                    .with_simple_exporter(exporter)
+                    .build()
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                // No exporter for release builds - spans will be dropped
+                SdkTracerProvider::builder().with_resource(resource).build()
+            }
+        };
+
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // Set up W3C traceparent header propagation
+    global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+
+    // Store the provider in static for flushing
+    TRACER_PROVIDER
+        .set(tracer_provider.clone())
+        .expect("Tracer provider already set");
+
+    // Set up tracing-opentelemetry integration
+    // We use the tracer provider directly instead of the global tracer to get proper types
+    let telemetry = OpenTelemetryLayer::new(tracer_provider.tracer("dropshot"));
+
+    // Initialize tracing subscriber with OpenTelemetry layer
+    // This will work with existing slog bridge if the "tracing" feature is enabled
+    if tracing::dispatcher::has_been_set() {
+        // If tracing is already initialized (e.g., by slog bridge), we need to
+        // reinitialize with both the existing layers and the OpenTelemetry layer.
+        // We can't add layers to an existing subscriber, so we need to rebuild it.
+
+        // Create a new subscriber with just the OpenTelemetry layer.
+        // Note: This will replace the existing subscriber, which may include a slog bridge.
+        // The slog logging will still work through the slog logger directly, but tracing
+        // events will now go through OpenTelemetry instead of the slog bridge.
+        let new_subscriber = tracing_subscriber::registry().with(telemetry);
+        tracing::subscriber::set_global_default(new_subscriber).map_err(
+            |e| {
+                format!(
+                    "Failed to reinitialize tracing with OpenTelemetry: {}",
+                    e
+                )
+            },
+        )?;
+    } else {
+        // Initialize fresh tracing subscriber
+        tracing_subscriber::registry().with(telemetry).init();
+    }
+
+    // Return a guard that shuts down the provider when dropped
+    Ok(TracingGuard { _provider: tracer_provider })
+}
+
+/// Guard that ensures proper shutdown of the tracer provider.
+struct TracingGuard {
+    _provider: opentelemetry_sdk::trace::SdkTracerProvider,
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        // Force shutdown of the provider to ensure all spans are exported
+        if let Err(e) = self._provider.force_flush() {
+            eprintln!("Failed to flush traces on shutdown: {}", e);
+        }
+        if let Err(e) = self._provider.shutdown() {
+            eprintln!("Failed to shutdown tracer provider: {}", e);
+        }
+    }
+}
+
+/// Extract OpenTelemetry context from HTTP request headers.
+/// This should be called at the start of request processing to establish proper trace context.
+pub fn extract_context_from_request(
+    request: &hyper::Request<hyper::body::Incoming>,
+) -> opentelemetry::Context {
+    // Extract parent context from headers using the global text map propagator
+    // This handles W3C traceparent headers and other propagation formats
+    global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(request.headers()))
+    })
+}
+
+/// Force flush any pending spans to ensure they are exported immediately.
+/// This is useful in error scenarios to ensure spans are not lost.
+pub fn flush_spans() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(e) = provider.force_flush() {
+            eprintln!("Failed to force flush spans: {}", e);
+        }
+    }
+}
+
+/// Create an HTTP request span with proper parent context inheritance
+pub fn create_request_span(
+    request: &hyper::Request<hyper::body::Incoming>,
+    request_id: &str,
+    remote_addr: std::net::SocketAddr,
+) -> tracing::Span {
+    let parent_context = extract_context_from_request(request);
+    let guard = opentelemetry::Context::attach(parent_context);
+    let span = tracing::info_span!(
+        "http_request",
+        http.request.method = %request.method(),
+        http.request.uri = %request.uri(),
+        http.request.id = %request_id,
+        client.address = %remote_addr.ip(),
+        client.port = remote_addr.port(),
+        user_agent.original = request.headers().get("user-agent")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or(""),
+        otel.kind = "server",
+        http.response.status_code = tracing::field::Empty,
+        error = tracing::field::Empty,
+        error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty
+    );
+    drop(guard);
+    span
+}
+
+/// Record client disconnect information on a span
+pub fn record_disconnect_on_span(span: &tracing::Span) {
+    span.record("http.response.status_code", 499);
+    span.record("error", true);
+    span.record("error.type", "client_disconnect");
+    span.record(
+        "error.message",
+        "Client disconnected before response returned",
+    );
+    flush_spans();
+}
+
+/// Record error information on a span
+pub fn record_error_on_span(span: &tracing::Span, status: u16, message: &str) {
+    span.record("http.response.status_code", status);
+    span.record("error", true);
+    span.record("error.message", message);
+    flush_spans();
+}
+
+/// Record successful response information on a span
+pub fn record_success_on_span(span: &tracing::Span, status: u16) {
+    span.record("http.response.status_code", status);
+}

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -806,6 +806,9 @@ async fn http_request_handle_wrap<C: ServerContext>(
     #[cfg(feature = "otel-tracing")]
     let disconnect_span_clone = request_span.clone();
 
+    #[cfg(feature = "usdt-probes")]
+    let request_id_for_usdt = request_id.clone();
+
     // In the case the client disconnects early, the scopeguard allows us
     // to perform extra housekeeping before this task is dropped.
     let on_disconnect = guard((), move |_| {
@@ -821,7 +824,7 @@ async fn http_request_handle_wrap<C: ServerContext>(
         #[cfg(feature = "usdt-probes")]
         probes::request__done!(|| {
             crate::dtrace::ResponseInfo {
-                id: request_id.clone(),
+                id: request_id_for_usdt,
                 local_addr,
                 remote_addr,
                 // 499 is a non-standard code popularized by nginx to mean "client disconnected".

--- a/dropshot/src/tracing_support.rs
+++ b/dropshot/src/tracing_support.rs
@@ -127,7 +127,7 @@ async fn create_otel_tracer() -> Result<
 
     // Set service name if not already set, using crate name from compile time
     if std::env::var("OTEL_SERVICE_NAME").is_err() {
-        std::env::set_var("OTEL_SERVICE_NAME", env!("CARGO_PKG_NAME"));
+        std::env::set_var("OTEL_SERVICE_NAME", env!("CARGO_CRATE_NAME"));
     }
 
     let resource = SdkProvidedResourceDetector.detect();

--- a/dropshot/src/tracing_support.rs
+++ b/dropshot/src/tracing_support.rs
@@ -1,0 +1,674 @@
+// Copyright 2025 Oxide Computer Company
+//! Unified tracing support for Dropshot HTTP servers
+//!
+//! This module consolidates all tracing functionality including:
+//! - Slog bridge for tracing -> slog compatibility
+//! - OpenTelemetry integration
+//! - Unified initialization that supports both
+
+#[cfg(any(feature = "tracing", feature = "otel-tracing"))]
+use tracing_subscriber::prelude::*;
+
+#[cfg(feature = "otel-tracing")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "otel-tracing")]
+static TRACER_PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    OnceLock::new();
+
+/// Guard that ensures proper shutdown of tracing infrastructure
+pub struct TracingGuard {
+    #[cfg(feature = "otel-tracing")]
+    _otel_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+}
+
+#[cfg(feature = "otel-tracing")]
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = &self._otel_provider {
+            if let Err(e) = provider.force_flush() {
+                eprintln!("Failed to flush traces on shutdown: {}", e);
+            }
+            if let Err(e) = provider.shutdown() {
+                eprintln!("Failed to shutdown tracer provider: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "otel-tracing"))]
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        // Nothing to do when otel-tracing is not enabled
+    }
+}
+
+/// Initialize tracing with support for both slog bridge and OpenTelemetry
+pub async fn init_tracing(
+    #[allow(unused_variables)] logger: &slog::Logger,
+) -> Result<Option<TracingGuard>, Box<dyn std::error::Error + Send + Sync>> {
+    // Check if tracing has already been initialized
+    if tracing::dispatcher::has_been_set() {
+        return Ok(None);
+    }
+
+    // Build the subscriber based on enabled features
+    #[cfg(all(feature = "tracing", feature = "otel-tracing"))]
+    {
+        // Both features enabled - create layered subscriber
+        let bridge = SlogTracingBridge::new(logger.clone());
+
+        // Always try to initialize OpenTelemetry when the feature is enabled
+        {
+            // Create OpenTelemetry components
+            let (tracer_provider, tracer) = create_otel_tracer().await?;
+
+            // Create layers
+            let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+            // Build layered subscriber
+            let subscriber =
+                tracing_subscriber::registry().with(bridge).with(otel_layer);
+
+            tracing::subscriber::set_global_default(subscriber)?;
+
+            return Ok(Some(TracingGuard {
+                _otel_provider: Some(tracer_provider),
+            }));
+        }
+    }
+
+    #[cfg(all(feature = "tracing", not(feature = "otel-tracing")))]
+    {
+        // Only tracing feature - just slog bridge
+        let bridge = SlogTracingBridge::new(logger.clone());
+        let subscriber = tracing_subscriber::registry().with(bridge);
+        tracing::subscriber::set_global_default(subscriber)?;
+
+        return Ok(Some(TracingGuard {
+            #[cfg(feature = "otel-tracing")]
+            _otel_provider: None,
+        }));
+    }
+
+    #[cfg(all(not(feature = "tracing"), feature = "otel-tracing"))]
+    {
+        // Only otel-tracing feature
+        let (tracer_provider, tracer) = create_otel_tracer().await?;
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = tracing_subscriber::registry().with(otel_layer);
+        tracing::subscriber::set_global_default(subscriber)?;
+
+        return Ok(Some(TracingGuard {
+            _otel_provider: Some(tracer_provider),
+        }));
+    }
+
+    #[cfg(not(any(feature = "tracing", feature = "otel-tracing")))]
+    {
+        // No features enabled
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "otel-tracing")]
+async fn create_otel_tracer() -> Result<
+    (
+        opentelemetry_sdk::trace::SdkTracerProvider,
+        opentelemetry_sdk::trace::Tracer,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    use opentelemetry::{global, trace::TracerProvider};
+    use opentelemetry_sdk::{
+        resource::{ResourceDetector, SdkProvidedResourceDetector},
+        trace::SdkTracerProvider,
+    };
+
+    // Set service name if not already set, using crate name from compile time
+    if std::env::var("OTEL_SERVICE_NAME").is_err() {
+        std::env::set_var("OTEL_SERVICE_NAME", env!("CARGO_PKG_NAME"));
+    }
+
+    let resource = SdkProvidedResourceDetector.detect();
+
+    let tracer_provider =
+        if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
+            // Use OTLP exporter if endpoint is configured
+            use opentelemetry_otlp::SpanExporter;
+            let exporter = SpanExporter::builder().with_http().build()?;
+            SdkTracerProvider::builder()
+                .with_resource(resource)
+                .with_batch_exporter(exporter)
+                .build()
+        } else {
+            // In debug builds, use stdout exporter for development/testing
+            // In release builds, don't export spans at all
+            #[cfg(debug_assertions)]
+            {
+                use opentelemetry_stdout::SpanExporter;
+                let exporter = SpanExporter::default();
+                SdkTracerProvider::builder()
+                    .with_resource(resource)
+                    .with_simple_exporter(exporter)
+                    .build()
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                SdkTracerProvider::builder().with_resource(resource).build()
+            }
+        };
+
+    // Set global tracer provider
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // Set up W3C traceparent header propagation
+    global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+
+    // Store provider for flushing
+    TRACER_PROVIDER.set(tracer_provider.clone()).ok(); // Ignore if already set
+
+    let tracer = tracer_provider.tracer("dropshot");
+
+    Ok((tracer_provider, tracer))
+}
+
+#[cfg(feature = "otel-tracing")]
+/// Extract OpenTelemetry context from HTTP request headers
+pub fn extract_context_from_request(
+    request: &hyper::Request<hyper::body::Incoming>,
+) -> opentelemetry::Context {
+    use opentelemetry::global;
+    use opentelemetry_http::HeaderExtractor;
+
+    global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(request.headers()))
+    })
+}
+
+#[cfg(feature = "otel-tracing")]
+/// Force flush any pending spans to ensure they are exported immediately
+pub fn flush_spans() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(e) = provider.force_flush() {
+            eprintln!("Failed to force flush spans: {}", e);
+        }
+    }
+}
+
+// Move SlogTracingBridge implementation here
+#[cfg(feature = "tracing")]
+use tracing_subscriber::Layer;
+
+#[cfg(feature = "tracing")]
+/// A tracing subscriber layer that bridges tracing events to slog
+pub struct SlogTracingBridge {
+    logger: slog::Logger,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogTracingBridge {
+    pub fn new(logger: slog::Logger) -> Self {
+        Self { logger }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl<S> Layer<S> for SlogTracingBridge
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let metadata = event.metadata();
+        let level = match *metadata.level() {
+            tracing::Level::TRACE => slog::Level::Trace,
+            tracing::Level::DEBUG => slog::Level::Debug,
+            tracing::Level::INFO => slog::Level::Info,
+            tracing::Level::WARN => slog::Level::Warning,
+            tracing::Level::ERROR => slog::Level::Error,
+        };
+
+        // Extract the message and key-value pairs from the tracing event
+        let mut visitor = SlogEventVisitor::new();
+        event.record(&mut visitor);
+
+        // Log to slog with the extracted data
+        let message = visitor.message.unwrap_or_else(|| "".to_string());
+
+        // Create a dynamic key-value object for slog
+        let kv = SlogKV::new(visitor.fields);
+
+        // Use slog macros based on level with proper key-value pairs
+        match level {
+            slog::Level::Trace => {
+                slog::trace!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Debug => {
+                slog::debug!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Info => {
+                slog::info!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Warning => {
+                slog::warn!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Error => {
+                slog::error!(self.logger, "{}", message; kv)
+            }
+            slog::Level::Critical => {
+                slog::crit!(self.logger, "{}", message; kv)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tracing")]
+/// Wrapper for different value types that can be logged
+#[derive(Debug, Clone)]
+enum SlogValue {
+    Str(String),
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+    Debug(String),
+}
+
+#[cfg(feature = "tracing")]
+/// Helper struct to pass tracing fields as slog key-value pairs
+struct SlogKV {
+    fields: Vec<(String, SlogValue)>,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogKV {
+    fn new(fields: Vec<(String, SlogValue)>) -> Self {
+        Self { fields }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl slog::KV for SlogKV {
+    fn serialize(
+        &self,
+        _record: &slog::Record,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        for (key, value) in &self.fields {
+            let key = slog::Key::from(key.clone());
+            match value {
+                SlogValue::Str(v) => serializer.emit_str(key, v)?,
+                SlogValue::I64(v) => serializer.emit_i64(key, *v)?,
+                SlogValue::U64(v) => serializer.emit_u64(key, *v)?,
+                SlogValue::Bool(v) => serializer.emit_bool(key, *v)?,
+                SlogValue::Debug(v) => serializer.emit_str(key, v)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "tracing")]
+/// Visitor to extract fields from tracing events
+struct SlogEventVisitor {
+    message: Option<String>,
+    fields: Vec<(String, SlogValue)>,
+}
+
+#[cfg(feature = "tracing")]
+impl SlogEventVisitor {
+    fn new() -> Self {
+        Self { message: None, fields: Vec::new() }
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl tracing::field::Visit for SlogEventVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.fields.push((
+                field.name().to_string(),
+                SlogValue::Str(value.to_string()),
+            ));
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields.push((field.name().to_string(), SlogValue::I64(value)));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields.push((field.name().to_string(), SlogValue::U64(value)));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields.push((field.name().to_string(), SlogValue::Bool(value)));
+    }
+
+    fn record_debug(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        if field.name() == "message" {
+            self.message = Some(format!("{:?}", value));
+        } else {
+            self.fields.push((
+                field.name().to_string(),
+                SlogValue::Debug(format!("{:?}", value)),
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::logging::test::read_config_and_create_logger;
+    use crate::logging::test::LogTest;
+    use crate::test_util::read_bunyan_log;
+    use crate::tracing_support;
+
+    /// Test that the tracing-to-slog bridge works with basic logging
+    #[tokio::test]
+    async fn test_tracing_bridge_basic() {
+        let mut logtest = LogTest::setup("tracing_bridge_basic");
+        let logpath = logtest.will_create_file("bridge.log");
+
+        // Windows paths need to have \ turned into \\
+        let escaped_path =
+            logpath.display().to_string().escape_default().to_string();
+
+        let config = format!(
+            r#"
+            mode = "file"
+            level = "info"
+            if_exists = "truncate"
+            path = "{}"
+            "#,
+            escaped_path
+        );
+
+        {
+            let logger =
+                read_config_and_create_logger("tracing_bridge_basic", &config)
+                    .unwrap();
+
+            let _tracing_guard =
+                tracing_support::init_tracing(&logger).await.unwrap();
+
+            // Test slog logging
+            slog::info!(logger, "slog message"; "slog_key" => "slog_value", "slog_num" => 42);
+
+            // Test tracing logging (bridge is automatically initialized when feature is enabled)
+            #[cfg(feature = "tracing")]
+            {
+                tracing::info!(
+                    tracing_key = "tracing_value",
+                    tracing_num = 84,
+                    "tracing message"
+                );
+            }
+
+            // Explicitly drop the logger to ensure async drain flushes
+            drop(logger);
+        }
+
+        // Retry reading the log file to handle async drain flushing
+        let log_records = {
+            let mut records = Vec::new();
+            for _ in 0..10 {
+                records = read_bunyan_log(&logpath);
+                #[cfg(feature = "tracing")]
+                if records.len() >= 2 {
+                    break;
+                }
+                #[cfg(not(feature = "tracing"))]
+                if records.len() >= 1 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            records
+        };
+
+        assert_eq!(log_records[0].msg, "slog message");
+        #[cfg(not(feature = "tracing"))]
+        {
+            assert_eq!(log_records.len(), 1);
+        }
+        #[cfg(feature = "tracing")]
+        {
+            assert_eq!(log_records.len(), 2);
+            assert_eq!(log_records[1].msg, "tracing message");
+            // Check that the structured fields are preserved
+            let log_json: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(&logpath)
+                    .unwrap()
+                    .lines()
+                    .last()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(log_json["tracing_key"], "tracing_value");
+            assert_eq!(log_json["tracing_num"], 84);
+        }
+    }
+
+    /// Test the SlogKV implementation with different value types
+    #[test]
+    #[cfg(feature = "tracing")]
+    fn test_slog_kv_types() {
+        use super::{SlogKV, SlogValue};
+        use slog::KV;
+
+        let fields = vec![
+            (
+                "str_field".to_string(),
+                SlogValue::Str("test_string".to_string()),
+            ),
+            ("i64_field".to_string(), SlogValue::I64(-123)),
+            ("u64_field".to_string(), SlogValue::U64(456)),
+            ("bool_field".to_string(), SlogValue::Bool(true)),
+            (
+                "debug_field".to_string(),
+                SlogValue::Debug("debug_value".to_string()),
+            ),
+        ];
+
+        let kv = SlogKV::new(fields);
+
+        // Create a mock serializer to test the KV implementation
+        struct MockSerializer {
+            pub calls: std::cell::RefCell<Vec<(String, String)>>,
+        }
+
+        impl slog::Serializer for MockSerializer {
+            fn emit_str(&mut self, key: slog::Key, val: &str) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("str:{}", val)));
+                Ok(())
+            }
+
+            fn emit_i64(&mut self, key: slog::Key, val: i64) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("i64:{}", val)));
+                Ok(())
+            }
+
+            fn emit_u64(&mut self, key: slog::Key, val: u64) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("u64:{}", val)));
+                Ok(())
+            }
+
+            fn emit_bool(&mut self, key: slog::Key, val: bool) -> slog::Result {
+                self.calls
+                    .borrow_mut()
+                    .push((key.as_ref().to_string(), format!("bool:{}", val)));
+                Ok(())
+            }
+
+            fn emit_arguments(
+                &mut self,
+                _key: slog::Key,
+                _val: &std::fmt::Arguments,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_unit(&mut self, _key: slog::Key) -> slog::Result {
+                Ok(())
+            }
+            fn emit_char(
+                &mut self,
+                _key: slog::Key,
+                _val: char,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u8(&mut self, _key: slog::Key, _val: u8) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i8(&mut self, _key: slog::Key, _val: i8) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u16(&mut self, _key: slog::Key, _val: u16) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i16(&mut self, _key: slog::Key, _val: i16) -> slog::Result {
+                Ok(())
+            }
+            fn emit_u32(&mut self, _key: slog::Key, _val: u32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_i32(&mut self, _key: slog::Key, _val: i32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_f32(&mut self, _key: slog::Key, _val: f32) -> slog::Result {
+                Ok(())
+            }
+            fn emit_f64(&mut self, _key: slog::Key, _val: f64) -> slog::Result {
+                Ok(())
+            }
+            fn emit_usize(
+                &mut self,
+                _key: slog::Key,
+                _val: usize,
+            ) -> slog::Result {
+                Ok(())
+            }
+            fn emit_isize(
+                &mut self,
+                _key: slog::Key,
+                _val: isize,
+            ) -> slog::Result {
+                Ok(())
+            }
+        }
+
+        let mut serializer =
+            MockSerializer { calls: std::cell::RefCell::new(Vec::new()) };
+
+        // Test serialization
+        let args = format_args!("test message");
+        let record = slog::Record::new(
+            &slog::RecordStatic {
+                location: &slog::RecordLocation {
+                    file: "test",
+                    line: 1,
+                    column: 1,
+                    function: "test",
+                    module: "test",
+                },
+                level: slog::Level::Info,
+                tag: "test",
+            },
+            &args,
+            slog::BorrowedKV(&()),
+        );
+
+        kv.serialize(&record, &mut serializer).unwrap();
+
+        let calls = serializer.calls.borrow();
+        assert_eq!(calls.len(), 5);
+        assert_eq!(
+            calls[0],
+            ("str_field".to_string(), "str:test_string".to_string())
+        );
+        assert_eq!(calls[1], ("i64_field".to_string(), "i64:-123".to_string()));
+        assert_eq!(calls[2], ("u64_field".to_string(), "u64:456".to_string()));
+        assert_eq!(
+            calls[3],
+            ("bool_field".to_string(), "bool:true".to_string())
+        );
+        assert_eq!(
+            calls[4],
+            ("debug_field".to_string(), "str:debug_value".to_string())
+        );
+    }
+
+    /// Test the SlogEventVisitor field extraction (without creating real tracing fields)
+    #[test]
+    #[cfg(feature = "tracing")]
+    fn test_slog_event_visitor() {
+        use super::{SlogEventVisitor, SlogValue};
+
+        let mut visitor = SlogEventVisitor::new();
+
+        // Create mock data - we can't easily create real tracing::field::Field instances
+        // in tests, so we'll test by directly populating the visitor fields
+
+        // Directly populate the visitor with test data
+        visitor.fields.push((
+            "str_key".to_string(),
+            SlogValue::Str("string_value".to_string()),
+        ));
+        visitor.fields.push(("i64_key".to_string(), SlogValue::I64(-789)));
+        visitor.fields.push(("u64_key".to_string(), SlogValue::U64(101112)));
+        visitor.fields.push(("bool_key".to_string(), SlogValue::Bool(false)));
+        visitor.message = Some("test message".to_string());
+
+        // Check message extraction
+        assert_eq!(visitor.message, Some("test message".to_string()));
+
+        // Check field extraction and types
+        assert_eq!(visitor.fields.len(), 4);
+
+        let (key, value) = &visitor.fields[0];
+        assert_eq!(key, "str_key");
+        match value {
+            SlogValue::Str(s) => assert_eq!(s, "string_value"),
+            _ => panic!("Expected Str variant"),
+        }
+
+        let (key, value) = &visitor.fields[1];
+        assert_eq!(key, "i64_key");
+        match value {
+            SlogValue::I64(i) => assert_eq!(*i, -789),
+            _ => panic!("Expected I64 variant"),
+        }
+
+        let (key, value) = &visitor.fields[2];
+        assert_eq!(key, "u64_key");
+        match value {
+            SlogValue::U64(u) => assert_eq!(*u, 101112),
+            _ => panic!("Expected U64 variant"),
+        }
+
+        let (key, value) = &visitor.fields[3];
+        assert_eq!(key, "bool_key");
+        match value {
+            SlogValue::Bool(b) => assert_eq!(*b, false),
+            _ => panic!("Expected Bool variant"),
+        }
+    }
+}

--- a/dropshot/tests/integration-tests/main.rs
+++ b/dropshot/tests/integration-tests/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Integration tests for Dropshot.
 //!
@@ -20,6 +20,7 @@ mod multipart;
 mod openapi;
 mod pagination;
 mod pagination_schema;
+mod panic_handling;
 mod path_names;
 mod starter;
 mod streaming;

--- a/dropshot/tests/integration-tests/panic_handling.rs
+++ b/dropshot/tests/integration-tests/panic_handling.rs
@@ -1,0 +1,85 @@
+// Copyright 2025 Oxide Computer Company
+
+//! Test cases for handler panic handling.
+
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::HandlerTaskMode;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::RequestContext;
+use http::Method;
+use http::StatusCode;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::common;
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct EmptyResult {}
+
+#[endpoint {
+    method = GET,
+    path = "/panic",
+}]
+async fn handler_that_panics(
+    _rqctx: RequestContext<()>,
+) -> Result<HttpResponseOk<EmptyResult>, HttpError> {
+    panic!("test panic message");
+}
+
+#[tokio::test]
+async fn test_panic_handler_returns_500_in_detached_mode() {
+    let mut api = ApiDescription::new();
+    api.register(handler_that_panics).unwrap();
+
+    let testctx = common::test_setup_with_context(
+        "test_panic_handler_returns_500_in_detached_mode",
+        api,
+        (),
+        HandlerTaskMode::Detached,
+    );
+
+    testctx
+        .client_testctx
+        .make_request_error(
+            Method::GET,
+            "/panic",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+
+    testctx.teardown().await;
+}
+
+// Note: We cannot easily test CancelOnDisconnect mode panic behavior in a unit test
+// because panics propagate through the test harness and cause test failures.
+// The key difference is:
+// - Detached mode: Panics are caught and converted to 500 errors (tested above)
+// - CancelOnDisconnect mode: Panics propagate and crash the handler (as intended)
+// For now this test is just marked as should_panic.
+// TODO: Should this test be removed?
+#[tokio::test]
+#[should_panic]
+async fn test_panic_handler_returns_500_in_cancel_on_disconnect_mode() {
+    let mut api = ApiDescription::new();
+    api.register(handler_that_panics).unwrap();
+
+    let testctx = common::test_setup_with_context(
+        "test_panic_handler_returns_500_in_cancel_on_disconnect_mode",
+        api,
+        (),
+        HandlerTaskMode::CancelOnDisconnect,
+    );
+
+    testctx
+        .client_testctx
+        .make_request_error(
+            Method::GET,
+            "/panic",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+
+    testctx.teardown().await;
+}


### PR DESCRIPTION
# OpenTelemetry for Dropshot

This is now version 2. It has leaned into the use of `tokio-tracing` and `opentelemetry-tracing`.
The `tracing` feature funnels tracing logs out to `slog` for unified logging.
The `otel-tracing` feature enables shipping traces via OTLP.
They can be used together or individually.

Checklist of things that are needed (note that much of it is currently incomplete):
- [x] Documentation
- [ ] Tests
- [ ] All desired fields properly traced
- [x] Examples including how to do propagation

# Known Issues

~~- If a handler panics, currently we get a 499 error span. I don't really like that.~~ See #1359 

# dtrace.conf(24) References

Slides: 
https://docs.google.com/presentation/d/1AW_ugVrmkXDTROgPbEt7bCLrLhFo8-z13PoJAdfPO78/

Raw video link:
https://www.youtube.com/watch?v=KQN1t2qlhaw&t=11760s

# Screenshot

![image](https://github.com/user-attachments/assets/b8eebcb0-7cda-4442-8360-2398ccce34e3)
