### PR TITLE
run trybuild tests in their own CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,23 @@ jobs:
       - name: Build
         run: cargo build ${{ matrix.feature_flags }} --locked --all-targets --verbose
       - name: Run tests
+        # The trybuild fixtures run in the trybuild job below, since they require the pinned toolchain.
         run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact --skip fail
-      - name: Run trybuild tests
-        run: cargo test ${{ matrix.feature_flags }} --locked --all-targets --verbose -- --exact fail
 
+  trybuild:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      # rust-toolchain.toml overrides dtolnay/rust-toolchain@stable, so in some
+      # sense using it is pointless. But it does a few other useful things such
+      # as disable incremental compilation, so we use it anyway.
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Report cargo version
+        run: cargo --version
+      - name: Report rustc version
+        run: rustc --version
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false # See Swatinem/rust-cache#341.
+      - name: Run trybuild tests
+        run: cargo test --locked --verbose -p dropshot --test fail


### PR DESCRIPTION
The trybuild tests require a pinned toolchain for output stability. By accident, we were using the pinned toolchain on all CI jobs -- the next commit fixes this, which ends up breaking the trybuild tests.

Move the tests into their own job that explicitly depends on the pinned toolchain.

The trybuild output doesn't depend on the OS, so we don't need to use a matrix setup for it -- just run it on Linux.

(After this lands we should probably mark the trybuild job required.)