### PR TITLE
Include request latency in DTrace probe.

### DIFF
--- a/dropshot/src/dtrace.rs
+++ b/dropshot/src/dtrace.rs
@@ -20,6 +20,7 @@ pub(crate) struct ResponseInfo {
     pub remote_addr: std::net::SocketAddr,
     pub status_code: u16,
     pub message: String,
+    pub latency: std::time::Duration,
 }
 
 #[cfg(feature = "usdt-probes")]


### PR DESCRIPTION
Adds request latency to the `ResponseInfo` struct. The way that `std::time::Duration` gets serialized is not particularly nice on the eyes (`{"secs":0,"nanos":296793}`), but it is sound and unambiguous.

Example:

```
❯ sudo dtrace -Zq -n 'dropshot*:::request-done { printf("%s\n", copyinstr(arg0)); }'
{"ok":{"id":"d228d0f6-e026-455b-869d-99c3641697f0","local_addr":"127.0.0.1:39367","remote_addr":"127.0.0.1:62492","status_code":200,"message":"","latency":{"secs":0,"nanos":296793}}}
{"ok":{"id":"4c8d9fa9-5091-4290-83b2-227360833400","local_addr":"127.0.0.1:39367","remote_addr":"127.0.0.1:47030","status_code":200,"message":"","latency":{"secs":0,"nanos":106743}}}
{"ok":{"id":"5b2a0212-7f76-4dfd-8025-1ee7144dd56a","local_addr":"127.0.0.1:39367","remote_addr":"127.0.0.1:41432","status_code":200,"message":"","latency":{"secs":0,"nanos":102561}}}
{"ok":{"id":"11f77d57-c9a8-4321-8f71-faf601f0ea8e","local_addr":"127.0.0.1:39367","remote_addr":"127.0.0.1:43735","status_code":200,"message":"","latency":{"secs":0,"nanos":97882}}}
{"ok":{"id":"214d82b2-d48a-402f-9b74-4f58269df99c","local_addr":"127.0.0.1:39367","remote_addr":"127.0.0.1:59932","status_code":200,"message":"","latency":{"secs":0,"nanos":92672}}}
```