### PR TITLE
Add a Header extractor for header parameters

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -1,4 +1,5 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
+
 //! Describes the endpoints and handler functions in your API
 
 use crate::extractor::RequestExtractor;
@@ -258,6 +259,9 @@ impl ApiEndpointParameter {
                 ApiEndpointParameterLocation::Query => {
                     ApiEndpointParameterMetadata::Query(name)
                 }
+                ApiEndpointParameterLocation::Header => {
+                    ApiEndpointParameterMetadata::Header(name)
+                }
             },
             description,
             required,
@@ -286,12 +290,14 @@ impl ApiEndpointParameter {
 pub enum ApiEndpointParameterLocation {
     Path,
     Query,
+    Header,
 }
 
 #[derive(Debug, Clone)]
 pub enum ApiEndpointParameterMetadata {
     Path(String),
     Query(String),
+    Header(String),
     Body(ApiEndpointBodyContentType),
 }
 
@@ -764,6 +770,9 @@ impl<Context: ServerContext> ApiDescription<Context> {
                         ApiEndpointParameterMetadata::Query(name) => {
                             (name, ApiEndpointParameterLocation::Query)
                         }
+                        ApiEndpointParameterMetadata::Header(name) => {
+                            (name, ApiEndpointParameterLocation::Header)
+                        }
                     };
 
                     let schema = match &param.schema {
@@ -805,6 +814,14 @@ impl<Context: ServerContext> ApiDescription<Context> {
                                 openapiv3::Parameter::Path {
                                     parameter_data,
                                     style: openapiv3::PathStyle::Simple,
+                                },
+                            ))
+                        }
+                        ApiEndpointParameterLocation::Header => {
+                            Some(openapiv3::ReferenceOr::Item(
+                                openapiv3::Parameter::Header {
+                                    parameter_data,
+                                    style: Default::default(),
                                 },
                             ))
                         }

--- a/dropshot/src/extractor/header.rs
+++ b/dropshot/src/extractor/header.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 Oxide Computer Company
+
+//! Header extractor
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    from_map::from_map, ApiEndpointBodyContentType,
+    ApiEndpointParameterLocation, HttpError, RequestContext, RequestInfo,
+    ServerContext,
+};
+
+use super::{metadata::get_metadata, ExtractorMetadata, SharedExtractor};
+
+pub struct Header<HeaderType: DeserializeOwned + JsonSchema + Send + Sync> {
+    inner: HeaderType,
+}
+
+impl<HeaderType: DeserializeOwned + JsonSchema + Send + Sync>
+    Header<HeaderType>
+{
+    pub fn into_inner(self) -> HeaderType {
+        self.inner
+    }
+}
+
+/// Given an HTTP request, pull out the headers and attempt to deserialize
+/// it as an instance of `HeaderType`.
+fn http_request_load_header<HeaderType>(
+    request: &RequestInfo,
+) -> Result<Header<HeaderType>, HttpError>
+where
+    HeaderType: DeserializeOwned + JsonSchema + Send + Sync,
+{
+    let headers = request
+        .headers()
+        .iter()
+        .map(|(k, v)| Ok((k.to_string(), v.to_str()?.to_string())))
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .map_err(|message: http::header::ToStrError| {
+            HttpError::for_bad_request(None, message.to_string())
+        })?;
+    let x: HeaderType = from_map(&headers).unwrap();
+    Ok(Header { inner: x })
+}
+
+#[async_trait]
+impl<HeaderType> SharedExtractor for Header<HeaderType>
+where
+    HeaderType: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+{
+    async fn from_request<Context: ServerContext>(
+        rqctx: &RequestContext<Context>,
+    ) -> Result<Header<HeaderType>, HttpError> {
+        http_request_load_header(&rqctx.request)
+    }
+
+    fn metadata(
+        _body_content_type: ApiEndpointBodyContentType,
+    ) -> ExtractorMetadata {
+        get_metadata::<HeaderType>(&ApiEndpointParameterLocation::Header)
+    }
+}

--- a/dropshot/src/extractor/mod.rs
+++ b/dropshot/src/extractor/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Extractors: traits and impls
 //!
