### PR TITLE
add `TypedBody::map` and `TypedBody::try_map`

### DIFF
--- a/dropshot/src/extractor/body.rs
+++ b/dropshot/src/extractor/body.rs
@@ -45,6 +45,22 @@ impl<BodyType: JsonSchema + DeserializeOwned + Send + Sync>
     pub fn into_inner(self) -> BodyType {
         self.inner
     }
+
+    pub fn map<T, F>(self, f: F) -> TypedBody<T>
+    where
+        T: JsonSchema + DeserializeOwned + Send + Sync,
+        F: Fn(BodyType) -> T,
+    {
+        TypedBody { inner: f(self.inner) }
+    }
+
+    pub fn try_map<T, E, F>(self, f: F) -> Result<TypedBody<T>, E>
+    where
+        T: JsonSchema + DeserializeOwned + Send + Sync,
+        F: Fn(BodyType) -> Result<T, E>,
+    {
+        Ok(TypedBody { inner: f(self.inner)? })
+    }
 }
 
 #[derive(Debug)]

--- a/dropshot/src/extractor/body.rs
+++ b/dropshot/src/extractor/body.rs
@@ -46,6 +46,9 @@ impl<BodyType: JsonSchema + DeserializeOwned + Send + Sync>
         self.inner
     }
 
+    /// Convert this `TypedBody` into one with a different type parameter; this
+    /// may be useful when multiple, related endpoints take body parameters that
+    /// are similar and convertible into a common type.
     pub fn map<T, F>(self, f: F) -> TypedBody<T>
     where
         T: JsonSchema + DeserializeOwned + Send + Sync,
@@ -54,6 +57,7 @@ impl<BodyType: JsonSchema + DeserializeOwned + Send + Sync>
         TypedBody { inner: f(self.inner) }
     }
 
+    /// Similar to [`TypedBody::map`] but with support for fallibility.
     pub fn try_map<T, E, F>(self, f: F) -> Result<TypedBody<T>, E>
     where
         T: JsonSchema + DeserializeOwned + Send + Sync,


### PR DESCRIPTION
I'm working on a change which requires modifying a struct used in a versioned API. To keep the conversions as self-contained as possible, I'm wanting to do something along these lines:

```rust
/// Copies of data types that changed between v3 and v4.
mod v3;

#[dropshot::api_description]
pub trait MyApi {
    #[endpoint {
        method = PUT,
        path = "/config",
        versions = VERSION_ADD_CONFIG_FIELD..,
    }]
    async fn config_put(
        rqctx: RequestContext<Self::Context>,
        body: TypedBody<Config>,
    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;

    #[endpoint {
        operation_id = "config_put",
        method = PUT,
        path = "/config",
        versions = ..VERSION_ADD_CONFIG_FIELD,
    }]
    async fn v3_config_put(
        rqctx: RequestContext<Self::Context>,
        body: TypedBody<v3::Config>,
    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
        Self::config_put(rqctx, /* ??? */).await
    }
}
```

This keeps the actual implementation of this trait clean of any additional indirection required; only `config_put` needs to be implemented, as before.

Because a `TypedBody` can only be created by extracting the body from a request, it's not possible for me to call `config_put` directly. This PR adds `TypedBody::map` so that I can perform the conversion. In this particular case I'm writing `TypedBody::map(Into::into)` because I'm using the `From` trait to implement the necessary conversions.

I've also added a `try_map` method which does the same thing but can return a `Result`, so that we can potentially have a fallible transformation in the future.

This seems like the most useful solution. We could also `impl From<TypedBody<T>> for TypedBody<U> where U: From<T>` but I think that can get a little complex. Another solution which does not require any changes to Dropshot is to change the trait method signature to accept the object directly, remove the `#[endpoint]` macro, and create e.g. `v4_config_put` and `v3_config_put` methods which call the required method.