### PR TITLE
Document blocker for upgrading schemars to v1.0

### DIFF
--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -87,10 +87,8 @@ version = "1.18.1"
 features = [ "serde", "v4" ]
 
 [dependencies.schemars]
-# While a 1.0 version is out, there is no way to generate an OpenAPIv3 spec without adding nullable
-# for all of the fields - see https://docs.rs/schemars/1.0.4/src/schemars/generate.rs.html#126 for
-# how SchemaSettings::option_nullable is handled now. As the other transformers are not public
-# creating our own version would take quite a bit of source code copy
+# While newer versions of schemars are available, they are not trivial for us to update to.
+# See oxidecomputer/dropshot#1375 for more information.
 version = "0.8.22"
 features = [ "uuid1" ]
 


### PR DESCRIPTION
Tried doing a project with dropshot and was surprised it was on an old version of schemars. I thought I would give back by upgrading. After spending some time updating schema constructions and checks to the new format, I encountered that we use a `SchemaSettings` setting which is no longer viable in the new version of `schemars`. I hope you are willing to add a comment like the one in this PR to upstream to avoid another person going down the same rabbit hole.