### PR TITLE
raise the MSRV to 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,23 +53,29 @@ jobs:
 
   build-and-test:
     runs-on: ${{ matrix.os }}
+    env:
+      # rust-toolchain.toml overrides the dtolnay/rust-toolchain selection --
+      # set this environment variable, which overrides rust-toolchain.toml.
+      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
     strategy:
       matrix:
         # macos-14 for M1 runners
         os: [ubuntu-22.04, windows-2022, macos-14]
         features: [all, default]
-        rust-version:
-          - stable
-          # 1.85 is the MSRV
-          - "1.85"
+        rust-version: [stable, msrv]
         include:
           - features: all
             feature_flags: --all-features
+          - rust-version: stable
+            toolchain: stable
+          - rust-version: msrv
+            # Keep this in sync with rust-version in Cargo.toml.
+            toolchain: "1.88"
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ matrix.rust-version }}
+          toolchain: ${{ matrix.toolchain }}
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/dropshot/compare/v0.17.1\...HEAD[Full list of commits]
 
+* The minimum supported Rust version is now 1.88.
+
 == 0.17.1 (released 2026-06-02)
 
 https://github.com/oxidecomputer/dropshot/compare/v0.17.0\...v0.17.1[Full list of commits]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.lints.clippy]
 # Clippy's style nits are useful, but not worth keeping in CI.


### PR DESCRIPTION
dropshot_endpoint already uses a let chain (stabilized in Rust 1.88), so the declared MSRV of 1.85 no longer builds:

    error[E0658]: `let` expressions in this position are unstable
       --> dropshot_endpoint/src/api_trait.rs:235:20

Specify an MSRV of 1.88 and fix CI to check for it. In upcoming commits we're going to add more let chains.

After #1695 and this PR, the CI test matrix is:

* all tests except trybuild ones on MSRV and stable, and across Linux/macOS/Windows
* trybuild tests on pinned toolchain on Linux