### PR TITLE
ci: GitHub Actions workflow improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,8 +58,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     env:
-      # Override rust-toolchain.toml, which otherwise takes precedence over the
-      # toolchain installed below.
+      # Override rust-toolchain.toml using explicit RUSTUP_TOOLCHAIN
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
     strategy:
       matrix:
@@ -99,9 +98,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Deliberately no RUSTUP_TOOLCHAIN here: the toolchain is pinned by
-      # rust-toolchain.toml, since the trybuild fixtures assert exact rustc
-      # diagnostics against committed .stderr files.
+      # toolchain is pinned by rust-toolchain.toml which is required as the trybuild
+      # fixtures assert exact rustc diagnostics against committed .stderr files.
       - name: Install Rust toolchain from rust-toolchain.toml
         run: rustup toolchain install
       - name: Report cargo version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,11 +101,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Deliberately no RUSTUP_TOOLCHAIN here: the toolchain is pinned by
       # rust-toolchain.toml, since the trybuild fixtures assert exact rustc
-      # diagnostics against committed .stderr files. `rustup toolchain install`
-      # with no argument installs the toolchain named by that file; `rustup
-      # show` no longer installs it implicitly as of rustup 1.28.
+      # diagnostics against committed .stderr files.
       - name: Install Rust toolchain from rust-toolchain.toml
-        run: rustup show active-toolchain || rustup toolchain install
+        run: rustup toolchain install
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,8 +75,8 @@ jobs:
             # Keep this in sync with rust-version in Cargo.toml.
             toolchain: "1.88"
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Report cargo version
@@ -97,11 +97,11 @@ jobs:
   trybuild:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # rust-toolchain.toml overrides dtolnay/rust-toolchain@stable, so in some
       # sense using it is pointless. But it does a few other useful things such
       # as disable incremental compilation, so we use it anyway.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,9 +57,9 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     env:
-      # override rustup using toolchain specified in rust-toolchain.toml
+      # rust-toolchain.toml overrides the dtolnay/rust-toolchain selection --
+      # set this environment variable, which overrides rust-toolchain.toml.
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
-      CARGO_INCREMENTAL: 0
     strategy:
       matrix:
         # macos-14 for M1 runners
@@ -75,10 +75,10 @@ jobs:
             # Keep this in sync with rust-version in Cargo.toml.
             toolchain: "1.88"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install Rust toolchain
-        shell: bash
-        run: rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
@@ -96,12 +96,12 @@ jobs:
 
   trybuild:
     runs-on: ubuntu-24.04
-    env:
-      CARGO_INCREMENTAL: 0
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Deliberately no RUSTUP_TOOLCHAIN here, uses rust-toolchain.toml to pin version.
-      # trybuild fixtures assert exact rustc diagnostics in committed .stderr files.
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      # rust-toolchain.toml overrides dtolnay/rust-toolchain@stable, so in some
+      # sense using it is pointless. But it does a few other useful things such
+      # as disable incremental compilation, so we use it anyway.
+      - uses: dtolnay/rust-toolchain@stable
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -17,7 +20,7 @@ jobs:
   check-style:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
       - name: Report rustfmt version
@@ -28,12 +31,12 @@ jobs:
   clippy-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
       - name: Report Clippy version
         run: cargo clippy -- --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false # See Swatinem/rust-cache#341.
       - name: Run Clippy Lints
@@ -42,10 +45,10 @@ jobs:
   check-docs:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Report cargo version
         run: cargo --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false # See Swatinem/rust-cache#341.
       - name: Check Docs
@@ -54,9 +57,9 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     env:
-      # rust-toolchain.toml overrides the dtolnay/rust-toolchain selection --
-      # set this environment variable, which overrides rust-toolchain.toml.
+      # override rustup using toolchain specified in rust-toolchain.toml
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
+      CARGO_INCREMENTAL: 0
     strategy:
       matrix:
         # macos-14 for M1 runners
@@ -72,15 +75,15 @@ jobs:
             # Keep this in sync with rust-version in Cargo.toml.
             toolchain: "1.88"
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust toolchain
+        shell: bash
+        run: rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
         run: rustc --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Matrix instances other than OS need to be added to this explicitly
           key: ${{ matrix.features }}
@@ -93,17 +96,17 @@ jobs:
 
   trybuild:
     runs-on: ubuntu-24.04
+    env:
+      CARGO_INCREMENTAL: 0
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-      # rust-toolchain.toml overrides dtolnay/rust-toolchain@stable, so in some
-      # sense using it is pointless. But it does a few other useful things such
-      # as disable incremental compilation, so we use it anyway.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Deliberately no RUSTUP_TOOLCHAIN here, uses rust-toolchain.toml to pin version.
+      # trybuild fixtures assert exact rustc diagnostics in committed .stderr files.
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
         run: rustc --version
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false # See Swatinem/rust-cache#341.
       - name: Run trybuild tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
@@ -57,8 +58,8 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     env:
-      # rust-toolchain.toml overrides the dtolnay/rust-toolchain selection --
-      # set this environment variable, which overrides rust-toolchain.toml.
+      # Override rust-toolchain.toml, which otherwise takes precedence over the
+      # toolchain installed below.
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
     strategy:
       matrix:
@@ -76,9 +77,9 @@ jobs:
             toolchain: "1.88"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
+      - name: Install Rust toolchain
+        shell: bash
+        run: rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version
@@ -98,10 +99,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # rust-toolchain.toml overrides dtolnay/rust-toolchain@stable, so in some
-      # sense using it is pointless. But it does a few other useful things such
-      # as disable incremental compilation, so we use it anyway.
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+      # Deliberately no RUSTUP_TOOLCHAIN here: the toolchain is pinned by
+      # rust-toolchain.toml, since the trybuild fixtures assert exact rustc
+      # diagnostics against committed .stderr files. `rustup toolchain install`
+      # with no argument installs the toolchain named by that file; `rustup
+      # show` no longer installs it implicitly as of rustup 1.28.
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: rustup show active-toolchain || rustup toolchain install
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -7,12 +7,16 @@ on:
       - dropshot/tests/test_openapi_fuller.json
   workflow_dispatch:
     inputs:
+
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
       - name: Install our tools


### PR DESCRIPTION
- Supersedes https://github.com/oxidecomputer/dropshot/pull/1693
- Explicitly specify permissions for all GitHub Actions workflows
- Update Swatinem/rust-cache to v2.9.2 from v2.9.1
- Update actions/checkout to v7.0.1 (add comment with version)
- Pin actions/setup-node to a SHA (`# v7.0.0`)
- Drop dtolnay/rust-toolchain
- Add `CARGO_INCREMENTAL=0` to match the previous dtolnay/rust-toolchain behavior