### PR TITLE
ci: Fix for rustup breakage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,8 @@ jobs:
             feature_flags: --all-features
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: Install Rust toolchain
+        run: rustup toolchain install
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Report Clippy version
         run: cargo clippy -- --version
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false # See Swatinem/rust-cache#341.
       - name: Run Clippy Lints
         run: cargo clippy --all-targets -- --deny warnings
 
@@ -44,6 +46,8 @@ jobs:
       - name: Report cargo version
         run: cargo --version
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false # See Swatinem/rust-cache#341.
       - name: Check Docs
         run: cargo doc --no-deps --lib --bins --examples
 
@@ -59,8 +63,6 @@ jobs:
             feature_flags: --all-features
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-      - name: Install Rust toolchain
-        run: rustup toolchain install
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
@@ -69,6 +71,7 @@ jobs:
         with:
           # Matrix instances other than OS need to be added to this explicitly
           key: ${{ matrix.features }}
+          cache-bin: false # See Swatinem/rust-cache#341.
       - name: Build
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests


### PR DESCRIPTION
Something broke with GitHub actions runners in the last two days.
This is an attempt to fix it.

Current main 918848cf8bf930dfe6be4b574752d04aee080c2e passed May 12, 2026, 12:05 PM EDT
https://github.com/oxidecomputer/dropshot/actions/runs/25746385530/job/75610647928

But failed when I reran it today May 14, 2026, 10:19 AM EDT
https://github.com/oxidecomputer/dropshot/actions/runs/25746385530/job/76005483181

Error is:
```
Run cargo build --all-features --locked --all-targets --verbose
error: error: unexpected argument 'build' found

Usage: rustup-init[EXE] [OPTIONS]

For more information, try '--help'.
```
Which makes me think there's a rustup-init cargo alias or somesuch.
I didn't see any upstream issues for this on [rust-lang/rustup](https://github.com/rust-lang/rustup) or [actions/runner](https://github.com/actions/runner)

Found it:
- https://github.com/Swatinem/rust-cache/issues/341

Root cause is the changes in [macos-14-arm64 (20260512) Image Update](https://github.com/actions/runner-images/pull/14037/changes).