### PR TITLE
accept body parameters of the form application/subtype+json

### DIFF
--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -353,9 +353,7 @@ impl ApiEndpointBodyContentType {
 /// Split the mime type in to the type, subtype, and optional suffix
 /// components.
 fn mime_split(mime_type: &str) -> Option<(&str, &str, Option<&str>)> {
-    let mut parts = mime_type.splitn(2, '/');
-    let type_ = parts.next()?;
-    let rest = parts.next()?;
+    let (type_, rest) = mime_type.split_once('/')?;
     let mut sub_parts = rest.splitn(2, '+');
     let subtype = sub_parts.next()?;
     let suffix = sub_parts.next();

--- a/dropshot/src/api_description.rs
+++ b/dropshot/src/api_description.rs
@@ -335,9 +335,31 @@ impl ApiEndpointBodyContentType {
             CONTENT_TYPE_JSON => Ok(Self::Json),
             CONTENT_TYPE_URL_ENCODED => Ok(Self::UrlEncoded),
             CONTENT_TYPE_MULTIPART_FORM_DATA => Ok(Self::MultipartFormData),
-            _ => Err(mime_type.to_string()),
+            _ => match mime_split(mime_type) {
+                // We may see content-type that is of the form
+                // application/XXX+json which means "XXX protocol serialized as
+                // JSON". A more pedantic implementation might involve a server
+                // (or subset of its API) indicating that it expects (and
+                // produces) bodies in a particular format, but for now it
+                // suffices to treat input bodies of this form as equivalent to
+                // application/json.
+                Some(("application", _, Some("json"))) => Ok(Self::Json),
+                _ => Err(mime_type.to_string()),
+            },
         }
     }
+}
+
+/// Split the mime type in to the type, subtype, and optional suffix
+/// components.
+fn mime_split(mime_type: &str) -> Option<(&str, &str, Option<&str>)> {
+    let mut parts = mime_type.splitn(2, '/');
+    let type_ = parts.next()?;
+    let rest = parts.next()?;
+    let mut sub_parts = rest.splitn(2, '+');
+    let subtype = sub_parts.next()?;
+    let suffix = sub_parts.next();
+    Some((type_, subtype, suffix))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
To support SCIM support, dropshot needs to be able to accept requests whose `content-type` header is specifically `application/scim+json`. Taking this apart, this MIME type means "the SCIM protocol, serialized as JSON". One can think of it as strictly a subset of JSON i.e. all messages are in the SCIM protocol, but all are also valid JSON.

We have several options for how to address this. It would seem reasonable and robust to allow an `ApiDescription` (i.e. a collection of endpoints) for which we say "the input and response bodies are all SCIM protocol so application/scim+json is applicable" (and that might be inclusive or exclusive of application/json i.e. the `scim+` part might be optional). We could include this in the OpenAPI output to document the content type for body parameters and responses. This idea, however, requires something along the lines of what's imagined in PR #922 and hasn't been completed.

Instead, this PR implements a more expedient approach: treat `content-type: application/X+json` as `application/json`. This isn't wrong *per se* as the former is a subset of the latter, but it doesn't allow a consumer to impose a distinction between the two.

Closes #1383