@@ -23,6 +23,9 @@ pub use path::Path;
 
 mod query;
 pub use query::Query;
+
+mod header;
+pub use header::Header;
 
 mod raw_request;
 pub use raw_request::RawRequest;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Dropshot is a general-purpose crate for exposing REST APIs from a Rust
 //! program.  Planned highlights include:
@@ -894,6 +894,7 @@ pub use error_status_code::NotAClientError;
 pub use error_status_code::NotAnError;
 pub use extractor::ExclusiveExtractor;
 pub use extractor::ExtractorMetadata;
+pub use extractor::Header;
 pub use extractor::MultipartBody;
 pub use extractor::Path;
 pub use extractor::Query;

--- a/dropshot/tests/fail/bad_channel17.stderr
+++ b/dropshot/tests/fail/bad_channel17.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `WebsocketConnection: SharedExtractor` is not sati
    |                 ^^^^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `WebsocketConnection`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_channel18.stderr
+++ b/dropshot/tests/fail/bad_channel18.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `WebsocketConnection: SharedExtractor` is not sati
    |                ^^^^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `WebsocketConnection`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_channel19.stderr
+++ b/dropshot/tests/fail/bad_channel19.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `std::string::String: SharedExtractor` is not sati
    |        ^^^^^^ the trait `SharedExtractor` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_endpoint17.stderr
+++ b/dropshot/tests/fail/bad_endpoint17.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `TypedBody<Stuff>: SharedExtractor` is not satisfi
    |              ^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `TypedBody<Stuff>`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_endpoint18.stderr
+++ b/dropshot/tests/fail/bad_endpoint18.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `TypedBody<Stuff>: SharedExtractor` is not satisfi
    |              ^^^^^^^^^^^^^^^^ the trait `SharedExtractor` is not implemented for `TypedBody<Stuff>`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_endpoint19.stderr
+++ b/dropshot/tests/fail/bad_endpoint19.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `std::string::String: SharedExtractor` is not sati
    |              ^^^^^^ the trait `SharedExtractor` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
 note: required by a bound in `need_shared_extractor`

