### PR TITLE
various improvements to JSON schema processing

### DIFF
--- a/dropshot/src/extractor/common.rs
+++ b/dropshot/src/extractor/common.rs
@@ -15,7 +15,7 @@ pub struct ExtractorMetadata {
     pub parameters: Vec<ApiEndpointParameter>,
 }
 
-/// Extractors that require exclusive access to the underyling `hyper::Request`
+/// Extractors that require exclusive access to the underlying `hyper::Request`
 ///
 /// These extractors usually need to read the body of the request or else modify
 /// how the server treats the rest of it (e.g., websocket upgrade).  There may

--- a/dropshot/src/extractor/metadata.rs
+++ b/dropshot/src/extractor/metadata.rs
@@ -4,7 +4,7 @@ use crate::api_description::ApiSchemaGenerator;
 use crate::pagination::PAGINATION_PARAM_SENTINEL;
 use crate::schema_util::schema2struct;
 use crate::schema_util::schema_extensions;
-use crate::schema_util::ReferenceVisitor;
+use crate::schema_util::StructMember;
 use crate::websocket::WEBSOCKET_PARAM_SENTINEL;
 use crate::ApiEndpointParameter;
 use crate::ApiEndpointParameterLocation;
@@ -61,19 +61,19 @@ where
         true,
     )
     .into_iter()
