### PR TITLE
add dropshot-api-manager references to documentation

### DIFF
--- a/dropshot/large-service-dep-graph.mmd
+++ b/dropshot/large-service-dep-graph.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-    openapi_generator([OpenAPI generator]) --> api
+    dropshot_api_manager([Dropshot API manager]) --> api
     types[base types]
     stateless_logic[stateless logic]
     api[Dropshot API trait] --> types

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -291,6 +291,18 @@
 )]
 #![cfg_attr(feature = "internal-docs", doc = simple_mermaid::mermaid!("../large-service-dep-graph.mmd"))]
 //!
+//! ### Dropshot API manager
+//!
+//! For OpenAPI document generation from API traits, the Dropshot project
+//! provides an **OpenAPI manager**. The manager can be used to:
+//!
+//! * Generate OpenAPI documents from API traits
+//! * Check that OpenAPI documents are up-to-date, including in CI
+//! * Manage [versioned](#api-versioning) API documents
+//!
+//! For more information, see the documentation for
+//! [`dropshot-api-manager`](https://crates.io/crates/dropshot-api-manager).
+//!
 //! ### `#[endpoint { ... }]` attribute parameters
 //!
 //! The `endpoint` attribute accepts parameters the affect the operation of


### PR DESCRIPTION
Followup to #1429 -- mention the Dropshot API manager in documentation.
