### PR TITLE
Fix argument inconsistency in example documentation

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 Oxide Computer Company
+// Copyright 2024 Brianna Bennett
 
 //! Dropshot is a general-purpose crate for exposing REST APIs from a Rust
 //! program.  Planned highlights include:
@@ -50,7 +51,6 @@
 //! use dropshot::ConfigLoggingLevel;
 //! use dropshot::HandlerTaskMode;
 //! use dropshot::ServerBuilder;
-//! use std::sync::Arc;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), String> {
@@ -67,7 +67,7 @@
 //!     // Register API functions -- see detailed example or ApiDescription docs.
 //!
 //!     // Start the server.
-//!     let server = ServerBuilder::new(api, Arc::new(()), log)
+//!     let server = ServerBuilder::new(api, (), log)
 //!         .start()
 //!         .map_err(|error| format!("failed to start server: {}", error))?;
 //!


### PR DESCRIPTION
The "bare minimum" example has (among other things) this:

```
    let server = ServerBuilder::new(api, Arc::new(()), log)
        .start()
        .map_err(|error| format!("failed to start server: {}", error))?;
```

Then later the examples for registering APIs (both as a free function and as an API trait) don't wrap the argument in `Arc<>`.

This leads new users into a trap where these two (three) disconnected examples *seem* like they should work, but lead to a compile error once they add a handler.

Discussing with @davepacheco, it seems the consensus is that `Arc` is not particularly recommended here anymore.

This change will help new users walk right into a working example, rather than encountering an error.