### PR TITLE
ci: GitHub Actions hygeine and MSRV 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,15 +9,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
 
 jobs:
   check-style:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
       - name: Report rustfmt version
@@ -28,12 +32,12 @@ jobs:
   clippy-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
       - name: Report Clippy version
         run: cargo clippy -- --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false # See Swatinem/rust-cache#341.
       - name: Run Clippy Lints
@@ -42,10 +46,10 @@ jobs:
   check-docs:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false # See Swatinem/rust-cache#341.
       - name: Check Docs
@@ -53,6 +57,8 @@ jobs:
 
   build-and-test:
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust-version }}
     strategy:
       matrix:
         # macos-14 for M1 runners
@@ -66,15 +72,15 @@ jobs:
           - features: all
             feature_flags: --all-features
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust-version }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust toolchain
+        shell: bash
+        run: rustup toolchain install ${{ matrix.rust-version }} --profile minimal --no-self-update
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
         run: rustc --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Matrix instances other than OS need to be added to this explicitly
           key: ${{ matrix.features }}
@@ -85,4 +91,3 @@ jobs:
         run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact --skip fail
       - name: Run trybuild tests
         run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact fail
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,8 +66,8 @@ jobs:
         features: [all, default]
         rust-version:
           - stable
-          # 1.85 is the MSRV
-          - "1.85"
+          # 1.88 is the MSRV
+          - "1.88"
         include:
           - features: all
             feature_flags: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,13 +64,14 @@ jobs:
         # macos-14 for M1 runners
         os: [ubuntu-22.04, windows-2022, macos-14]
         features: [all, default]
-        rust-version:
-          - stable
-          # 1.88 is the MSRV
-          - "1.88"
+        toolchain: [stable, msrv]
         include:
           - features: all
             feature_flags: --all-features
+          - toolchain: stable
+            rust-version: stable
+          - toolchain: msrv
+            rust-version: "1.88"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,5 +89,21 @@ jobs:
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
         run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact --skip fail
+
+  # The trybuild tests assert on exact rustc diagnostics, which change between
+  # releases. Run them only on the toolchain that generated the committed
+  # .stderr expectations -- so, deliberately no RUSTUP_TOOLCHAIN here: this job
+  # uses the revision pinned in rust-toolchain.toml.
+  trybuild:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Report cargo version
+        run: cargo --version
+      - name: Report rustc version
+        run: rustc --version
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-bin: false # See Swatinem/rust-cache#341.
       - name: Run trybuild tests
-        run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact fail
+        run: cargo test --all-features --locked --all-targets --verbose -- --exact fail

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -7,12 +7,16 @@ on:
       - dropshot/tests/test_openapi_fuller.json
   workflow_dispatch:
     inputs:
+
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
       - name: Install our tools

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.17.1\...HEAD[Full list of commits]
 
+* Minimum supported rust version (MSRV) is now correctly specified as 1.88.
+
 == 0.17.1 (released 2026-06-02)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.17.0\...v0.17.1[Full list of commits]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.lints.clippy]
 # Clippy's style nits are useful, but not worth keeping in CI.


### PR DESCRIPTION
- Explicitly specify permissions for all GitHub Actions workflows
- Update Swatinem/rust-cache to v2.9.2 from v2.9.1
- Update actions/checkout to v7.0.1 (add comment with version)
- Add comment for actions/setup-node (`# v7.0.0`)
- Remove dtolnay/rust-toolchain dependency (`rustup` is in base runner)
- Switch from using `rustup default` to using explicit `RUSTUP_TOOLCHAIN`,
  as the former is overridden by the existence of a `rust-toolchain.toml`
- Add `CARGO_INCREMENTAL=0` to match the previous behavior provided by dtolnay/rust-toolchain. 
- Run `trybuild` as a dedicated ubuntu job, rather than as part of the matrix because rustc output differs between (stable, msrv).
  I think it's ok to not run this on every platform as the rustc output should be (has been) identical between platforms and if not, it's a rustc bug not a dropshot issue.
- Update MSRV to 1.88 (from 1.85)
- Tweak job names so they won't change when MSRV changes (allows stable repo config). E.g.
  Before: `build-and-test (macos-14, all, 1.85)`
  After: `build-and-test (macos-14, all, msrv)`
  Unchanged: `build-and-test (macos-14, all, stable)`

> [!NOTE] 
> Until this change we were not actually testing under our specified MSRV (1.85)
> Which meant we didn't realize that our MSRV was actually 1.88.

<img width="834" height="332" alt="rust-not185" src="https://github.com/user-attachments/assets/d9ce4f5c-edf7-473b-b96b-005a8fc8566c" />

See example [run output](https://github.com/oxidecomputer/dropshot/actions/runs/33425722062/job/99598673902#step:5:10)