-    .map(|struct_member| {
-        let mut s = struct_member.schema;
-        let mut visitor = ReferenceVisitor::new(&generator);
-        schemars::visit::visit_schema(&mut visitor, &mut s);
-
+    .map(|StructMember { name, description, schema, required }| {
         ApiEndpointParameter::new_named(
             loc,
-            struct_member.name,
-            struct_member.description,
-            struct_member.required,
+            name,
+            description,
+            required,
             ApiSchemaGenerator::Static {
-                schema: Box::new(s),
-                dependencies: visitor.dependencies(),
+                schema: Box::new(schema),
+                dependencies: generator
+                    .definitions()
+                    .clone()
+                    .into_iter()
+                    .collect(),
             },
             Vec::new(),
         )

--- a/dropshot/src/schema_util.rs
+++ b/dropshot/src/schema_util.rs
@@ -335,14 +335,26 @@ pub(crate) fn j2oas_schema(
         // when consumers use a type such as serde_json::Value.
         schemars::schema::Schema::Bool(true) => {
             openapiv3::ReferenceOr::Item(openapiv3::Schema {
-                schema_data: openapiv3::SchemaData::default(),
-                schema_kind: openapiv3::SchemaKind::Any(
-                    openapiv3::AnySchema::default(),
-                ),
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Any(Default::default()),
             })
         }
+        // The unsatisfiable, "match nothing" schema. We represent this as
+        // the `not` of the permissive schema.
         schemars::schema::Schema::Bool(false) => {
-            panic!("We don't expect to see a schema that matches the null set")
+            openapiv3::ReferenceOr::Item(openapiv3::Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Not {
+                    not: Box::new(openapiv3::ReferenceOr::Item(
+                        openapiv3::Schema {
+                            schema_data: Default::default(),
+                            schema_kind: openapiv3::SchemaKind::Any(
+                                Default::default(),
+                            ),
+                        },
+                    )),
+                },
+            })
         }
         schemars::schema::Schema::Object(obj) => j2oas_schema_object(name, obj),
     }

--- a/dropshot/tests/integration-tests/openapi.rs
+++ b/dropshot/tests/integration-tests/openapi.rs
@@ -601,7 +601,8 @@ struct XRustTypeParam {
 
 #[endpoint {
     method = PUT,
-    path = "/testing/{thing}"
+    path = "/testing/{thing}",
+    tags = ["it"]
 }]
 async fn handler30(
     _: RequestContext<()>,

--- a/dropshot/tests/integration-tests/openapi.rs
+++ b/dropshot/tests/integration-tests/openapi.rs
@@ -548,6 +548,68 @@ async fn handler29(
     todo!()
 }
 
+#[derive(Deserialize, JsonSchema)]
+struct PathArgs30 {
+    #[expect(unused)]
+    thing: WithXRustType<XRustTypeParam>,
+}
+
+#[derive(Deserialize, Debug)]
+struct WithXRustType<T> {
+    _data: T,
+}
+
+impl<T: JsonSchema> JsonSchema for WithXRustType<T> {
+    fn schema_name() -> String {
+        format!("WithXRustTypeFor{}", T::schema_name())
+    }
+
+    fn json_schema(
+        gen: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        let mut schema = SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(
+                InstanceType::String,
+            ))),
+            ..Default::default()
+        };
+
+        // Add the x-rust-type extension.
+        let mut extensions = schemars::Map::new();
+        let rust_type = serde_json::json!({
+            "crate": "foo",
+            "version": "*",
+            "path": "foo",
+            "parameters": [
+                gen.subschema_for::<T>(),
+            ],
+        });
+        extensions.insert("x-rust-type".to_string(), rust_type);
+        schema.extensions = extensions;
+
+        Schema::Object(schema)
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct XRustTypeParam {
+    #[expect(unused)]
+    data: String,
+}
+
+#[endpoint {
+    method = PUT,
+    path = "/testing/{thing}"
+}]
+async fn handler30(
+    _: RequestContext<()>,
+    _: Path<PathArgs30>,
+) -> Result<HttpResponseOk<CoolStruct>, HttpError> {
+    todo!();
+}
+
 fn make_api(
     maybe_tag_config: Option<TagConfig>,
 ) -> Result<ApiDescription<()>, ApiDescriptionRegisterError> {
@@ -586,6 +648,7 @@ fn make_api(
     api.register(handler27)?;
     api.register(handler28)?;
     api.register(handler29)?;
+    api.register(handler30)?;
     Ok(api)
 }
 

--- a/dropshot/tests/integration-tests/openapi.rs
+++ b/dropshot/tests/integration-tests/openapi.rs
@@ -551,7 +551,9 @@ async fn handler29(
 #[derive(Deserialize, JsonSchema)]
 struct PathArgs30 {
     #[expect(unused)]
-    thing: WithXRustType<XRustTypeParam>,
+    aa: WithXRustType<XRustAParam>,
+    #[expect(unused)]
+    bb: WithXRustType<XRustBParam>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -594,14 +596,17 @@ impl<T: JsonSchema> JsonSchema for WithXRustType<T> {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-struct XRustTypeParam {
+struct XRustAParam {
     #[expect(unused)]
     data: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+enum XRustBParam {}
+
 #[endpoint {
     method = PUT,
-    path = "/testing/{thing}",
+    path = "/testing/{aa}/{bb}",
     tags = ["it"]
 }]
 async fn handler30(

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -764,7 +764,7 @@
         }
       }
     },
-    "/testing/{thing}": {
+    "/testing/{aa}/{bb}": {
       "put": {
         "tags": [
           "it"
@@ -773,10 +773,18 @@
         "parameters": [
           {
             "in": "path",
-            "name": "thing",
+            "name": "aa",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/WithXRustTypeForXRustTypeParam"
+              "$ref": "#/components/schemas/WithXRustTypeForXRustAParam"
+            }
+          },
+          {
+            "in": "path",
+            "name": "bb",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WithXRustTypeForXRustBParam"
             }
           }
         ],
@@ -1224,12 +1232,12 @@
           "items"
         ]
       },
-      "WithXRustTypeForXRustTypeParam": {
+      "WithXRustTypeForXRustAParam": {
         "x-rust-type": {
           "crate": "foo",
           "parameters": [
             {
-              "$ref": "#/components/schemas/XRustTypeParam"
+              "$ref": "#/components/schemas/XRustAParam"
             }
           ],
           "path": "foo",
@@ -1237,7 +1245,20 @@
         },
         "type": "string"
       },
-      "XRustTypeParam": {
+      "WithXRustTypeForXRustBParam": {
+        "x-rust-type": {
+          "crate": "foo",
+          "parameters": [
+            {
+              "$ref": "#/components/schemas/XRustBParam"
+            }
+          ],
+          "path": "foo",
+          "version": "*"
+        },
+        "type": "string"
+      },
+      "XRustAParam": {
         "type": "object",
         "properties": {
           "data": {
@@ -1247,6 +1268,9 @@
         "required": [
           "data"
         ]
+      },
+      "XRustBParam": {
+        "not": {}
       },
       "Foo": {
         "type": "string"

--- a/dropshot/tests/test_openapi.json
+++ b/dropshot/tests/test_openapi.json
@@ -764,6 +764,42 @@
         }
       }
     },
+    "/testing/{thing}": {
+      "put": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "handler30",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thing",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WithXRustTypeForXRustTypeParam"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoolStruct"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/thing_with_headers": {
       "get": {
         "tags": [
@@ -1186,6 +1222,30 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "WithXRustTypeForXRustTypeParam": {
+        "x-rust-type": {
+          "crate": "foo",
+          "parameters": [
+            {
+              "$ref": "#/components/schemas/XRustTypeParam"
+            }
+          ],
+          "path": "foo",
+          "version": "*"
+        },
+        "type": "string"
+      },
+      "XRustTypeParam": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "Foo": {

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -772,6 +772,42 @@
         }
       }
     },
+    "/testing/{thing}": {
+      "put": {
+        "tags": [
+          "it"
+        ],
+        "operationId": "handler30",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thing",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WithXRustTypeForXRustTypeParam"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoolStruct"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/thing_with_headers": {
       "get": {
         "tags": [
@@ -1194,6 +1230,30 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "WithXRustTypeForXRustTypeParam": {
+        "x-rust-type": {
+          "crate": "foo",
+          "parameters": [
+            {
+              "$ref": "#/components/schemas/XRustTypeParam"
+            }
+          ],
+          "path": "foo",
+          "version": "*"
+        },
+        "type": "string"
+      },
+      "XRustTypeParam": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "Foo": {

--- a/dropshot/tests/test_openapi_fuller.json
+++ b/dropshot/tests/test_openapi_fuller.json
@@ -772,7 +772,7 @@
         }
       }
     },
-    "/testing/{thing}": {
+    "/testing/{aa}/{bb}": {
       "put": {
         "tags": [
           "it"
@@ -781,10 +781,18 @@
         "parameters": [
           {
             "in": "path",
-            "name": "thing",
+            "name": "aa",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/WithXRustTypeForXRustTypeParam"
+              "$ref": "#/components/schemas/WithXRustTypeForXRustAParam"
+            }
+          },
+          {
+            "in": "path",
+            "name": "bb",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WithXRustTypeForXRustBParam"
             }
           }
         ],
@@ -1232,12 +1240,12 @@
           "items"
         ]
       },
-      "WithXRustTypeForXRustTypeParam": {
+      "WithXRustTypeForXRustAParam": {
         "x-rust-type": {
           "crate": "foo",
           "parameters": [
             {
-              "$ref": "#/components/schemas/XRustTypeParam"
+              "$ref": "#/components/schemas/XRustAParam"
             }
           ],
           "path": "foo",
@@ -1245,7 +1253,20 @@
         },
         "type": "string"
       },
-      "XRustTypeParam": {
+      "WithXRustTypeForXRustBParam": {
+        "x-rust-type": {
+          "crate": "foo",
+          "parameters": [
+            {
+              "$ref": "#/components/schemas/XRustBParam"
+            }
+          ],
+          "path": "foo",
+          "version": "*"
+        },
+        "type": "string"
+      },
+      "XRustAParam": {
         "type": "object",
         "properties": {
           "data": {
@@ -1255,6 +1276,9 @@
         "required": [
           "data"
         ]
+      },
+      "XRustBParam": {
+        "not": {}
       },
       "Foo": {
         "type": "string"


### PR DESCRIPTION
@sunshowers noticed that we aren't including schemas in OpenAPI output that are only referenced by our custom `x-rust-type` extension. We can address this by massively simplifying how we process schemas. This is some very very old code in dropshot, and I'm not quite sure why it felt like the right approach, but we had been generating them schema, and then scraping out references using a visitor.... but the references were already present in the structures used to generate the schema. It's a bit perplexing why we took this extra step--perhaps there's some other shoe that will drop, but we've certainly developed many more tests since then, and none of them point to any reason why this excursion might have been necessary.

We also noticed that `schemars` allows for modeling a empty `enum` value e.g. `{ "enum": [] }` and `openapiv3` does not; `schemars` will also emit such a schema when the `JsonSchema` derive macro is applied to a never-type enum (e.g. `enum Foo {}). To handle this while preserving extensions we emit the following schema which **is** representable by `openapiv3` structures: `{ "not": {} }`.

And for funsies, we also handle the `false` schema using the same construction.