### PR TITLE
server: Log HTTP response code as u16

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.16.0\...HEAD[Full list of commits]
 
+* https://github.com/oxidecomputer/dropshot/pull/1269[#1269] HTTP response codes are now logged as numeric values, rather than strings.
+
 == 0.16.0 (released 2025-02-19)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.15.1\...v0.16.0[Full list of commits]

--- a/dropshot/src/server.rs
+++ b/dropshot/src/server.rs
@@ -853,7 +853,7 @@ async fn http_request_handle_wrap<C: ServerContext>(
 
                 // TODO-debug: add request and response headers here
                 info!(request_log, "request completed";
-                    "response_code" => status.as_str(),
+                    "response_code" => status.as_u16(),
                     "latency_us" => latency_us,
                     "error_message_internal" => message_internal,
                     "error_message_external" => message_external,
@@ -865,7 +865,7 @@ async fn http_request_handle_wrap<C: ServerContext>(
         Ok(response) => {
             // TODO-debug: add request and response headers here
             info!(request_log, "request completed";
-                "response_code" => response.status().as_str(),
+                "response_code" => response.status().as_u16(),
                 "latency_us" => latency_us,
             );
 
@@ -942,11 +942,11 @@ async fn http_request_handle<C: ServerContext>(
                     match result {
                         Ok(r) => warn!(
                             request_log, "request completed after handler was already cancelled";
-                            "response_code" => r.status().as_str(),
+                            "response_code" => r.status().as_u16(),
                         ),
                         Err(error) => {
                             warn!(request_log, "request completed after handler was already cancelled";
-                                "response_code" => %error.status_code(),
+                                "response_code" => error.status_code().as_u16(),
                                 "error_message_internal" => error.internal_message(),
                                 "error_message_external" => error.external_message(),,
                             );


### PR DESCRIPTION
Currently HTTP response codes are generally logged as strings, which is a bit unintuitive as these are integers.

Log the response code as a numeric value.