--- a/dropshot/tests/fail/bad_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_endpoint3.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `String: ExclusiveExtractor` is not satisfied
    |             ^^^^^^ the trait `SharedExtractor` is not implemented for `String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `String` to implement `ExclusiveExtractor`

--- a/dropshot/tests/fail/bad_trait_channel17.stderr
+++ b/dropshot/tests/fail/bad_trait_channel17.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `dropshot::WebsocketConnection: SharedExtractor` i
    |     ^ the trait `SharedExtractor` is not implemented for `dropshot::WebsocketConnection`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(dropshot::WebsocketConnection, WebsocketUpgrade)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_channel18.stderr
+++ b/dropshot/tests/fail/bad_trait_channel18.stderr
@@ -44,6 +44,7 @@ error[E0277]: the trait bound `dropshot::WebsocketConnection: SharedExtractor` i
    |     ^ the trait `SharedExtractor` is not implemented for `dropshot::WebsocketConnection`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(dropshot::WebsocketConnection, WebsocketUpgrade)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_channel19.stderr
+++ b/dropshot/tests/fail/bad_trait_channel19.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `std::string::String: SharedExtractor` is not sati
    |     ^ the trait `SharedExtractor` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(std::string::String, WebsocketUpgrade)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_endpoint17.stderr
+++ b/dropshot/tests/fail/bad_trait_endpoint17.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `dropshot::TypedBody<Stuff>: SharedExtractor` is n
    |     ^ the trait `SharedExtractor` is not implemented for `dropshot::TypedBody<Stuff>`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(dropshot::TypedBody<Stuff>, dropshot::UntypedBody)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_endpoint18.stderr
+++ b/dropshot/tests/fail/bad_trait_endpoint18.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `dropshot::TypedBody<Stuff>: SharedExtractor` is n
    |     ^ the trait `SharedExtractor` is not implemented for `dropshot::TypedBody<Stuff>`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(dropshot::TypedBody<Stuff>, dropshot::Query<Stuff>)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_endpoint19.stderr
+++ b/dropshot/tests/fail/bad_trait_endpoint19.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `std::string::String: SharedExtractor` is not sati
    |     ^ the trait `SharedExtractor` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `(std::string::String, dropshot::Query<QueryParams>)` to implement `dropshot::extractor::common::RequestExtractor`

--- a/dropshot/tests/fail/bad_trait_endpoint3.stderr
+++ b/dropshot/tests/fail/bad_trait_endpoint3.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `String: SharedExtractor` is not satisfied
    |     ^ the trait `SharedExtractor` is not implemented for `String`
    |
    = help: the following other types implement trait `SharedExtractor`:
+             dropshot::Header<HeaderType>
              dropshot::Path<PathType>
              dropshot::Query<QueryType>
    = note: required for `String` to implement `ExclusiveExtractor`

--- a/dropshot/tests/integration-tests/openapi.rs
+++ b/dropshot/tests/integration-tests/openapi.rs
@@ -3,12 +3,12 @@
 use dropshot::{
     channel, endpoint, http_response_found, http_response_see_other,
     http_response_temporary_redirect, ApiDescription,
-    ApiDescriptionRegisterError, FreeformBody, HttpError, HttpResponseAccepted,
-    HttpResponseCreated, HttpResponseDeleted, HttpResponseFound,
-    HttpResponseHeaders, HttpResponseOk, HttpResponseSeeOther,
-    HttpResponseTemporaryRedirect, HttpResponseUpdatedNoContent, MultipartBody,
-    PaginationParams, Path, Query, RequestContext, ResultsPage, TagConfig,
-    TagDetails, TypedBody, UntypedBody,
+    ApiDescriptionRegisterError, FreeformBody, Header, HttpError,
+    HttpResponseAccepted, HttpResponseCreated, HttpResponseDeleted,
+    HttpResponseFound, HttpResponseHeaders, HttpResponseOk,
+    HttpResponseSeeOther, HttpResponseTemporaryRedirect,
+    HttpResponseUpdatedNoContent, MultipartBody, PaginationParams, Path, Query,
+    RequestContext, ResultsPage, TagConfig, TagDetails, TypedBody, UntypedBody,
 };
 use dropshot::{Body, WebsocketConnection};
 use schemars::JsonSchema;
@@ -486,7 +486,7 @@ async fn handler26(
     Ok(HttpResponseCreated(Response {}))
 }
 
-// test: websocket using overriden operation id
+// test: websocket using overridden operation id
 #[channel {
     protocol = WEBSOCKETS,
     operation_id = "vzerolower",
@@ -498,6 +498,27 @@ async fn handler27(
     _: WebsocketConnection,
 ) -> dropshot::WebsocketChannelResult {
     Ok(())
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[allow(dead_code)]
+struct MyHeaders {
+    a: String,
+    b: Option<String>,
+}
+
+// test: header params
+#[endpoint {
+    operation_id = "hparam",
+    method = GET,
+    path = "/thing_with_headers",
+    tags = ["it"]
+}]
+async fn handler28(
+    _rqctx: RequestContext<()>,
+    _headers: Header<MyHeaders>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    Ok(HttpResponseUpdatedNoContent())
 }
 
 fn make_api(
@@ -536,6 +557,7 @@ fn make_api(
     api.register(handler25)?;
     api.register(handler26)?;
     api.register(handler27)?;
+    api.register(handler28)?;
     Ok(api)
 }
 

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -738,6 +738,43 @@
         }
       }
     },
+    "/thing_with_headers": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "hparam",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "b",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/too/smart/for/my/own/good": {
       "get": {
         "tags": [

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -746,6 +746,43 @@
         }
       }
     },
+    "/thing_with_headers": {
+      "get": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "hparam",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "b",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/too/smart/for/my/own/good": {
       "get": {
         "tags": [


### PR DESCRIPTION
I think `from_map` could be updated to be more elegant (it's basically the first Rust I ever wrote), but I think this will be fine in the meantime (and probably much longer).