### PR TITLE
export semver out of the dropshot crate

### DIFF
--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -958,6 +958,7 @@ pub use websocket::WebsocketUpgrade;
 // Users of the `endpoint` macro need the following macros:
 pub use handler::RequestContextArgument;
 pub use http::Method;
+pub use semver;
 
 extern crate dropshot_endpoint;
 

--- a/dropshot_endpoint/src/metadata.rs
+++ b/dropshot_endpoint/src/metadata.rs
@@ -179,12 +179,16 @@ fn semver_parts(x: &semver::Version) -> (u64, u64, u64) {
     (x.major, x.minor, x.patch)
 }
 
-fn semver_expr(span: proc_macro2::Span, x: &VersionSpecifier) -> TokenStream {
+fn semver_expr(
+    dropshot: &TokenStream,
+    span: proc_macro2::Span,
+    x: &VersionSpecifier,
+) -> TokenStream {
     match x {
         VersionSpecifier::Literal(v) => {
             let (major, minor, patch) = semver_parts(v);
             quote_spanned! { span=>
-                semver::Version::new(#major, #minor, #patch)
+                #dropshot::semver::Version::new(#major, #minor, #patch)
             }
         }
         VersionSpecifier::Identifier(ident) => {
@@ -260,7 +264,7 @@ impl ValidatedEndpointMetadata {
                 quote_spanned! {span=> #dropshot::ApiEndpointVersions::All }
             }
             VersionRange::From(x) => {
-                let v = semver_expr(span, &x);
+                let v = semver_expr(dropshot, span, &x);
                 quote_spanned! {span=>
                     #dropshot::ApiEndpointVersions::From(
                         #v
@@ -268,7 +272,7 @@ impl ValidatedEndpointMetadata {
                 }
             }
             VersionRange::Until(y) => {
-                let v = semver_expr(span, &y);
+                let v = semver_expr(dropshot, span, &y);
                 quote_spanned! {span=>
                     #dropshot::ApiEndpointVersions::Until(
                         #v
@@ -276,8 +280,8 @@ impl ValidatedEndpointMetadata {
                 }
             }
             VersionRange::FromUntil(x, y) => {
-                let x = semver_expr(span, &x);
-                let y = semver_expr(span, &y);
+                let x = semver_expr(dropshot, span, &x);
+                let y = semver_expr(dropshot, span, &y);
                 quote_spanned! {span=>
                     #dropshot::ApiEndpointVersions::from_until(
                         #x,

--- a/dropshot_endpoint/tests/output/api_trait_basic.rs
+++ b/dropshot_endpoint/tests/output/api_trait_basic.rs
@@ -74,7 +74,7 @@ mod my_trait_mod {
                 "application/json",
                 "/xyz",
                 dropshot::ApiEndpointVersions::From(
-                    semver::Version::new(1u64, 2u64, 3u64),
+                    dropshot::semver::Version::new(1u64, 2u64, 3u64),
                 ),
             );
             if let Err(error) = dropshot_api.register(endpoint_handler_xyz) {
@@ -161,7 +161,7 @@ mod my_trait_mod {
                 "application/json",
                 "/xyz",
                 dropshot::ApiEndpointVersions::From(
-                    semver::Version::new(1u64, 2u64, 3u64),
+                    dropshot::semver::Version::new(1u64, 2u64, 3u64),
                 ),
             );
             if let Err(error) = dropshot_api.register(endpoint_handler_xyz) {

--- a/dropshot_endpoint/tests/output/channel_with_versions.rs
+++ b/dropshot_endpoint/tests/output/channel_with_versions.rs
@@ -59,7 +59,9 @@ for dropshot::ApiEndpoint<
             dropshot::Method::GET,
             "application/json",
             "/my/ws/channel",
-            dropshot::ApiEndpointVersions::Until(semver::Version::new(1u64, 2u64, 3u64)),
+            dropshot::ApiEndpointVersions::Until(
+                dropshot::semver::Version::new(1u64, 2u64, 3u64),
+            ),
         )
     }
 }

--- a/dropshot_endpoint/tests/output/endpoint_with_versions_from_literal.rs
+++ b/dropshot_endpoint/tests/output/endpoint_with_versions_from_literal.rs
@@ -57,7 +57,9 @@ for dropshot::ApiEndpoint<
             dropshot::Method::GET,
             "application/json",
             "/test",
-            dropshot::ApiEndpointVersions::From(semver::Version::new(1u64, 2u64, 3u64)),
+            dropshot::ApiEndpointVersions::From(
+                dropshot::semver::Version::new(1u64, 2u64, 3u64),
+            ),
         )
     }
 }

--- a/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_literals.rs
+++ b/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_literals.rs
@@ -58,8 +58,8 @@ for dropshot::ApiEndpoint<
             "application/json",
             "/test",
             dropshot::ApiEndpointVersions::from_until(
-                    semver::Version::new(1u64, 2u64, 3u64),
-                    semver::Version::new(4u64, 5u64, 6u64),
+                    dropshot::semver::Version::new(1u64, 2u64, 3u64),
+                    dropshot::semver::Version::new(4u64, 5u64, 6u64),
                 )
                 .unwrap(),
         )

--- a/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_mixed1.rs
+++ b/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_mixed1.rs
@@ -58,7 +58,7 @@ for dropshot::ApiEndpoint<
             "application/json",
             "/test",
             dropshot::ApiEndpointVersions::from_until(
-                    semver::Version::new(1u64, 2u64, 3u64),
+                    dropshot::semver::Version::new(1u64, 2u64, 3u64),
                     TWO,
                 )
                 .unwrap(),

--- a/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_mixed2.rs
+++ b/dropshot_endpoint/tests/output/endpoint_with_versions_from_until_mixed2.rs
@@ -59,7 +59,7 @@ for dropshot::ApiEndpoint<
             "/test",
             dropshot::ApiEndpointVersions::from_until(
                     ONE,
-                    semver::Version::new(4u64, 5u64, 6u64),
+                    dropshot::semver::Version::new(4u64, 5u64, 6u64),
                 )
                 .unwrap(),
         )

--- a/dropshot_endpoint/tests/output/endpoint_with_versions_until_literal.rs
+++ b/dropshot_endpoint/tests/output/endpoint_with_versions_until_literal.rs
@@ -57,7 +57,9 @@ for dropshot::ApiEndpoint<
             dropshot::Method::GET,
             "application/json",
             "/test",
-            dropshot::ApiEndpointVersions::Until(semver::Version::new(1u64, 2u64, 3u64)),
+            dropshot::ApiEndpointVersions::Until(
+                dropshot::semver::Version::new(1u64, 2u64, 3u64),
+            ),
         )
     }
 }


### PR DESCRIPTION
This way, users don't have to depend on semver while using Dropshot's versioning support.

I've opted to make this public rather than hiding it behind a hidden `macro_support` module because semver is a public dependency of Dropshot.